### PR TITLE
fix: use legacy add to cart when extended warranty is selected

### DIFF
--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -182,7 +182,6 @@ export function renderOptions(block, variants, custom) {
         warrentyValue.prepend(radio);
 
         radio.addEventListener('change', () => {
-          // TODO: allow warranty to be selected
           window.selectedWarranty = option;
         });
       }

--- a/scripts/minicart/cart.js
+++ b/scripts/minicart/cart.js
@@ -338,12 +338,8 @@ async function addToCartLegacy(sku, options, quantity) {
 
   const formData = new FormData();
   formData.append('product', productId);
-  // formData.append('selected_configurable_option');
-  // formData.append('related_product');
   formData.append('item', productId);
   formData.append('form_key', formKey);
-  // formData.append('magic360gallery', 1);
-  // formData.append('movegalleryintotab', 1);
   formData.append('qty', quantity);
   formData.append('vitamixProductId', productId);
 


### PR DESCRIPTION


Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/propel-series-510
- After: https://legacy-atc--vitamix--aemsites.aem.network/us/en_us/products/propel-series-510
