### PR TITLE
fix: reset atc button before redirect

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -208,6 +208,10 @@ export default function renderAddToCart(block, parent) {
 
     // redirect to cart page after successful addition
     window.location.href = '/us/en_us/checkout/cart/';
+
+    // update button state to show ATC
+    addToCartButton.textContent = 'Add to Cart';
+    addToCartButton.removeAttribute('aria-disabled');
   });
 
   // assemble the quantity container with select and button


### PR DESCRIPTION
reset to base ATC button state before redirecting to cart

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
- After: https://atc-reset--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
