### PR TITLE
chore: hide implied banner for users from the US

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -64,6 +64,7 @@ export default async function decorate(block) {
   if (cookieDeclaration) {
     cookieDeclaration.addEventListener('click', (e) => {
       e.preventDefault();
+      window.Cookiebot.forceDialog = true;
       window.Cookiebot.renew();
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1086,6 +1086,19 @@ async function loadDelayed() {
   const params = new URLSearchParams(window.location.search);
   if (params.get('martech') !== 'off') {
     await loadScript('https://consent.cookiebot.com/uc.js', { 'data-cbid': '1d1d4c74-9c10-49e5-9577-f8eb4ba520fb' });
+    window.addEventListener('CookiebotOnDialogDisplay', () => {
+      const userCountry = new URLSearchParams(window.location.search).get('geoip-country') || window.Cookiebot.userCountry;
+      if (userCountry.startsWith('US-')) {
+        if (!window.Cookiebot.forceDialog) {
+          document.body.classList.add('hide-consent-banner-for-us');
+        } else {
+          document.body.classList.remove('hide-consent-banner-for-us');
+        }
+      } else {
+        window.Cookiebot.dialog.consentLevel = 'strict';
+        window.Cookiebot.dialog.detachOnscrollEvent();
+      }
+    });
     if (params.get('martech') === 'on') {
       import('./consented.js');
     } else {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -802,3 +802,9 @@ body.fragment-preview::before {
   font-size: 16px;
   font-weight: bold;
 }
+
+/* suppress automatically opening consent banner for us */
+/* stylelint-disable-next-line */
+body.hide-consent-banner-for-us #CybotCookiebotDialog {
+  display: none !important;
+}


### PR DESCRIPTION
Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/
- After: https://implied-hidden-us-banner--vitamix--aemsites.aem.network/us/en_us/


For testing, run a new incognito mode tab on localhost to see the effect.

`git checkout implied-hidden-us-banner` branch and then use `aem up`

new incognito mode for standard behavior:
http://localhost:3000/us/en_us/

for simulated other geoip-country use the following syntax
http://localhost:3000/us/en_us/?geoip-country=CA
