### PR TITLE
fix: variant selection

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -94,14 +94,11 @@ export function isVariantAvailableForSale(variant) {
 export default function renderAddToCart(block, parent) {
   // Default selectedVariant to parent product, if simple product, selectedVariant will be undefined
   // TODO: this should be fixed with https://github.com/aemsites/vitamix/issues/185
-  let selectedVariant = parent;
+  let selectedVariant = parent.offers?.[0]?.custom ? parent.offers[0] : parent;
   if (window.selectedVariant) {
     // If we actually have a selected variant, use it instead of the parent product
     const { sku: selectedSku } = window.selectedVariant;
     selectedVariant = parent.offers.find((variant) => variant.sku === selectedSku);
-  } else if (parent.offers?.[0]?.custom) {
-    // use first in stock variant if none selected
-    selectedVariant = parent.offers.find((variant) => isVariantAvailableForSale(variant));
   }
 
   // Only look at findLocally and findDealer from parent product

--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -2,7 +2,7 @@ import { buildSlide, buildThumbnails } from './gallery.js';
 import { rebuildIndices, checkOutOfStock } from '../../scripts/scripts.js';
 import { toClassName, getMetadata } from '../../scripts/aem.js';
 import renderPricing from './pricing.js';
-import { isVariantAvailableForSale } from './add-to-cart.js';
+import renderAddToCart, { isVariantAvailableForSale } from './add-to-cart.js';
 
 /**
  * Handles the change of an option.
@@ -89,11 +89,19 @@ export function onOptionChange(block, variants, color) {
   buildThumbnails(gallery);
 
   window.selectedVariant = variant;
+
+  // update add to cart
+  const addToCartContainer = renderAddToCart(block, window.jsonLdData);
+  if (addToCartContainer) {
+    block.querySelector('.add-to-cart').replaceWith(addToCartContainer);
+  }
 }
 
 /**
  * Renders the options section of the PDP block.
  * @param {Element} block - The PDP block element
+ * @param {any[]} variants - The variants of the product
+ * @param {Record<string, any>} custom - The custom data for the product
  * @returns {Element} The options container element
  */
 export function renderOptions(block, variants, custom) {

--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -314,6 +314,10 @@ export default function decorate(block) {
     [window.selectedVariant] = variants;
   }
 
-  buyBox.dataset.sku = offers[0].sku;
-  buyBox.dataset.oos = checkOutOfStock(offers[0].sku);
+  buyBox.dataset.sku = window.selectedVariant?.sku || offers[0].sku;
+  buyBox.dataset.oos = checkOutOfStock(
+    window.selectedVariant
+      ? offers.find((offer) => offer.sku === window.selectedVariant.sku).sku
+      : offers[0].sku,
+  );
 }


### PR DESCRIPTION
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/a2300-smartprep-kitchen-system
- After: https://variant-selection--vitamix--aemsites.aem.network/us/en_us/products/a2300-smartprep-kitchen-system

also
Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/a2300
After: https://variant-selection--vitamix--aemsites.aem.network/us/en_us/products/a2300

https://variant-selection--vitamix--aemsites.aem.network/us/en_us/products/propel-series-510
