### PR TITLE
chore: gallery fix for products without variants

### DIFF
--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -32,7 +32,6 @@ export function attachImageListeners(galleryImages, selectedImageElement) {
  * @returns {Element} The gallery container element
  */
 export default function renderGallery(block, variants) {
-  console.log(variants);
   const galleryContainer = document.createElement('div');
   galleryContainer.classList.add('gallery');
 
@@ -63,8 +62,6 @@ export default function renderGallery(block, variants) {
 
     galleryContainer.append(galleryImages);
   }
-
-  console.log(galleryContainer);
 
   return galleryContainer;
 }

--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -32,26 +32,29 @@ export function attachImageListeners(galleryImages, selectedImageElement) {
  * @returns {Element} The gallery container element
  */
 export default function renderGallery(block, variants) {
+  console.log(variants);
   const galleryContainer = document.createElement('div');
   galleryContainer.classList.add('gallery');
 
   const selectedImage = block.querySelector('.lcp-image');
   galleryContainer.append(selectedImage);
 
-  if (variants && variants.length > 0) {
-    const defaultVariant = variants[0];
+  if (variants) {
+    let firstVariantImages = [];
     const galleryImages = document.createElement('div');
     galleryImages.classList.add('gallery-images');
-    defaultVariant.images[0]?.classList.add('selected');
-
-    const images = block.querySelectorAll('.img-wrapper');
-    let firstVariantImages = defaultVariant.images;
-
-    const type = document.head.querySelector('meta[name="type"]')?.content;
-    if (type === 'bundle') {
-      firstVariantImages = [];
+    if (variants.length > 0) {
+      const defaultVariant = variants[0];
+      defaultVariant.images[0]?.classList.add('selected');
+      firstVariantImages = defaultVariant.images;
+      const type = document.head.querySelector('meta[name="type"]')?.content;
+      if (type === 'bundle') {
+        firstVariantImages = [];
+      }
     }
+
     // Keep track of the default product images
+    const images = block.querySelectorAll('.img-wrapper');
     window.defaultProductImages = Array.from(images).map((image) => image.cloneNode(true));
 
     galleryImages.append(...firstVariantImages, ...images);
@@ -60,6 +63,8 @@ export default function renderGallery(block, variants) {
 
     galleryContainer.append(galleryImages);
   }
+
+  console.log(galleryContainer);
 
   return galleryContainer;
 }


### PR DESCRIPTION
Fix #68 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/48-ounce-container
- After: 
https://gallery-fix--vitamix--aemsites.aem.network/us/en_us/products/48-ounce-container
https://gallery-fix--vitamix--aemsites.aem.network/us/en_us/products/aer-disc-container
https://gallery-fix--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2