### PR TITLE
refactor: pdp gallery

### DIFF
--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -1,7 +1,7 @@
 .gallery.carousel {
   place-self: start center;
   max-width: 620px;
-  padding-bottom: 30px;
+  padding-bottom: 44px;
 }
 
 .gallery.carousel > ul > li {
@@ -60,21 +60,21 @@
   right: var(--spacing-60);
 }
 
-.gallery.carousel nav ul {
+.gallery.carousel nav [role='radiogroup'] {
   gap: 0;
   width: 100%;
   overflow-x: hidden;
 }
 
-.gallery.carousel nav ul button {
-  width: 18px;
-  height: 30px;
+.gallery.carousel nav [role='radiogroup'] button {
+  width: 44px;
+  height: 44px;
   line-height: 0;
   text-align: center;
   cursor: pointer;
 }
 
-.gallery.carousel nav ul button::after {
+.gallery.carousel nav [role='radiogroup'] button::after {
   content: '';
   display: inline-block;
   width: 6px;
@@ -85,12 +85,12 @@
   transition: border-color 0.2s, background-color 0.2s;
 }
 
-.gallery.carousel nav ul button[aria-checked='true']::after {
+.gallery.carousel nav [role='radiogroup'] button[aria-checked='true']::after {
   border-color: transparent;
   background-color: #ff5501;
 }
 
-.gallery.carousel nav ul button img {
+.gallery.carousel nav [role='radiogroup'] button img {
   display: none;
 }
 
@@ -112,27 +112,28 @@
     right: var(--spacing-100);
   }
 
-  .gallery.carousel nav ul {
+  .gallery.carousel nav [role='radiogroup'] {
     gap: var(--spacing-60);
     justify-content: flex-start;
   }
 
-  .gallery.carousel nav ul button {
+  .gallery.carousel nav [role='radiogroup'] button {
     width: 58px;
+    min-width: 58px;
     height: 58px;
     border: 1px solid var(--color-gray-500);
     transition: border-color 0.2s;
   }
 
-  .gallery.carousel nav ul button::after {
+  .gallery.carousel nav [role='radiogroup'] button::after {
     content: none;
   }
 
-  .gallery.carousel nav ul button[aria-checked='true'] {
+  .gallery.carousel nav [role='radiogroup'] button[aria-checked='true'] {
     border-color: var(--color-charcoal);
   }
 
-  .gallery.carousel nav ul button img {
+  .gallery.carousel nav [role='radiogroup'] button img {
     display: block;
   }
 }

--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -85,7 +85,7 @@
   transition: border-color 0.2s, background-color 0.2s;
 }
 
-.gallery.carousel nav ul button[aria-selected='true']::after {
+.gallery.carousel nav ul button[aria-checked='true']::after {
   border-color: transparent;
   background-color: #ff5501;
 }
@@ -128,7 +128,7 @@
     content: none;
   }
 
-  .gallery.carousel nav ul button[aria-selected='true'] {
+  .gallery.carousel nav ul button[aria-checked='true'] {
     border-color: var(--color-charcoal);
   }
 

--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -1,0 +1,138 @@
+.gallery.carousel {
+  place-self: start center;
+  max-width: 620px;
+  padding-bottom: 30px;
+}
+
+.gallery.carousel > ul > li {
+  flex: 0 0 100%;
+  width: 100%;
+  text-align: center;
+  justify-content: center;
+}
+
+.gallery.carousel > ul > li picture {
+  width: 100%;
+}
+
+.gallery.carousel nav {
+  display: flex;
+  align-items: flex-end;
+}
+
+.gallery.carousel nav button.nav-arrow {
+  top: calc(50% - 15px);
+  border-radius: 50%;
+  background-color: var(--color-gray-300);
+  color: var(--color-gray-800);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, left 0.2s, right 0.2s;
+}
+
+.gallery.carousel:hover nav button.nav-arrow {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.gallery.carousel nav button.nav-arrow:disabled,
+.gallery.carousel:hover nav button.nav-arrow:disabled {
+  opacity: 0.2;
+}
+
+.gallery.carousel nav button.nav-arrow::after {
+  border-width: 2px;
+}
+
+.gallery.carousel nav button.nav-arrow.nav-arrow-previous {
+  left: -52px;
+}
+
+.gallery.carousel:hover nav button.nav-arrow.nav-arrow-previous {
+  left: var(--spacing-60);
+}
+
+.gallery.carousel nav button.nav-arrow.nav-arrow-next {
+  right: -52px;
+}
+
+.gallery.carousel:hover nav button.nav-arrow.nav-arrow-next {
+  right: var(--spacing-60);
+}
+
+.gallery.carousel nav ul {
+  gap: 0;
+  width: 100%;
+  overflow-x: hidden;
+}
+
+.gallery.carousel nav ul button {
+  width: 18px;
+  height: 30px;
+  line-height: 0;
+  text-align: center;
+  cursor: pointer;
+}
+
+.gallery.carousel nav ul button::after {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--color-gray-800);
+  border-radius: 50%;
+  background-color: transparent;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.gallery.carousel nav ul button[aria-selected='true']::after {
+  border-color: transparent;
+  background-color: #ff5501;
+}
+
+.gallery.carousel nav ul button img {
+  display: none;
+}
+
+@media (width >= 900px) {
+  .gallery.carousel {
+    justify-self: start;
+    padding-bottom: calc(58px + var(--spacing-200));
+  }
+
+  .gallery.carousel nav button.nav-arrow {
+    top: calc(50% - 58px + var(--spacing-200));
+  }
+
+  .gallery.carousel:hover nav button.nav-arrow.nav-arrow-previous {
+    left: var(--spacing-100);
+  }
+  
+  .gallery.carousel:hover nav button.nav-arrow.nav-arrow-next {
+    right: var(--spacing-100);
+  }
+
+  .gallery.carousel nav ul {
+    gap: var(--spacing-60);
+    justify-content: flex-start;
+  }
+
+  .gallery.carousel nav ul button {
+    width: 58px;
+    height: 58px;
+    border: 1px solid var(--color-gray-500);
+    transition: border-color 0.2s;
+  }
+
+  .gallery.carousel nav ul button::after {
+    content: none;
+  }
+
+  .gallery.carousel nav ul button[aria-selected='true'] {
+    border-color: var(--color-charcoal);
+  }
+
+  .gallery.carousel nav ul button img {
+    display: block;
+  }
+}

--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -23,11 +23,11 @@ export function buildSlide(el, source) {
  */
 export function buildThumbnails(carousel) {
   const imgs = carousel.querySelectorAll('li img');
-  const indices = carousel.querySelectorAll('nav li button');
+  const indices = carousel.querySelectorAll('nav [role="radiogroup"] button');
 
   // scroll selected thumbnail into view on selection
   const observer = new MutationObserver(() => {
-    const selected = carousel.querySelector('nav li button[aria-checked="true"]');
+    const selected = carousel.querySelector('nav [role="radiogroup"] button[aria-checked="true"]');
     if (selected) selected.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
   });
 
@@ -39,10 +39,7 @@ export function buildThumbnails(carousel) {
     const { source } = imgLi.dataset;
 
     const thumb = img.cloneNode(true);
-    if (source) {
-      const btnLi = btn.closest('li');
-      btnLi.dataset.source = source;
-    }
+    if (source) btn.dataset.source = source;
     btn.replaceChildren(thumb);
 
     // track aria-checked updates

--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -27,7 +27,7 @@ export function buildThumbnails(carousel) {
 
   // scroll selected thumbnail into view on selection
   const observer = new MutationObserver(() => {
-    const selected = carousel.querySelector('nav li button[aria-selected="true"]');
+    const selected = carousel.querySelector('nav li button[aria-checked="true"]');
     if (selected) selected.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
   });
 
@@ -45,8 +45,8 @@ export function buildThumbnails(carousel) {
     }
     btn.replaceChildren(thumb);
 
-    // track aria-selected updates
-    observer.observe(btn, { attributes: true, attributeFilter: ['aria-selected'] });
+    // track aria-checked updates
+    observer.observe(btn, { attributes: true, attributeFilter: ['aria-checked'] });
   });
 }
 

--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -40,11 +40,12 @@ export function onOptionChange(block, variants, color) {
   });
 
   const gallery = block.querySelector('.gallery');
-  const [slides, nav] = gallery.querySelectorAll('ul');
+  const slides = gallery.querySelector('ul');
+  const nav = gallery.querySelector('[role="radiogroup"]');
 
   // update LCP image(s)
   const lcpSlide = slides.querySelector('[data-source="lcp"]');
-  const lcpButton = nav.querySelector('[data-source="lcp"] button');
+  const lcpButton = nav.querySelector('[data-source="lcp"]');
   if (lcpSlide && lcpButton) {
     // measure current <picture> size
     const oldPic = lcpSlide.querySelector('picture');

--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -1,8 +1,7 @@
 import { buildSlide, buildThumbnails } from './gallery.js';
-import { rebuildIndices } from '../../scripts/scripts.js';
+import { rebuildIndices, checkOutOfStock } from '../../scripts/scripts.js';
 import { toClassName, getMetadata } from '../../scripts/aem.js';
 import renderPricing from './pricing.js';
-import { checkOutOfStock } from '../../scripts/scripts.js';
 
 /**
  * Handles the change of an option.

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -1,3 +1,5 @@
+@import url('./gallery.css');
+
 .pdp-wrapper {
   display: flex;
   flex-direction: column;
@@ -282,35 +284,6 @@
 
 .gallery {
   grid-area: gallery;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-l);
-}
-
-.lcp-image img {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-}
-
-.gallery-images {
-  display: flex;
-  flex-flow: row wrap;
-  gap: var(--spacing-s);
-}
-
-.gallery-images img {
-  width: 58px;
-  height: 58px;
-  object-fit: cover;
-  cursor: pointer;
-}
-
-.gallery-images picture img {
-  border: 1px solid var(--color-gray-600);
-}
-
-.gallery-images picture.selected img {
-  border: 1px solid var(--color-text);
 }
 
 /** Pricing */

--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -178,11 +178,6 @@ function renderShare() {
  * @param {Element} block - The PDP block element
  */
 export default function decorate(block) {
-  // remove eyebrow classes from all but the first eyebrow
-  [...block.querySelectorAll('p.eyebrow')].forEach((element) => {
-    element.classList.remove('eyebrow');
-  });
-
   // Get the json-ld from the head and parse it
   const jsonLd = document.head.querySelector('script[type="application/ld+json"]');
   const jsonLdData = jsonLd ? JSON.parse(jsonLd.textContent) : null;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -101,10 +101,11 @@ function buildCarouselIndex(i, carousel, indices, visibleSlides = 1) {
   const button = document.createElement('button');
   button.type = 'button';
   button.setAttribute('aria-label', `Go to slide ${i + 1}`);
-  button.setAttribute('aria-selected', !i);
+  button.setAttribute('aria-checked', !i);
+  button.setAttribute('role', 'radio');
   button.addEventListener('click', () => {
     indices.querySelectorAll('button').forEach((b) => {
-      b.setAttribute('aria-selected', b === button);
+      b.setAttribute('aria-checked', b === button);
     });
     carousel.scrollTo({
       left: i * (carousel.clientWidth / visibleSlides),
@@ -183,6 +184,7 @@ export function buildCarousel(container, visibleSlides = 1, pagination = true) {
   if (pagination) {
     // build indices
     const indices = document.createElement('ul');
+    indices.setAttribute('role', 'radiogroup');
     navEl.append(indices);
     buildCarouselIndices(carousel, indices, visibleSlides);
 
@@ -190,7 +192,7 @@ export function buildCarousel(container, visibleSlides = 1, pagination = true) {
       const { scrollLeft, clientWidth } = carousel;
       const current = Math.round(scrollLeft / (clientWidth * visibleSlides));
       [...indices.querySelectorAll('button')].forEach((btn, i) => {
-        btn.setAttribute('aria-selected', i === current);
+        btn.setAttribute('aria-checked', i === current);
       });
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -97,22 +97,20 @@ export function buildIcon(name, modifier) {
  * @returns {HTMLLIElement} Constructed carousel index
  */
 function buildCarouselIndex(i, carousel, indices, visibleSlides = 1) {
-  const index = document.createElement('li');
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.setAttribute('aria-label', `Go to slide ${i + 1}`);
-  button.setAttribute('aria-checked', !i);
-  button.setAttribute('role', 'radio');
-  button.addEventListener('click', () => {
+  const index = document.createElement('button');
+  index.type = 'button';
+  index.setAttribute('aria-label', `Go to slide ${i + 1}`);
+  index.setAttribute('aria-checked', !i);
+  index.setAttribute('role', 'radio');
+  index.addEventListener('click', () => {
     indices.querySelectorAll('button').forEach((b) => {
-      b.setAttribute('aria-checked', b === button);
+      b.setAttribute('aria-checked', b === index);
     });
     carousel.scrollTo({
       left: i * (carousel.clientWidth / visibleSlides),
       behavior: 'smooth',
     });
   });
-  index.append(button);
   return index;
 }
 
@@ -137,7 +135,7 @@ function buildCarouselIndices(carousel, indices, visibleSlides = 1) {
  */
 export function rebuildIndices(carousel) {
   const slides = carousel.querySelector('ul');
-  const indices = carousel.querySelector('nav ul');
+  const indices = carousel.querySelector('nav [role="radiogroup"]');
   if (!slides || !indices) return;
 
   const visibleSlides = parseInt(carousel.dataset.visibleSlides, 10) || 1;
@@ -183,7 +181,7 @@ export function buildCarousel(container, visibleSlides = 1, pagination = true) {
 
   if (pagination) {
     // build indices
-    const indices = document.createElement('ul');
+    const indices = document.createElement('div');
     indices.setAttribute('role', 'radiogroup');
     navEl.append(indices);
     buildCarouselIndices(carousel, indices, visibleSlides);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -713,7 +713,7 @@ input[type='radio'] {
   transform: rotate(45deg) translate(-50%, -50%);
 }
 
-.carousel nav ul {
+.carousel nav [role='radiogroup'] {
   list-style: none;
   display: flex;
   align-items: center;
@@ -722,8 +722,3 @@ input[type='radio'] {
   margin: 0;
   padding: 0;
 }
-
-.carousel nav ul > li {
-  line-height: 0;
-}
-


### PR DESCRIPTION
Fix #70 

⚠️  NOTE: the slide navigation below the carousel on mobile looks different here (increased the target touch size per PSI a11y recommendation). if it's more important to hit existing site pixels, i can revert but let me know. 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5
- After: https://pdp-gallery--vitamix--aemsites.aem.network/us/en_us/products/simply-soups-cookbook
- After: https://pdp-gallery--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5
- After: https://pdp-gallery--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5-smartprep-kitchen-system
- After: https://pdp-gallery--vitamix--aemsites.aem.network/us/en_us/products/propel-series-750
