### PR TITLE
Update 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script src="/scripts/scripts.js" type="module"></script>
   <script type="module">
     window.addEventListener('load', () => {
       if (document.referrer) {


### PR DESCRIPTION
Remove legacy script tag behavior to match the existing `head.html` behavior.

This attribute prevents the script from accessing other cross origin scripts (like dapreview.js). This attribute has already been removed from `head.html` for years.