### PR TITLE
fix: add `was` on discounted price

### DIFF
--- a/blocks/pdp/pricing.js
+++ b/blocks/pdp/pricing.js
@@ -61,7 +61,7 @@ export default function renderPricing(block, variant) {
     const savingsAmount = pricing.regular - pricing.final;
     const saveText = document.createElement('span');
     saveText.className = 'pricing-save';
-    saveText.textContent = `Save $${savingsAmount.toFixed(2)} | `;
+    saveText.textContent = `Save $${savingsAmount.toFixed(2)} | Was `;
 
     const regularPrice = document.createElement('del');
     regularPrice.className = 'pricing-regular';


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/a2300
- After: https://was-label--vitamix--aemsites.aem.network/us/en_us/products/a2300
