### PR TITLE
fix: bundle variant options should update gallery images when clicked

### DIFF
--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -1,6 +1,6 @@
 import { buildSlide, buildThumbnails } from './gallery.js';
 import { rebuildIndices, checkOutOfStock } from '../../scripts/scripts.js';
-import { toClassName, getMetadata } from '../../scripts/aem.js';
+import { toClassName } from '../../scripts/aem.js';
 import renderPricing from './pricing.js';
 import renderAddToCart from './add-to-cart.js';
 


### PR DESCRIPTION
We are currently preventing variant images from being inserted into the gallery when a variant is selected and the product is of type `bundle`. Vitamix logged an issue for this.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5-smartprep-kitchen-system
- After: https://bundle-variant-images--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5-smartprep-kitchen-system
