### PR TITLE
chore: gallery grid layout tweak

### DIFF
--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -2,7 +2,6 @@
   place-self: start center;
   max-width: 620px;
   padding-bottom: 44px;
-  overflow: unset;
 }
 
 .gallery.carousel > ul > li {

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -433,7 +433,7 @@ a.button.pdp-find-locally-button {
   .pdp {
     padding-top: var(--spacing-xl);
     grid-template-columns: 2fr 3fr;
-    grid-template-rows: 45px 180px auto auto auto auto;
+    grid-template-rows: fit-content(30px) auto auto auto auto auto;
     /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
     grid-template-areas:
       "alert gallery"


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: 
https://main--vitamix--aemsites.aem.network/us/en_us/products/a2300-super-bundle
https://main--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-s50
https://main--vitamix--aemsites.aem.network/us/en_us/products/creations-gallery
https://main--vitamix--aemsites.aem.network/us/en_us/products/creations-ii
https://main--vitamix--aemsites.aem.network/us/en_us/products/foodcycler-fc-50
https://main--vitamix--aemsites.aem.network/us/en_us/products/s55
https://main--vitamix--aemsites.aem.network/us/en_us/products/turboblend-three-speed
https://main--vitamix--aemsites.aem.network/us/en_us/products/turboblend-two-speed
https://main--vitamix--aemsites.aem.network/us/en_us/products/v1200-super-pack
https://main--vitamix--aemsites.aem.network/us/en_us/products/vitamix-one


- After:
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/a2300-super-bundle
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-s50
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/creations-gallery
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/creations-ii
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/foodcycler-fc-50
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/s55
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/turboblend-three-speed
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/turboblend-two-speed
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/v1200-super-pack
https://gallery-grid--vitamix--aemsites.aem.network/us/en_us/products/vitamix-one

