### PR TITLE
fix: extract variant pricing from initial HTML

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,3 +1,4 @@
+import { extractPricing } from '../blocks/pdp/pricing.js';
 import {
   loadHeader,
   loadFooter,
@@ -293,10 +294,14 @@ function parseVariants(sections) {
 
     const imagesHTML = div.querySelectorAll('picture');
 
+    const priceHTML = div.querySelector('p:nth-of-type(1)');
+    const price = extractPricing(priceHTML);
+
     return {
       ...metadata,
       name,
       options,
+      price,
       images: imagesHTML,
     };
   });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-178--vitamix--aemsites.aem.network/
