### PR TITLE
chore: hide consent for US for initial load

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -64,6 +64,7 @@ export default async function decorate(block) {
   if (cookieDeclaration) {
     cookieDeclaration.addEventListener('click', (e) => {
       e.preventDefault();
+      window.Cookiebot.forceDialog = true;
       window.Cookiebot.renew();
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1088,10 +1088,17 @@ async function loadDelayed() {
     await loadScript('https://consent.cookiebot.com/uc.js', {
       'data-cbid': '1d1d4c74-9c10-49e5-9577-f8eb4ba520fb',
       'data-blockingmode': 'auto',
-      'data-georegions': `
-        {'region':'US','cbid':'e9652803-d7e7-491b-a318-632a8f288b5b'},
-        {'region':'AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,DE,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,IS,LI,NO,UK','cbid':'1d1d4c74-9c10-49e5-9577-f8eb4ba520fb'}
-      `,
+      'data-georegions': '{"region":"US","cbid":"e9652803-d7e7-491b-a318-632a8f288b5b"}',
+    });
+    window.addEventListener('CookiebotOnDialogDisplay', () => {
+      const { userCountry } = window.Cookiebot;
+      if (userCountry && userCountry.startsWith('US-')) {
+        if (!window.Cookiebot.forceDialog) {
+          document.body.classList.add('hide-consent-banner-for-us');
+        } else {
+          document.body.classList.remove('hide-consent-banner-for-us');
+        }
+      }
     });
     if (params.get('martech') === 'on') {
       import('./consented.js');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -802,3 +802,9 @@ body.fragment-preview::before {
   font-size: 16px;
   font-weight: bold;
 }
+
+/* suppress automatically opening consent banner for us */
+/* stylelint-disable-next-line */
+body.hide-consent-banner-for-us #CybotCookiebotDialog {
+  display: none !important;
+}


### PR DESCRIPTION
Test URLs:

Before: https://main--vitamix--aemsites.aem.network/us/en_us/
After: https://hidden-consent2--vitamix--aemsites.aem.network/us/en_us/
For testing, run a new incognito mode tab on localhost to see the effect.

`git checkout hidden-consent2` branch and then use `aem up`

new incognito mode for testing:
http://localhost:3000/us/en_us/
