### PR TITLE
fix: update pr template to use aem.network for psi check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--vitamix--aemsites.aem.live/
-- After: https://<branch>--vitamix--aemsites.aem.live/
+- Before: https://main--vitamix--aemsites.aem.network/
+- After: https://<branch>--vitamix--aemsites.aem.network/


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
- After: https://psi--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
