### PR TITLE
fix: disable auto eyebrows on pdp

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -535,6 +535,10 @@ function decorateImages(main) {
  * @param {HTMLElement} main - Main container element
  */
 function decorateEyebrows(main) {
+  // Disable auto eyebrows if the page is a PDP
+  const metaSku = document.querySelector('meta[name="sku"]');
+  if (metaSku) return;
+
   main.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     const beforeH = h.previousElementSibling;
     if (beforeH && beforeH.tagName === 'P') {
@@ -544,7 +548,6 @@ function decorateEyebrows(main) {
       // ignore p tags with images or links
       const disqualifiers = beforeH.querySelector('img, a[href]');
       if (disqualifiers) return;
-
       beforeH.classList.add('eyebrow');
       h.dataset.eyebrow = beforeH.textContent.trim();
     }


### PR DESCRIPTION
The auto eyebrow logic was decorating content in the details panel of the pdp. Since we are handling the eyebrows explicitly in the pdp I'm disabling this logic if it's a pdp page.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/64-ounce-low-profile-container-with-self-detect
- After: https://disable-auto-eyebrows--vitamix--aemsites.aem.network/us/en_us/products/64-ounce-low-profile-container-with-self-detect
