### PR TITLE
chore: subnav tweak

### DIFF
--- a/blocks/navigation/navigation.js
+++ b/blocks/navigation/navigation.js
@@ -92,6 +92,7 @@ export default function decorate(block) {
     });
 
     wrapper.appendChild(ul);
+    ul.querySelector('li').setAttribute('aria-current', true);
     nav.appendChild(wrapper);
     row.prepend(nav);
   }


### PR DESCRIPTION
subnav selects first chapter by default.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.live/us/en_us/why-vitamix
- After: https://subnav-tweak--vitamix--aemsites.aem.live/us/en_us/why-vitamix
