### PR TITLE
fix: exclude no warranty from tabs

### DIFF
--- a/blocks/pdp/specification-tabs.js
+++ b/blocks/pdp/specification-tabs.js
@@ -1,5 +1,7 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
 
+const NO_WARRANTY_PHRASE = 'this product does not include a warranty';
+
 /*
  * Creates the tab buttons for the specifications section.
  * @param {Array<{id: string, label: string}>} tabs - Array of tab objects with id and label.
@@ -160,7 +162,7 @@ function createTabContent(tab, specifications, standardWarranty, custom, product
       }
       break;
     case 'warranty':
-      if (custom.warranty) {
+      if (typeof custom.warranty === 'string' && !custom.warranty.toLowerCase().includes(NO_WARRANTY_PHRASE)) {
         content.appendChild(createWarrantyContent(standardWarranty, custom.warranty));
       }
       break;

--- a/blocks/pdp/specification-tabs.js
+++ b/blocks/pdp/specification-tabs.js
@@ -162,7 +162,7 @@ function createTabContent(tab, specifications, standardWarranty, custom, product
       }
       break;
     case 'warranty':
-      if (typeof custom.warranty === 'string' && !custom.warranty.toLowerCase().includes(NO_WARRANTY_PHRASE)) {
+      if (custom.warranty) {
         content.appendChild(createWarrantyContent(standardWarranty, custom.warranty));
       }
       break;
@@ -225,7 +225,7 @@ export default function renderSpecs(specifications, custom, productName) {
   const standardWarranty = options?.find((option) => option.name.includes('Standard Warranty'));
   const tabs = [
     { id: 'specifications', label: 'Specifications', show: !!specifications },
-    { id: 'warranty', label: 'Warranty', show: !!custom.warranty },
+    { id: 'warranty', label: 'Warranty', show: !!custom.warranty && !custom.warranty.toLowerCase().includes(NO_WARRANTY_PHRASE) },
     { id: 'resources', label: 'Resources', show: true },
   ].filter((tab) => tab.show);
 


### PR DESCRIPTION

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/24-ounce-tumbler
- After: https://no-warranty--vitamix--aemsites.aem.network/us/en_us/products/24-ounce-tumbler
