### PR TITLE
refactor: hero block

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -144,6 +144,10 @@ main > .hero-container.section {
   background-color: var(--image-color);
 }
 
+.hero.split .button-wrapper {
+  justify-content: unset;
+}
+
 @media (width >= 800px) {
   .hero.split {
     min-height: 575px;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -10,38 +10,47 @@ main > .hero-container.section {
 
 .hero,
 .hero > div {
-  display: flex;
   align-items: center;
+  display: flex;
   position: relative;
-  width: 100%;
   min-height: 575px;
+  width: 100%;
 }
 
 .hero {
   position: relative;
-  text-align: center;
-  overflow: hidden;
   z-index: 1;
+  overflow: hidden;
+  text-align: center;
 }
 
 .hero::after {
   content: '';
   position: absolute;
   inset: 0;
-  background-color: black;
-  opacity: 0.6;
   z-index: -1;
+  background-color: var(--image-color);
   pointer-events: none;
+}
+
+.hero.image-darkest::after,
+.hero.image-lightest::after {
+  opacity: 0.6;
+}
+
+.hero.image-dark::after,
+.hero.image-light::after {
+  opacity: 0.8;
 }
 
 .hero video,
 .hero img {
   position: absolute;
   inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
   z-index: -1;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
 }
 
 .hero .eyebrow {
@@ -49,8 +58,8 @@ main > .hero-container.section {
 }
 
 .hero .button-wrapper {
-  margin-top: var(--spacing-600);
   justify-content: center;
+  margin-top: var(--spacing-600);
 }
 
 .hero .disclaimer {
@@ -58,24 +67,6 @@ main > .hero-container.section {
   inset: 0;
   top: unset;
   padding: var(--horizontal-spacing);
-}
-
-.hero > div > div {
-  margin: 0 auto;
-  width: 100%;
-  max-width: 600px;
-  padding: var(--horizontal-spacing);
-  padding-top: 55px;
-  color: var(--color-gray-100);
-}
-
-.hero.image-light > div > div,
-.hero.image-lightest > div > div {
-  /* color: var(--color-charcoal); */
-}
-
-.hero > div > div h1 b {
-  font-weight: 900;
 }
 
 @media (width >= 800px) {
@@ -89,8 +80,129 @@ main > .hero-container.section {
   }
 }
 
+.hero > div > div {
+  margin: 0 auto;
+  max-width: 600px;
+  width: 100%;
+  padding: var(--horizontal-spacing);
+  padding-top: 55px;
+  color: var(--color-gray-100);
+}
+
+.hero.image-light > div > div,
+.hero.image-lightest > div > div {
+  color: var(--color-charcoal);
+}
+
 @media (width >= 1200px) {
   .hero > div > div {
     max-width: 800px;
+  }
+}
+
+.hero > div > div h1 b {
+  font-weight: 900;
+}
+
+/* stylelint-disable no-descending-specificity */
+
+/* split variant */
+
+.hero.split {
+  text-align: left;
+}
+
+.hero.split,
+.hero.split > div {
+  min-height: unset;
+}
+
+.hero.split::after {
+  content: none;
+}
+
+.hero.split > div {
+  flex-direction: column;
+  display: flex;
+}
+
+.hero.split .img-wrapper {
+  position: relative;
+  margin: 0;
+  max-width: unset;
+  min-height: 260px;
+  width: 100%;
+  padding: 0;
+}
+
+.hero.split .text-wrapper {
+  order: 1;
+  margin: 0;
+  max-width: unset;
+  width: 100%;
+  padding: var(--horizontal-spacing);
+  background-color: var(--image-color);
+}
+
+@media (width >= 800px) {
+  .hero.split {
+    min-height: 575px;
+  }
+
+  .hero.split::after {
+    content: '';
+  }
+
+  .hero.split > div {
+    flex-direction: row;
+    align-items: center;
+    min-height: 575px;
+  }
+
+  .hero.split .text-wrapper {
+    order: unset;
+    max-width: 600px;
+    width: 50%;
+    padding-top: 55px;
+    background-color: transparent;
+  }
+
+  .hero.split.left-text .text-wrapper {
+    margin-left: auto;
+    margin-right: 0;
+  }
+
+  .hero.split.right-text .text-wrapper {
+    margin-left: 0;
+    margin-right: auto;
+  }
+
+  .hero.split .img-wrapper {
+    position: absolute;
+    inset: 0;
+  }
+
+  .hero.split .img-wrapper img,
+  .hero.split .img-wrapper video {
+    position: absolute;
+    inset: 0;
+  }
+
+  .hero.split.left-text::after {
+    background: linear-gradient(to right, transparent, var(--image-color) 50%);
+  }
+
+  .hero.split.right-text::after {
+    background: linear-gradient(to left, transparent, var(--image-color) 50%);
+  }
+}
+
+@media (width >= 1200px) {
+  .hero.split.left-text::after {
+    background: linear-gradient(to right, transparent, var(--image-color) calc(100dvw - 600px));
+  }
+
+  .hero.split.right-text::after {
+    background: linear-gradient(to left, transparent, var(--image-color) calc(100dvw - 600px));
   }
 }

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -1,17 +1,46 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
 import { buildVideo, applyImgColor } from '../../scripts/scripts.js';
 
+/**
+ * Detects layout from column count.
+ * @param {Element} block
+ */
+function detectLayout(block) {
+  const row = block.firstElementChild;
+  if (!row) return;
+  const cells = [...row.children];
+
+  if (cells.length >= 2) {
+    block.classList.add('split');
+    cells.forEach((cell) => {
+      if (cell.querySelector('picture') || cell.querySelector('a[href*=".mp4"]')) {
+        cell.className = 'img-wrapper';
+      } else cell.classList.add('text-wrapper');
+    });
+    const imgIndex = cells.findIndex((c) => c.classList.contains('img-wrapper'));
+    block.classList.add(imgIndex === 0 ? 'left-text' : 'right-text');
+  }
+}
+
+/** @param {Element} block */
 export default function decorate(block) {
-  // set background
+  detectLayout(block);
   buildVideo(block);
+
+  const override = [...block.classList].filter((c) => c === 'dark' || c === 'light')[0];
+  if (override) {
+    block.style.setProperty('--image-color', override === 'dark' ? 'black' : 'white');
+    block.classList.add(`image-${override}est`);
+  }
+
   const img = block.querySelector('picture img');
   if (img) {
-    img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]));
-    if (img.complete) applyImgColor(block);
-    else if (img.tagName === 'IMG') {
-      img.addEventListener('load', () => {
-        applyImgColor(block);
-      });
+    const picture = createOptimizedPicture(img.src, img.alt, false, [{ width: '2000' }]);
+    img.closest('picture').replaceWith(picture);
+    if (!override) {
+      const newImg = picture.querySelector('img');
+      if (newImg.complete) applyImgColor(block);
+      else newImg.addEventListener('load', () => applyImgColor(block));
     }
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -561,6 +561,12 @@ function buildAutoBlocks(main) {
       });
     }
 
+    // migrate aligned banners to hero blocks
+    const alignedBanners = main.querySelectorAll('.banner.aligned');
+    alignedBanners.forEach((banner) => {
+      banner.className = 'hero';
+    });
+
     // setup pdp
     const metaSku = document.querySelector('meta[name="sku"]');
     const pdpBlock = document.querySelector('.pdp');
@@ -913,7 +919,7 @@ export function applyImgColor(block) {
       const thumbnailImg = new Image();
       thumbnailImg.src = thumbnail;
       thumbnailImg.onload = () => {
-        const color = colorThief.getColor(thumbnailImg, 5, 10);
+        const color = colorThief.getColor(thumbnailImg, 50);
         const [r, g, b] = color;
         const y = Math.floor(r * 0.2126 + g * 0.7152 + b * 0.0722);
         const brightness = {
@@ -924,7 +930,8 @@ export function applyImgColor(block) {
         };
         const brightnessKey = Object.keys(brightness).find((key) => y <= brightness[key]);
         block.classList.add(`image-${brightnessKey}`);
-        block.style.setProperty('--image-color', `#${r.toString(16)}${g.toString(16)}${b.toString(16)}`);
+        const toHex = (n) => n.toString(16).padStart(2, '0');
+        block.style.setProperty('--image-color', `#${toHex(r)}${toHex(g)}${toHex(b)}`);
       };
     });
   }


### PR DESCRIPTION
Replaces **banner (aligned)** block with **hero** at auto-block time. Extends **hero** with two-col split layout and gradient overlay driven by existing `applyImgColor` functionality.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/hero-variants
- After: https://hero-refactor--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/hero-variants
- Before: https://main--vitamix--aemsites.aem.page/vr/en_us/commercial
- After: https://hero-refactor--vitamix--aemsites.aem.page/vr/en_us/commercial