### PR TITLE
Related recipes mobile

### DIFF
--- a/blocks/related-recipes/related-recipes.css
+++ b/blocks/related-recipes/related-recipes.css
@@ -106,11 +106,11 @@
 }
 
 /* Hide description text on mobile for secondary cards, keep links and meta */
-.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta) {
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow, .meta) {
   display: none;
 }
 
-.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta):has(a) {
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow, .meta):has(a) {
   display: block;
 }
 
@@ -130,7 +130,7 @@
     min-height: unset;
   }
 
-  .related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta) {
+  .related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow, .meta) {
     display: block;
   }
 }

--- a/blocks/related-recipes/related-recipes.css
+++ b/blocks/related-recipes/related-recipes.css
@@ -105,12 +105,12 @@
   min-height: 120px;
 }
 
-/* Hide description text on mobile for secondary cards, keep links */
-.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow) {
+/* Hide description text on mobile for secondary cards, keep links and meta */
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta) {
   display: none;
 }
 
-.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):has(a) {
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta):has(a) {
   display: block;
 }
 
@@ -130,7 +130,7 @@
     min-height: unset;
   }
 
-  .related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow) {
+  .related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):not(.meta) {
     display: block;
   }
 }

--- a/blocks/related-recipes/related-recipes.css
+++ b/blocks/related-recipes/related-recipes.css
@@ -89,6 +89,52 @@
   color: inherit;
 }
 
+/* Mobile: image left, text right for secondary cards */
+.related-recipes.highlight > ul > li:not(:first-child) {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  align-items: stretch;
+}
+
+.related-recipes.highlight > ul > li:not(:first-child) a {
+  display: contents;
+}
+
+.related-recipes.highlight > ul > li:not(:first-child) .image-wrapper img {
+  height: 100%;
+  min-height: 120px;
+}
+
+/* Hide description text on mobile for secondary cards, keep links */
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow) {
+  display: none;
+}
+
+.related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow):has(a) {
+  display: block;
+}
+
+@media (width >= 900px) {
+  /* Reset mobile horizontal layout at desktop */
+  .related-recipes.highlight > ul > li:not(:first-child) {
+    display: flex;
+    grid-template-columns: unset;
+  }
+
+  .related-recipes.highlight > ul > li:not(:first-child) a {
+    display: flex;
+  }
+
+  .related-recipes.highlight > ul > li:not(:first-child) .image-wrapper img {
+    height: 220px;
+    min-height: unset;
+  }
+
+  .related-recipes.highlight > ul > li:not(:first-child) .body > p:not(.eyebrow) {
+    display: block;
+  }
+}
+
 .related-recipes.highlight .image-wrapper {
   flex-shrink: 0;
   position: relative;
@@ -98,7 +144,9 @@
 
 .related-recipes.highlight .image-wrapper img {
   display: block;
+  width: 100%;
   height: 220px;
+  object-fit: cover;
   transition: transform 0.4s;
 }
 
@@ -163,12 +211,24 @@
 .related-recipes.highlight .body h2,
 .related-recipes.highlight .body h3 {
   margin: 0;
-  font-size: var(--font-size-500);
+  font-size: var(--font-size-300);
 }
 
 .related-recipes.highlight > ul > li:first-child .body h2,
 .related-recipes.highlight > ul > li:first-child .body h3 {
-  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-size: var(--font-size-500);
+}
+
+@media (width >= 900px) {
+  .related-recipes.highlight .body h2,
+  .related-recipes.highlight .body h3 {
+    font-size: var(--font-size-500);
+  }
+
+  .related-recipes.highlight > ul > li:first-child .body h2,
+  .related-recipes.highlight > ul > li:first-child .body h3 {
+    font-size: clamp(1.5rem, 2.5vw, 2rem);
+  }
 }
 
 .related-recipes.highlight .meta {


### PR DESCRIPTION
Create a mobile friendly version of the related-recipes highlight block. Image should be on the left and text should be on the right to reduce scrolling. 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/meet-ascent-x5
- After: https://related-recipes-mobile--vitamix--aemsites.aem.page/us/en_us/meet-ascent-x5
<img width="494" height="680" alt="Screenshot 2026-04-16 at 3 46 24 PM" src="https://github.com/user-attachments/assets/439bb3f5-d3c6-43dd-9839-ccb2f46a07b6" />

