### PR TITLE
fix: add disabled state for sync button

### DIFF
--- a/tools/sidekick/sync/sync.css
+++ b/tools/sidekick/sync/sync.css
@@ -135,6 +135,13 @@
   background-color: #1d6138;
 }
 
+.sync-submit-button:disabled {
+  background-color: #a0a0a0;
+  color: #e0e0e0;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .sync-status {
   margin-top: 1rem;
   min-height: 150px;


### PR DESCRIPTION
Add disabled state for sync button

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-sidekick-sync-button--vitamix--aemsites.aem.network/
