### PR TITLE
Hero variation

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -31,7 +31,7 @@ main > .hero-container.section {
   inset: 0;
   background-color: black;
   opacity: 0.6;
-  z-index: 0;
+  z-index: -1;
   pointer-events: none;
 }
 
@@ -43,25 +43,6 @@ main > .hero-container.section {
   height: 100%;
   object-fit: cover;
   z-index: -1;
-}
-
-.hero picture {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-}
-
-.hero > picture img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.hero > div {
-  position: relative;
-  z-index: 1;
 }
 
 .hero .eyebrow {
@@ -116,11 +97,10 @@ main > .hero-container.section {
 }
 
 /* ============================================================
-   left-aligned variant
-   Mirrors the banner.aligned pattern:
-   - no full ::after overlay
-   - ::before gradient on the picture, driven by --image-color
-   - text pinned to one side, left-aligned
+   left/right aligned variant
+   - picture hoisted to block level as full-bleed background
+   - ::after becomes a directional gradient using --image-color
+   - text pinned to left or right, constrained to ~50% width
    ============================================================ */
 
 .hero.left-text,
@@ -130,15 +110,40 @@ main > .hero-container.section {
   text-align: left;
 }
 
+/* picture is hoisted to a direct child of .hero in JS */
+.hero.left-text > picture,
+.hero.right-text > picture {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
+
+.hero.left-text > picture img,
+.hero.right-text > picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 /* replace solid black overlay with a directional gradient using --image-color */
 .hero.left-text::after {
   background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
+  z-index: 0;
 }
 
 .hero.right-text::after {
   background: linear-gradient(to left, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
+  z-index: 0;
+}
+
+.hero.left-text > div,
+.hero.right-text > div {
+  position: relative;
+  z-index: 1;
 }
 
 .hero.left-text.image-darkest,
@@ -180,21 +185,17 @@ main > .hero-container.section {
 
 .hero.left-text > div > div,
 .hero.right-text > div > div {
-  position: relative;
   margin: 0;
   width: 50%;
   max-width: 520px;
   padding: var(--spacing-600) 0;
   padding-top: 55px;
-  z-index: 1;
 }
 
-/* left-text: content sits on the left */
 .hero.left-text > div > div {
   margin-right: auto;
 }
 
-/* right-text: content sits on the right */
 .hero.right-text > div > div {
   margin-left: auto;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -140,10 +140,35 @@ main > .hero-container.section {
   z-index: 0;
 }
 
+/* text content block — constrained to ~50% so it stays in the gradient zone */
 .hero.left-text > div,
 .hero.right-text > div {
   position: relative;
+  align-items: center;
+  padding: 0 var(--horizontal-spacing);
   z-index: 1;
+}
+
+.hero.left-text > div > div,
+.hero.right-text > div > div {
+  margin: 0;
+  width: 50%;
+  max-width: 520px;
+  padding: var(--spacing-600) 0;
+  padding-top: 55px;
+}
+
+.hero.left-text > div > div {
+  margin-right: auto;
+}
+
+.hero.right-text > div > div {
+  margin-left: auto;
+}
+
+.hero.left-text .button-wrapper,
+.hero.right-text .button-wrapper {
+  justify-content: flex-start;
 }
 
 .hero.left-text.image-darkest,
@@ -174,35 +199,6 @@ main > .hero-container.section {
 .hero.left-text.image-lightest > div > div,
 .hero.right-text.image-lightest > div > div {
   color: var(--color-charcoal);
-}
-
-/* text content block — constrained to ~50% so it stays in the gradient zone */
-.hero.left-text > div,
-.hero.right-text > div {
-  align-items: center;
-  padding: 0 var(--horizontal-spacing);
-}
-
-.hero.left-text > div > div,
-.hero.right-text > div > div {
-  margin: 0;
-  width: 50%;
-  max-width: 520px;
-  padding: var(--spacing-600) 0;
-  padding-top: 55px;
-}
-
-.hero.left-text > div > div {
-  margin-right: auto;
-}
-
-.hero.right-text > div > div {
-  margin-left: auto;
-}
-
-.hero.left-text .button-wrapper,
-.hero.right-text .button-wrapper {
-  justify-content: flex-start;
 }
 
 @media (width >= 800px) {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -212,3 +212,70 @@ main > .hero-container.section {
     max-width: 700px;
   }
 }
+
+/* mobile: stack image on top, text below on solid --image-color background */
+@media (width < 800px) {
+  .hero.left-text,
+  .hero.right-text {
+    flex-direction: column;
+    align-items: stretch;
+    min-height: unset;
+  }
+
+  .hero.left-text::after,
+  .hero.right-text::after {
+    display: none;
+  }
+
+  .hero.left-text > picture,
+  .hero.right-text > picture {
+    position: relative;
+    inset: unset;
+    width: 100%;
+    height: 280px;
+    z-index: 0;
+  }
+
+  .hero.left-text > picture img,
+  .hero.right-text > picture img {
+    height: 280px;
+    object-fit: cover;
+  }
+
+  .hero.left-text > div,
+  .hero.right-text > div {
+    position: relative;
+    z-index: 0;
+    padding: var(--spacing-400) var(--horizontal-spacing);
+    background-color: var(--image-color, var(--color-charcoal));
+  }
+
+  .hero.left-text > div > div,
+  .hero.right-text > div > div {
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+  }
+
+  /* text color based on image tone */
+  .hero.left-text.image-light > div,
+  .hero.right-text.image-light > div,
+  .hero.left-text.image-lightest > div,
+  .hero.right-text.image-lightest > div {
+    background-color: var(--image-color, var(--color-gray-200));
+  }
+
+  .hero.left-text.image-light > div > div,
+  .hero.right-text.image-light > div > div,
+  .hero.left-text.image-lightest > div > div,
+  .hero.right-text.image-lightest > div > div {
+    color: var(--color-charcoal);
+  }
+
+  .hero.left-text.image-dark > div > div,
+  .hero.right-text.image-dark > div > div,
+  .hero.left-text.image-darkest > div > div,
+  .hero.right-text.image-darkest > div > div {
+    color: var(--color-gray-100);
+  }
+}

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -53,6 +53,12 @@ main > .hero-container.section {
   z-index: -1;
 }
 
+.hero > picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .hero > div {
   position: relative;
   z-index: 1;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -94,3 +94,125 @@ main > .hero-container.section {
     max-width: 800px;
   }
 }
+
+/* ============================================================
+   left-aligned variant
+   Mirrors the banner.aligned pattern:
+   - no full ::after overlay
+   - ::before gradient on the picture, driven by --image-color
+   - text pinned to one side, left-aligned
+   ============================================================ */
+
+.hero.left-text,
+.hero.right-text {
+  text-align: left;
+}
+
+/* remove the default full-black overlay */
+.hero.left-text::after,
+.hero.right-text::after {
+  display: none;
+}
+
+/* default overlay opacity (overridden by image-tone classes below) */
+.hero.left-text,
+.hero.right-text {
+  --overlay-opacity: 0.66;
+}
+
+.hero.left-text.image-darkest,
+.hero.right-text.image-darkest {
+  --overlay-opacity: 0.2;
+}
+
+.hero.left-text.image-dark,
+.hero.right-text.image-dark {
+  --overlay-opacity: 0.8;
+}
+
+.hero.left-text.image-light,
+.hero.right-text.image-light {
+  --overlay-opacity: 0.8;
+  color: var(--color-charcoal);
+}
+
+.hero.left-text.image-lightest,
+.hero.right-text.image-lightest {
+  --overlay-opacity: 0.2;
+  color: var(--color-charcoal);
+}
+
+/* gradient overlay — same technique as banner.aligned ::before */
+.hero.left-text picture::after,
+.hero.right-text picture::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* text-on-right → gradient fades LEFT side of image */
+.hero.left-text picture::after {
+  background: linear-gradient(to right, var(--image-color, #000) 40%, transparent);
+  opacity: var(--overlay-opacity);
+}
+
+/* text-on-left → gradient fades RIGHT side of image */
+.hero.right-text picture::after {
+  background: linear-gradient(to left, var(--image-color, #000) 40%, transparent);
+  opacity: var(--overlay-opacity);
+}
+
+/* keep the picture container positioned so ::after sits over the image */
+.hero.left-text picture,
+.hero.right-text picture {
+  position: absolute;
+  inset: 0;
+}
+
+/* text content block */
+.hero.left-text > div,
+.hero.right-text > div {
+  align-items: center;
+  padding: 0 var(--horizontal-spacing);
+}
+
+.hero.left-text > div > div,
+.hero.right-text > div > div {
+  position: relative;
+  margin: 0;
+  max-width: 520px;
+  padding: var(--spacing-600) 0;
+  padding-top: 55px;
+  z-index: 1;
+}
+
+/* left-text: content sits on the left */
+.hero.left-text > div > div {
+  margin-right: auto;
+}
+
+/* right-text: content sits on the right */
+.hero.right-text > div > div {
+  margin-left: auto;
+}
+
+.hero.left-text .button-wrapper,
+.hero.right-text .button-wrapper {
+  justify-content: flex-start;
+}
+
+@media (width >= 800px) {
+  .hero.left-text > div > div,
+  .hero.right-text > div > div {
+    max-width: 600px;
+  }
+}
+
+@media (width >= 1200px) {
+  .hero.left-text > div > div,
+  .hero.right-text > div > div {
+    max-width: 700px;
+  }
+}

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -110,10 +110,15 @@ main > .hero-container.section {
   text-align: left;
 }
 
-/* remove the default full-black overlay */
-.hero.left-text::after,
+/* replace solid black overlay with a directional gradient using --image-color */
+.hero.left-text::after {
+  background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
+  opacity: var(--overlay-opacity);
+}
+
 .hero.right-text::after {
-  display: none;
+  background: linear-gradient(to left, var(--image-color, #000) 40%, transparent 70%);
+  opacity: var(--overlay-opacity);
 }
 
 .hero.left-text.image-darkest,
@@ -140,36 +145,7 @@ main > .hero-container.section {
   color: var(--color-charcoal);
 }
 
-/* gradient overlay — same technique as banner.aligned ::before */
-.hero.left-text picture::after,
-.hero.right-text picture::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-}
-
-/* text-on-right → gradient fades LEFT side of image */
-.hero.left-text picture::after {
-  background: linear-gradient(to right, var(--image-color, #000) 40%, transparent);
-  opacity: var(--overlay-opacity);
-}
-
-/* text-on-left → gradient fades RIGHT side of image */
-.hero.right-text picture::after {
-  background: linear-gradient(to left, var(--image-color, #000) 40%, transparent);
-  opacity: var(--overlay-opacity);
-}
-
-/* keep the picture container positioned so ::after sits over the image */
-.hero.left-text picture,
-.hero.right-text picture {
-  position: absolute;
-  inset: 0;
-}
-
-/* text content block */
+/* text content block — constrained to ~50% so it stays in the gradient zone */
 .hero.left-text > div,
 .hero.right-text > div {
   align-items: center;
@@ -180,6 +156,7 @@ main > .hero-container.section {
 .hero.right-text > div > div {
   position: relative;
   margin: 0;
+  width: 50%;
   max-width: 520px;
   padding: var(--spacing-600) 0;
   padding-top: 55px;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -70,16 +70,16 @@ main > .hero-container.section {
   color: var(--color-gray-100);
 }
 
-.hero.image-light > div > div,
-.hero.image-lightest > div > div {
-  /* color: var(--color-charcoal); */
-}
-
 .hero > div > div h1 b {
   font-weight: 900;
 }
 
 @media (width >= 800px) {
+  .hero,
+  .hero > div {
+    min-height: 650px;
+  }
+
   .hero h1 {
     font-size: var(--font-size-950);
   }
@@ -91,12 +91,20 @@ main > .hero-container.section {
 }
 
 @media (width >= 1200px) {
+  .hero,
+  .hero > div {
+    min-height: 720px;
+  }
+
   .hero > div > div {
     max-width: 800px;
   }
 }
 
-/* left/right aligned variant */
+/* left/right aligned variant
+   JS hoists picture to a direct child of .hero as a full-bleed background,
+   then ::after becomes a directional gradient driven by --image-color */
+
 .hero.left-text,
 .hero.right-text {
   --overlay-opacity: 0.66;
@@ -120,7 +128,6 @@ main > .hero-container.section {
   object-fit: cover;
 }
 
-/* directional gradient using --image-color */
 .hero.left-text::after {
   background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
@@ -163,6 +170,7 @@ main > .hero-container.section {
   justify-content: flex-start;
 }
 
+/* overlay opacity by image tone */
 .hero.left-text.image-darkest,
 .hero.right-text.image-darkest {
   --overlay-opacity: 0.2;
@@ -178,16 +186,14 @@ main > .hero-container.section {
   --overlay-opacity: 0.8;
 }
 
-.hero.left-text.image-light > div > div,
-.hero.right-text.image-light > div > div {
-  color: var(--color-charcoal);
-}
-
 .hero.left-text.image-lightest,
 .hero.right-text.image-lightest {
   --overlay-opacity: 0.2;
 }
 
+/* switch to dark text on light backgrounds */
+.hero.left-text.image-light > div > div,
+.hero.right-text.image-light > div > div,
 .hero.left-text.image-lightest > div > div,
 .hero.right-text.image-lightest > div > div {
   color: var(--color-charcoal);
@@ -204,19 +210,5 @@ main > .hero-container.section {
   .hero.left-text > div > div,
   .hero.right-text > div > div {
     max-width: 700px;
-  }
-}
-
-@media (width >= 800px) {
-  .hero,
-  .hero > div {
-    min-height: 650px;
-  }
-}
-
-@media (width >= 1200px) {
-  .hero,
-  .hero > div {
-    min-height: 720px;
   }
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -105,6 +105,8 @@ main > .hero-container.section {
 
 .hero.left-text,
 .hero.right-text {
+  --overlay-opacity: 0.66;
+
   text-align: left;
 }
 
@@ -112,12 +114,6 @@ main > .hero-container.section {
 .hero.left-text::after,
 .hero.right-text::after {
   display: none;
-}
-
-/* default overlay opacity (overridden by image-tone classes below) */
-.hero.left-text,
-.hero.right-text {
-  --overlay-opacity: 0.66;
 }
 
 .hero.left-text.image-darkest,
@@ -133,12 +129,14 @@ main > .hero-container.section {
 .hero.left-text.image-light,
 .hero.right-text.image-light {
   --overlay-opacity: 0.8;
+
   color: var(--color-charcoal);
 }
 
 .hero.left-text.image-lightest,
 .hero.right-text.image-lightest {
   --overlay-opacity: 0.2;
+
   color: var(--color-charcoal);
 }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -117,13 +117,11 @@ main > .hero-container.section {
 
 /* replace solid black overlay with a directional gradient using --image-color */
 .hero.left-text::after {
-  background-color: transparent;
   background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
 }
 
 .hero.right-text::after {
-  background-color: transparent;
   background: linear-gradient(to left, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -154,14 +154,20 @@ main > .hero-container.section {
 .hero.left-text.image-light,
 .hero.right-text.image-light {
   --overlay-opacity: 0.8;
+}
 
+.hero.left-text.image-light > div > div,
+.hero.right-text.image-light > div > div {
   color: var(--color-charcoal);
 }
 
 .hero.left-text.image-lightest,
 .hero.right-text.image-lightest {
   --overlay-opacity: 0.2;
+}
 
+.hero.left-text.image-lightest > div > div,
+.hero.right-text.image-lightest > div > div {
   color: var(--color-charcoal);
 }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -96,13 +96,7 @@ main > .hero-container.section {
   }
 }
 
-/* ============================================================
-   left/right aligned variant
-   - picture hoisted to block level as full-bleed background
-   - ::after becomes a directional gradient using --image-color
-   - text pinned to left or right, constrained to ~50% width
-   ============================================================ */
-
+/* left/right aligned variant */
 .hero.left-text,
 .hero.right-text {
   --overlay-opacity: 0.66;
@@ -110,7 +104,6 @@ main > .hero-container.section {
   text-align: left;
 }
 
-/* picture is hoisted to a direct child of .hero in JS */
 .hero.left-text > picture,
 .hero.right-text > picture {
   position: absolute;
@@ -127,7 +120,7 @@ main > .hero-container.section {
   object-fit: cover;
 }
 
-/* replace solid black overlay with a directional gradient using --image-color */
+/* directional gradient using --image-color */
 .hero.left-text::after {
   background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
@@ -140,7 +133,6 @@ main > .hero-container.section {
   z-index: 0;
 }
 
-/* text content block — constrained to ~50% so it stays in the gradient zone */
 .hero.left-text > div,
 .hero.right-text > div {
   position: relative;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -30,7 +30,7 @@ main > .hero-container.section {
   inset: 0;
   background-color: black;
   opacity: 0.6;
-  z-index: -1;
+  z-index: 0;
   pointer-events: none;
 }
 
@@ -42,6 +42,11 @@ main > .hero-container.section {
   height: 100%;
   object-fit: cover;
   z-index: -1;
+}
+
+.hero > div {
+  position: relative;
+  z-index: 1;
 }
 
 .hero .eyebrow {
@@ -112,11 +117,13 @@ main > .hero-container.section {
 
 /* replace solid black overlay with a directional gradient using --image-color */
 .hero.left-text::after {
+  background-color: transparent;
   background: linear-gradient(to right, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
 }
 
 .hero.right-text::after {
+  background-color: transparent;
   background: linear-gradient(to left, var(--image-color, #000) 40%, transparent 70%);
   opacity: var(--overlay-opacity);
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -15,7 +15,7 @@ main > .hero-container.section {
   align-items: center;
   position: relative;
   width: 100%;
-  min-height: 575px;
+  min-height: 480px;
 }
 
 .hero {
@@ -216,5 +216,19 @@ main > .hero-container.section {
   .hero.left-text > div > div,
   .hero.right-text > div > div {
     max-width: 700px;
+  }
+}
+
+@media (width >= 800px) {
+  .hero,
+  .hero > div {
+    min-height: 650px;
+  }
+}
+
+@media (width >= 1200px) {
+  .hero,
+  .hero > div {
+    min-height: 720px;
   }
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -6,6 +6,7 @@ main > .hero-container.section {
 .hero-container .hero-wrapper {
   margin: 0;
   padding: 0;
+  overflow: hidden;
 }
 
 .hero,
@@ -41,6 +42,14 @@ main > .hero-container.section {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  z-index: -1;
+}
+
+.hero picture {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   z-index: -1;
 }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -213,6 +213,7 @@ main > .hero-container.section {
   }
 }
 
+
 /* mobile: stack image on top, text below on solid --image-color background */
 @media (width < 800px) {
   .hero.left-text,
@@ -231,14 +232,15 @@ main > .hero-container.section {
   .hero.right-text > picture {
     position: relative;
     inset: unset;
+    order: -1;
     width: 100%;
-    height: 280px;
+    height: 260px;
     z-index: 0;
   }
 
   .hero.left-text > picture img,
   .hero.right-text > picture img {
-    height: 280px;
+    height: 260px;
     object-fit: cover;
   }
 
@@ -246,7 +248,7 @@ main > .hero-container.section {
   .hero.right-text > div {
     position: relative;
     z-index: 0;
-    padding: var(--spacing-400) var(--horizontal-spacing);
+    padding: var(--spacing-200) var(--horizontal-spacing);
     background-color: var(--image-color, var(--color-charcoal));
   }
 
@@ -257,7 +259,6 @@ main > .hero-container.section {
     padding: 0;
   }
 
-  /* text color based on image tone */
   .hero.left-text.image-light > div,
   .hero.right-text.image-light > div,
   .hero.left-text.image-lightest > div,

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -247,6 +247,7 @@ main > .hero-container.section {
   .hero.left-text > div,
   .hero.right-text > div {
     position: relative;
+    min-height: unset;
     z-index: 0;
     padding: var(--spacing-200) var(--horizontal-spacing);
     background-color: var(--image-color, var(--color-charcoal));

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -10,13 +10,11 @@ export default function decorate(block) {
       const img = picture.querySelector('img');
       const optimized = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
 
-      // find the direct-child row of block that contains the picture
-      let imageRow = picture;
-      while (imageRow.parentElement !== block) imageRow = imageRow.parentElement;
-
-      // append optimized picture to block as background before removing the row
+      // picture lives in a cell (div), which lives in a row (div), which lives in block
+      // we only want to remove the cell, not the row
+      const imgCell = picture.parentElement;
       block.appendChild(optimized);
-      imageRow.remove();
+      imgCell.remove();
 
       const newImg = optimized.querySelector('img');
       if (newImg.complete) applyImgColor(block);

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -2,31 +2,42 @@ import { createOptimizedPicture } from '../../scripts/aem.js';
 import { buildVideo, applyImgColor } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
-  // set background
-  buildVideo(block);
-  const img = block.querySelector('picture img');
-  if (img) {
-    img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]));
-    if (img.complete) applyImgColor(block);
-    else if (img.tagName === 'IMG') {
-      img.addEventListener('load', () => {
-        applyImgColor(block);
-      });
+  const isAligned = block.classList.contains('left') || block.classList.contains('right');
+
+  if (isAligned) {
+    // Hoist the picture out of its table cell and append directly to the block
+    // so it can be positioned as a full-bleed background via CSS
+    const picture = block.querySelector('picture');
+    if (picture) {
+      const img = picture.querySelector('img');
+      const optimized = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
+      block.appendChild(optimized);
+
+      // clean up the now-empty cell/row
+      const imgCell = picture.closest('div');
+      if (imgCell) imgCell.remove();
+
+      const newImg = optimized.querySelector('img');
+      if (newImg.complete) applyImgColor(block);
+      else newImg.addEventListener('load', () => applyImgColor(block));
+    }
+
+    block.classList.add(block.classList.contains('right') ? 'right-text' : 'left-text');
+  } else {
+    // default hero behaviour
+    buildVideo(block);
+    const img = block.querySelector('picture img');
+    if (img) {
+      img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]));
+      if (img.complete) applyImgColor(block);
+      else if (img.tagName === 'IMG') {
+        img.addEventListener('load', () => applyImgColor(block));
+      }
     }
   }
 
   const disclaimer = block.querySelector('.disclaimer');
   if (disclaimer) {
     block.dataset.disclaimer = disclaimer.textContent;
-  }
-
-  // left-aligned variant: determine text position relative to image
-  if (block.classList.contains('left')) {
-    block.classList.add('left-text');
-  } else if (block.classList.contains('right')) {
-    block.classList.add('right-text');
-  } else {
-    // default for the left-aligned variant: text on the right side
-    block.classList.add('left-text');
   }
 }

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -6,16 +6,20 @@ export default function decorate(block) {
 
   if (isAligned) {
     // Hoist the picture out of its table cell and append directly to the block
-    // so it can be positioned as a full-bleed background via CSS
+    // so it can be positioned as a full-bleed background via CSS.
+    // Block DOM is: block > div (row) > div (cell) > picture
     const picture = block.querySelector('picture');
     if (picture) {
       const img = picture.querySelector('img');
       const optimized = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
       block.appendChild(optimized);
 
-      // clean up the now-empty cell/row
-      const imgCell = picture.closest('div');
-      if (imgCell) imgCell.remove();
+      // remove only the row that contained the image, not any other rows
+      const imgRow = picture.closest(':scope > div', block) || picture.closest('div');
+      // walk up until we find a direct child of block
+      let el = picture;
+      while (el.parentElement !== block) el = el.parentElement;
+      el.remove();
 
       const newImg = optimized.querySelector('img');
       if (newImg.complete) applyImgColor(block);

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -5,21 +5,18 @@ export default function decorate(block) {
   const isAligned = block.classList.contains('left') || block.classList.contains('right');
 
   if (isAligned) {
-    // Hoist the picture out of its table cell and append directly to the block
-    // so it can be positioned as a full-bleed background via CSS.
-    // Block DOM is: block > div (row) > div (cell) > picture
     const picture = block.querySelector('picture');
     if (picture) {
       const img = picture.querySelector('img');
       const optimized = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
-      block.appendChild(optimized);
 
-      // remove only the row that contained the image, not any other rows
-      const imgRow = picture.closest(':scope > div', block) || picture.closest('div');
-      // walk up until we find a direct child of block
-      let el = picture;
-      while (el.parentElement !== block) el = el.parentElement;
-      el.remove();
+      // find the direct-child row of block that contains the picture
+      let imageRow = picture;
+      while (imageRow.parentElement !== block) imageRow = imageRow.parentElement;
+
+      // append optimized picture to block as background before removing the row
+      block.appendChild(optimized);
+      imageRow.remove();
 
       const newImg = optimized.querySelector('img');
       if (newImg.complete) applyImgColor(block);
@@ -28,7 +25,6 @@ export default function decorate(block) {
 
     block.classList.add(block.classList.contains('right') ? 'right-text' : 'left-text');
   } else {
-    // default hero behaviour
     buildVideo(block);
     const img = block.querySelector('picture img');
     if (img) {

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -9,9 +9,6 @@ export default function decorate(block) {
     if (picture) {
       const img = picture.querySelector('img');
       const optimized = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
-
-      // picture lives in a cell (div), which lives in a row (div), which lives in block
-      // we only want to remove the cell, not the row
       const imgCell = picture.parentElement;
       block.appendChild(optimized);
       imgCell.remove();

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -19,4 +19,14 @@ export default function decorate(block) {
   if (disclaimer) {
     block.dataset.disclaimer = disclaimer.textContent;
   }
+
+  // left-aligned variant: determine text position relative to image
+  if (block.classList.contains('left')) {
+    block.classList.add('left-text');
+  } else if (block.classList.contains('right')) {
+    block.classList.add('right-text');
+  } else {
+    // default for the left-aligned variant: text on the right side
+    block.classList.add('left-text');
+  }
 }


### PR DESCRIPTION
**Hero Block — Left/Right Aligned Variant**
Added a new left and right variant to the hero block that positions text over a partial gradient overlay, driven by the dominant color extracted from the background image.

How to use
Add the block to your document as hero (left) or hero (right).

What changed
hero.js
Added handling for left and right block variants
applyImgColor() is called on the new optimized picture, setting --image-color and the appropriate image-dark/light tone class on the block
Default hero behavior (centered, full overlay) is unchanged

hero.css
Added .hero.left-text and .hero.right-text styles for the aligned variant
::after overlay is replaced with a directional linear-gradient using --image-color, fading from 40% to transparent at 70%
Gradient direction is left-to-right for left-text, right-to-left for right-text
Overlay opacity is driven by --overlay-opacity, which adjusts based on the image-darkest/dark/light/lightest tone classes set by applyImgColor()
Text color switches to var(--color-charcoal) on image-light and image-lightest backgrounds
Text column is constrained to 50% width so it stays within the gradient zone
On mobile (< 800px), the layout stacks vertically — image on top, text below on a solid --image-color background block
Updated min-height to 480px mobile / 650px tablet / 720px desktop across all hero variants


Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/drafts/ashleya/blocks
- After: https://hero-variation--vitamix--aemsites.aem.page/drafts/ashleya/blocks
