### PR TITLE
chore: cookie renew instead of declaration

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -59,4 +59,12 @@ export default async function decorate(block) {
 
   block.append(footer);
   swapIcons(block);
+
+  const cookieDeclaration = block.querySelector('a[href$="cookie-declaration"]');
+  if (cookieDeclaration) {
+    cookieDeclaration.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.Cookiebot.renew();
+    });
+  }
 }


### PR DESCRIPTION
Display of cookie banner instead of declarations page...

https://cookie-renew--vitamix--aemsites.aem.network/us/en_us/
