### PR TITLE
fix: support next pipeline version

### DIFF
--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -6,7 +6,7 @@ import renderPricing, { extractPricing } from './pricing.js';
 // eslint-disable-next-line import/no-cycle
 import { renderOptions, onOptionChange } from './options.js';
 import { loadFragment } from '../fragment/fragment.js';
-import { checkOutOfStock } from '../../scripts/scripts.js';
+import { checkOutOfStock, isNextPipeline } from '../../scripts/scripts.js';
 import { openModal } from '../modal/modal.js';
 
 /**
@@ -411,7 +411,13 @@ export default async function decorate(block) {
 
   const faqContainer = renderFAQ(block);
 
-  fetchFragment(block);
+  if (isNextPipeline()) {
+    // Content is already in the initial HTML
+    renderContent(block);
+  } else {
+    // Fetch and render the fragment for legacy pipeline
+    fetchFragment(block);
+  }
 
   renderReviews(block, reviewsId);
 


### PR DESCRIPTION
The next pipeline version has two major changes
1. Authored product content is injected in pipeline
2. Variant metadata are now data attributes on the variant section as opposed to section metadata.

Rendering of the `next` pipeline is only used on products with the pipeline meta tag set to `next`.

To support these pipeline changes, the client needs to be adjusted in the following way

If pipeline metatag is `next` we
1. Pullout variant `sku`, `color` and `uid` from the data attributes instead of section metadata
2. Don't load the authored content fragment
3. The location of the LCP image in the initial HTML changes, so we need to adjust for that

The ascent x2 on the Canadian site is currently the only product set to use the new pipeline.

Once all products are using the new sync and the new pipeline is the default, we can remove this conditional logic.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/ca/en_us/products/ascent-x2
- After: https://next-pipeline--vitamix--aemsites.aem.network/ca/en_us/products/ascent-x2
