### PR TITLE
fix: add special labeling for recon pricing

### DIFF
--- a/blocks/pdp/pricing.js
+++ b/blocks/pdp/pricing.js
@@ -42,10 +42,16 @@ export default function renderPricing(block, variant) {
 
   if (!variant) pricingElement.remove();
 
+  // Check if the product is reconditioned
+  // If the variant is not null, check if the item condition is refurbished
+  // If the variant is null, check if the location href includes 'reconditioned'
+  // If both are false, item is not reconditioned
+  const isReconditioned = variant != null ? variant.itemCondition === 'RefurbishedCondition' : window.location.href.includes('reconditioned') || false;
+
   if (pricing.regular && pricing.regular > pricing.final) {
     const nowLabel = document.createElement('div');
     nowLabel.className = 'pricing-now';
-    nowLabel.textContent = 'Now';
+    nowLabel.textContent = isReconditioned ? 'Recon Price' : 'Now';
     pricingContainer.appendChild(nowLabel);
   }
 
@@ -61,7 +67,7 @@ export default function renderPricing(block, variant) {
     const savingsAmount = pricing.regular - pricing.final;
     const saveText = document.createElement('span');
     saveText.className = 'pricing-save';
-    saveText.textContent = `Save $${savingsAmount.toFixed(2)} | Was `;
+    saveText.textContent = isReconditioned ? `Save $${savingsAmount.toFixed(2)} | New ` : `Save $${savingsAmount.toFixed(2)} | Was `;
 
     const regularPrice = document.createElement('del');
     regularPrice.className = 'pricing-regular';


### PR DESCRIPTION
Add "Recon Price" and "New" to recondition products pricing

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a2500
- After: https://recon-pricing-label--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a2500
