### PR TITLE
feat: carousel video variant

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -802,9 +802,9 @@
 /* Track */
 .carousel.videos.block ul {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-100);
   list-style: none;
-  margin: 0 68px;
+  margin: 0 var(--spacing-800);
   padding: 0;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
@@ -822,15 +822,21 @@
 }
 
 @media (width >= 600px) {
-  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 0.5 * 16px) / 1.5); }
+  .carousel.videos.block ul > li {
+    flex: 0 0 calc((100% - 0.5 * var(--spacing-100)) / 1.5);
+  }
 }
 
 @media (width >= 900px) {
-  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 1.5 * 16px) / 2.5); }
+  .carousel.videos.block ul > li {
+    flex: 0 0 calc((100% - 1.5 * var(--spacing-100)) / 2.5);
+  }
 }
 
 @media (width >= 1200px) {
-  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 2.5 * 16px) / 3.5); }
+  .carousel.videos.block ul > li {
+    flex: 0 0 calc((100% - 2.5 * var(--spacing-100)) / 3.5);
+  }
 }
 
 /* Media */
@@ -866,8 +872,8 @@
 /* Play button */
 .carousel.videos.block .videos-play-btn {
   position: absolute;
-  bottom: 16px;
-  right: 16px;
+  bottom: var(--spacing-100);
+  right: var(--spacing-100);
   z-index: 1;
   display: flex;
   align-items: center;
@@ -878,7 +884,7 @@
   background: rgb(255 255 255 / 20%);
   backdrop-filter: blur(4px);
   cursor: pointer;
-  color: white;
+  color: var(--color-white);
   font-size: var(--heading-size-l);
   line-height: 0;
   transition: background 0.2s, transform 0.2s;
@@ -905,18 +911,18 @@
   left: 0;
   right: 0;
   z-index: 2;
-  padding: 12px 16px 14px;
-  color: #fff;
+  padding: var(--spacing-80) var(--spacing-100);
+  padding-right: calc((var(--spacing-100) * 2) + 44px);
+  color: var(--color-white);
   pointer-events: none;
 }
 
 .carousel.videos.block .videos-slide-body .slide-title {
-  margin: 0 0 4px;
+  margin: 0 0 var(--spacing-40);
   font-family: var(--body-font-family);
   font-size: var(--body-size-m);
   font-weight: 600;
   line-height: 1.3;
-  padding-right: 48px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -926,9 +932,8 @@
   display: block;
   font-family: var(--body-font-family);
   font-size: var(--body-size-s);
-  color: rgb(255 255 255 / 75%);
+  color: var(--color-gray-500);
   text-decoration: none;
-  padding-right: 48px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -936,7 +941,7 @@
 }
 
 .carousel.videos.block .videos-slide-body .slide-link:hover {
-  color: #fff;
+  color: var(--color-white);
   text-decoration: underline;
 }
 
@@ -951,7 +956,7 @@
   bottom: unset;
   left: unset;
   right: unset;
-  margin-top: 16px;
+  margin-top: var(--spacing-100);
 }
 
 .carousel.videos.block nav button.nav-arrow:disabled {
@@ -963,9 +968,9 @@
 .carousel.videos.block nav [role='radiogroup'] {
   display: flex;
   justify-content: center;
-  gap: 6px;
+  gap: var(--spacing-60);
   width: 100%;
-  margin-top: 16px;
+  margin-top: var(--spacing-100);
   order: 1;
 }
 
@@ -975,7 +980,7 @@
   border-radius: 50%;
   border: none;
   padding: 0;
-  background: #ccc;
+  background: var(--color-gray-500);
   cursor: pointer;
   transition: background 0.2s, width 0.25s;
 }
@@ -983,5 +988,5 @@
 .carousel.videos.block nav [role='radiogroup'] button[aria-checked='true'] {
   background: var(--color-charcoal);
   width: 22px;
-  border-radius: 4px;
+  border-radius: var(--rounding-m);
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -801,15 +801,21 @@
 /* Track */
 .carousel.videos.block ul {
   gap: var(--spacing-100);
-  margin: 0 var(--spacing-800);
+  margin: 0;
   overflow-x: auto;
   scrollbar-width: none;
 }
 
 .carousel.videos.block ul > li {
-  flex: 0 0 85%;
+  flex: 0 0 100%;
   cursor: pointer;
   overflow: hidden;
+}
+
+@media (width >= 600px) {
+  .carousel.videos.block ul {
+    margin: 0 var(--spacing-800);
+  }
 }
 
 @media (width >= 600px) {
@@ -939,8 +945,18 @@
   height: auto;
 }
 
+.carousel.videos.block nav button.nav-arrow {
+  display: none;
+}
+
 .carousel.videos.block nav button.nav-arrow:disabled {
   cursor: not-allowed;
+}
+
+@media (width >= 600px) {
+  .carousel.videos.block nav button.nav-arrow {
+    display: flex;
+  }
 }
 
 /* Dots */

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -868,29 +868,25 @@
   position: absolute;
   bottom: 16px;
   right: 16px;
-  z-index: 3;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  border: none;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   background: rgb(255 255 255 / 20%);
   backdrop-filter: blur(4px);
   cursor: pointer;
+  color: white;
+  font-size: var(--heading-size-l);
+  line-height: 0;
   transition: background 0.2s, transform 0.2s;
 }
 
 .carousel.videos.block .videos-play-btn:hover {
   background: rgb(255 255 255 / 35%);
   transform: scale(1.1);
-}
-
-.carousel.videos.block .videos-play-btn svg {
-  width: 18px;
-  height: 18px;
-  fill: #fff;
 }
 
 .carousel.videos.block .videos-play-btn .icon-pause,

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -792,9 +792,7 @@
   }
 }
 
-/* ============================================================
-   Carousel Videos variant
-   ============================================================ */
+/* Carousel Videos variant */
 
 .carousel.videos.block {
   overflow: visible;
@@ -861,7 +859,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, transparent 40%, var(--color-charcoal, #333f48) 100%);
+  background: linear-gradient(to bottom, transparent 40%, var(--color-charcoal) 100%);
   pointer-events: none;
 }
 
@@ -888,6 +886,7 @@
   background: rgb(255 255 255 / 35%);
   transform: scale(1.1);
 }
+
 .carousel.videos.block .videos-play-btn svg {
   width: 18px;
   height: 18px;
@@ -980,7 +979,7 @@
 }
 
 .carousel.videos.block nav [role='radiogroup'] button[aria-checked='true'] {
-  background: var(--color-charcoal, #333f48);
+  background: var(--color-charcoal);
   width: 22px;
   border-radius: 4px;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -794,6 +794,18 @@
 
 /* Videos variant */
 
+.carousel-wrapper:has(.carousel.videos.block) {
+  margin-left: calc(-1 * var(--horizontal-spacing));
+  margin-right: calc(-1 * var(--horizontal-spacing));
+}
+
+@media (width >= 600px) {
+  .carousel-wrapper:has(.carousel.videos.block) {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
 .carousel.videos.block {
   overflow: visible;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -807,7 +807,7 @@
 }
 
 .carousel.videos.block ul > li {
-  flex: 0 0 100%;
+  flex: 0 0 92%;
   cursor: pointer;
   overflow: hidden;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -792,33 +792,24 @@
   }
 }
 
-/* Carousel Videos variant */
+/* Videos variant */
 
 .carousel.videos.block {
   overflow: visible;
-  position: relative;
 }
 
 /* Track */
 .carousel.videos.block ul {
-  display: flex;
   gap: var(--spacing-100);
-  list-style: none;
   margin: 0 var(--spacing-800);
-  padding: 0;
   overflow-x: auto;
-  scroll-snap-type: x mandatory;
   scrollbar-width: none;
 }
 
-.carousel.videos.block ul::-webkit-scrollbar { display: none; }
-
 .carousel.videos.block ul > li {
   flex: 0 0 85%;
-  scroll-snap-align: start;
-  position: relative;
-  overflow: hidden;
   cursor: pointer;
+  overflow: hidden;
 }
 
 @media (width >= 600px) {
@@ -842,16 +833,16 @@
 /* Media */
 .carousel.videos.block .slide-media {
   position: relative;
-  width: 100%;
   aspect-ratio: 9 / 16;
+  width: 100%;
   overflow: hidden;
 }
 
 .carousel.videos.block .slide-media video,
 .carousel.videos.block .slide-media img {
   display: block;
-  width: 100%;
   height: 100%;
+  width: 100%;
   object-fit: cover;
   transition: transform 0.4s ease;
 }
@@ -865,28 +856,28 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, transparent 40%, var(--color-charcoal) 100%);
+  background: linear-gradient(to bottom, transparent 40%, var(--color-charcoal));
   pointer-events: none;
 }
 
 /* Play button */
 .carousel.videos.block .slide-media button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   bottom: var(--spacing-100);
   right: var(--spacing-100);
   z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
   height: 44px;
+  width: 44px;
   border-radius: 50%;
   background: rgb(255 255 255 / 20%);
-  backdrop-filter: blur(4px);
-  cursor: pointer;
   color: var(--color-white);
+  backdrop-filter: blur(4px);
   font-size: var(--heading-size-l);
   line-height: 0;
+  cursor: pointer;
   transition: background 0.2s, transform 0.2s;
 }
 
@@ -918,16 +909,16 @@
 
 .carousel.videos.block .slide-body p {
   margin: 0 0 0.2em;
-  font-weight: 600;
-  white-space: nowrap;
   overflow: hidden;
+  font-weight: 600;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .carousel.videos.block .slide-body a {
+  color: var(--color-gray-500);
   font-size: var(--body-size-s);
   font-weight: 400;
-  color: var(--color-gray-500);
   text-decoration: none;
   pointer-events: all;
 }
@@ -939,46 +930,40 @@
 
 /* Nav */
 .carousel.videos.block nav {
-  position: static;
-  display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  height: auto;
-  top: unset;
-  bottom: unset;
-  left: unset;
-  right: unset;
+  display: flex;
+  position: static;
+  inset: unset;
   margin-top: var(--spacing-100);
+  height: auto;
 }
 
 .carousel.videos.block nav button.nav-arrow:disabled {
-  opacity: 0.35;
   cursor: not-allowed;
 }
 
 /* Dots */
 .carousel.videos.block nav [role='radiogroup'] {
   display: flex;
+  order: 1;
   justify-content: center;
   gap: var(--spacing-60);
   width: 100%;
   margin-top: var(--spacing-100);
-  order: 1;
 }
 
 .carousel.videos.block nav [role='radiogroup'] button {
-  width: 8px;
   height: 8px;
+  width: 8px;
   border-radius: 50%;
-  border: none;
-  padding: 0;
   background: var(--color-gray-500);
   cursor: pointer;
-  transition: background 0.2s, width 0.25s;
+  transition: background 0.2s, border-radius 0.2s, width 0.2s;
 }
 
 .carousel.videos.block nav [role='radiogroup'] button[aria-checked='true'] {
-  background: var(--color-charcoal);
   width: 22px;
   border-radius: var(--rounding-m);
+  background: var(--color-charcoal);
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -814,23 +814,23 @@
 .carousel.videos.block ul::-webkit-scrollbar { display: none; }
 
 .carousel.videos.block ul > li {
-  flex: 0 0 calc((100% - 2.5 * 16px) / 3.5);
+  flex: 0 0 85%;
   scroll-snap-align: start;
   position: relative;
   overflow: hidden;
   cursor: pointer;
 }
 
-@media (width < 1000px) {
-  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 1.5 * 16px) / 2.5); }
-}
-
-@media (width < 700px) {
+@media (width >= 600px) {
   .carousel.videos.block ul > li { flex: 0 0 calc((100% - 0.5 * 16px) / 1.5); }
 }
 
-@media (width < 480px) {
-  .carousel.videos.block ul > li { flex: 0 0 85%; }
+@media (width >= 900px) {
+  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 1.5 * 16px) / 2.5); }
+}
+
+@media (width >= 1200px) {
+  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 2.5 * 16px) / 3.5); }
 }
 
 /* Media */

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -910,37 +910,29 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 2;
   padding: var(--spacing-80) var(--spacing-100);
   padding-right: calc((var(--spacing-100) * 2) + 44px);
   color: var(--color-white);
   pointer-events: none;
 }
 
-.carousel.videos.block .videos-slide-body .slide-title {
-  margin: 0 0 var(--spacing-40);
-  font-family: var(--body-font-family);
-  font-size: var(--body-size-m);
+.carousel.videos.block .videos-slide-body p {
+  margin: 0 0 0.2em;
   font-weight: 600;
-  line-height: 1.3;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.carousel.videos.block .videos-slide-body .slide-link {
-  display: block;
-  font-family: var(--body-font-family);
+.carousel.videos.block .videos-slide-body a {
   font-size: var(--body-size-s);
+  font-weight: 400;
   color: var(--color-gray-500);
   text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   pointer-events: all;
 }
 
-.carousel.videos.block .videos-slide-body .slide-link:hover {
+.carousel.videos.block .videos-slide-body a:hover {
   color: var(--color-white);
   text-decoration: underline;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -840,15 +840,15 @@
 }
 
 /* Media */
-.carousel.videos.block .videos-slide-media {
+.carousel.videos.block .slide-media {
   position: relative;
   width: 100%;
   aspect-ratio: 9 / 16;
   overflow: hidden;
 }
 
-.carousel.videos.block .videos-slide-media video,
-.carousel.videos.block .videos-slide-media img {
+.carousel.videos.block .slide-media video,
+.carousel.videos.block .slide-media img {
   display: block;
   width: 100%;
   height: 100%;
@@ -856,12 +856,12 @@
   transition: transform 0.4s ease;
 }
 
-.carousel.videos.block ul > li:hover .videos-slide-media video,
-.carousel.videos.block ul > li:hover .videos-slide-media img {
+.carousel.videos.block ul > li:hover .slide-media video,
+.carousel.videos.block ul > li:hover .slide-media img {
   transform: scale(1.03);
 }
 
-.carousel.videos.block .videos-slide-media::after {
+.carousel.videos.block .slide-media::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -870,7 +870,7 @@
 }
 
 /* Play button */
-.carousel.videos.block .videos-play-btn {
+.carousel.videos.block .slide-media button {
   position: absolute;
   bottom: var(--spacing-100);
   right: var(--spacing-100);
@@ -890,22 +890,22 @@
   transition: background 0.2s, transform 0.2s;
 }
 
-.carousel.videos.block .videos-play-btn:hover {
+.carousel.videos.block .slide-media button:hover {
   background: rgb(255 255 255 / 35%);
   transform: scale(1.1);
 }
 
-.carousel.videos.block .videos-play-btn .icon-pause,
-.carousel.videos.block .videos-play-btn[aria-pressed="true"] .icon-play {
+.carousel.videos.block .slide-media button .icon-pause,
+.carousel.videos.block .slide-media button[aria-pressed="true"] .icon-play {
   display: none;
 }
 
-.carousel.videos.block .videos-play-btn[aria-pressed="true"] .icon-pause {
+.carousel.videos.block .slide-media button[aria-pressed="true"] .icon-pause {
   display: block;
 }
 
 /* Text overlay */
-.carousel.videos.block .videos-slide-body {
+.carousel.videos.block .slide-body {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -916,7 +916,7 @@
   pointer-events: none;
 }
 
-.carousel.videos.block .videos-slide-body p {
+.carousel.videos.block .slide-body p {
   margin: 0 0 0.2em;
   font-weight: 600;
   white-space: nowrap;
@@ -924,7 +924,7 @@
   text-overflow: ellipsis;
 }
 
-.carousel.videos.block .videos-slide-body a {
+.carousel.videos.block .slide-body a {
   font-size: var(--body-size-s);
   font-weight: 400;
   color: var(--color-gray-500);
@@ -932,7 +932,7 @@
   pointer-events: all;
 }
 
-.carousel.videos.block .videos-slide-body a:hover {
+.carousel.videos.block .slide-body a:hover {
   color: var(--color-white);
   text-decoration: underline;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -300,7 +300,7 @@
 .carousel-wrapper.testimonial-wrapper .carousel-static {
   height: 250px;
 }
-  
+
 /* stylelint-disable-next-line no-descending-specificity */
 .carousel-wrapper.testimonial-wrapper .carousel-static img {
   width: 100%;
@@ -790,4 +790,197 @@
   .carousel.buy-now li:hover .slide-image img {
     transform: scale(1.05);
   }
+}
+
+/* ============================================================
+   Carousel Videos variant
+   ============================================================ */
+
+.carousel.videos.block {
+  overflow: visible;
+  position: relative;
+}
+
+/* Track */
+.carousel.videos.block ul {
+  display: flex;
+  gap: 16px;
+  list-style: none;
+  margin: 0 68px;
+  padding: 0;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+
+.carousel.videos.block ul::-webkit-scrollbar { display: none; }
+
+.carousel.videos.block ul > li {
+  flex: 0 0 calc((100% - 2.5 * 16px) / 3.5);
+  scroll-snap-align: start;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+@media (width < 1000px) {
+  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 1.5 * 16px) / 2.5); }
+}
+
+@media (width < 700px) {
+  .carousel.videos.block ul > li { flex: 0 0 calc((100% - 0.5 * 16px) / 1.5); }
+}
+
+@media (width < 480px) {
+  .carousel.videos.block ul > li { flex: 0 0 85%; }
+}
+
+/* Media */
+.carousel.videos.block .videos-slide-media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+}
+
+.carousel.videos.block .videos-slide-media video,
+.carousel.videos.block .videos-slide-media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.carousel.videos.block ul > li:hover .videos-slide-media video,
+.carousel.videos.block ul > li:hover .videos-slide-media img {
+  transform: scale(1.03);
+}
+
+.carousel.videos.block .videos-slide-media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent 40%, var(--color-charcoal, #333f48) 100%);
+  pointer-events: none;
+}
+
+/* Play button */
+.carousel.videos.block .videos-play-btn {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: rgb(255 255 255 / 20%);
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.carousel.videos.block .videos-play-btn:hover {
+  background: rgb(255 255 255 / 35%);
+  transform: scale(1.1);
+}
+.carousel.videos.block .videos-play-btn svg {
+  width: 18px;
+  height: 18px;
+  fill: #fff;
+}
+.carousel.videos.block .videos-play-btn .icon-pause { display: none; }
+.carousel.videos.block .videos-play-btn.is-playing .icon-play { display: none; }
+.carousel.videos.block .videos-play-btn.is-playing .icon-pause { display: block; }
+
+/* Text overlay */
+.carousel.videos.block .videos-slide-body {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  padding: 12px 16px 14px;
+  color: #fff;
+  pointer-events: none;
+}
+
+.carousel.videos.block .videos-slide-body .slide-title {
+  margin: 0 0 4px;
+  font-family: var(--body-font-family);
+  font-size: var(--body-size-m);
+  font-weight: 600;
+  line-height: 1.3;
+  padding-right: 48px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.carousel.videos.block .videos-slide-body .slide-link {
+  display: block;
+  font-family: var(--body-font-family);
+  font-size: var(--body-size-s);
+  color: rgb(255 255 255 / 75%);
+  text-decoration: none;
+  padding-right: 48px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: all;
+}
+
+.carousel.videos.block .videos-slide-body .slide-link:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
+/* Nav */
+.carousel.videos.block nav {
+  position: static;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  height: auto;
+  top: unset;
+  bottom: unset;
+  left: unset;
+  right: unset;
+  margin-top: 16px;
+}
+
+.carousel.videos.block nav button.nav-arrow:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Dots */
+.carousel.videos.block nav [role='radiogroup'] {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 16px;
+  order: 1;
+}
+
+.carousel.videos.block nav [role='radiogroup'] button {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  background: #ccc;
+  cursor: pointer;
+  transition: background 0.2s, width 0.25s;
+}
+
+.carousel.videos.block nav [role='radiogroup'] button[aria-checked='true'] {
+  background: var(--color-charcoal, #333f48);
+  width: 22px;
+  border-radius: 4px;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -795,13 +795,11 @@
 /* Videos variant */
 
 .carousel-wrapper:has(.carousel.videos.block) {
-  margin-left: calc(-1 * var(--horizontal-spacing));
   margin-right: calc(-1 * var(--horizontal-spacing));
 }
 
 @media (width >= 600px) {
   .carousel-wrapper:has(.carousel.videos.block) {
-    margin-left: 0;
     margin-right: 0;
   }
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -802,12 +802,13 @@
 .carousel.videos.block ul {
   gap: var(--spacing-100);
   margin: 0;
+  padding: 0;
   overflow-x: auto;
   scrollbar-width: none;
 }
 
 .carousel.videos.block ul > li {
-  flex: 0 0 92%;
+  flex: 0 0 88%;
   cursor: pointer;
   overflow: hidden;
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -892,9 +892,15 @@
   height: 18px;
   fill: #fff;
 }
-.carousel.videos.block .videos-play-btn .icon-pause { display: none; }
-.carousel.videos.block .videos-play-btn.is-playing .icon-play { display: none; }
-.carousel.videos.block .videos-play-btn.is-playing .icon-pause { display: block; }
+
+.carousel.videos.block .videos-play-btn .icon-pause,
+.carousel.videos.block .videos-play-btn[aria-pressed="true"] .icon-play {
+  display: none;
+}
+
+.carousel.videos.block .videos-play-btn[aria-pressed="true"] .icon-pause {
+  display: block;
+}
 
 /* Text overlay */
 .carousel.videos.block .videos-slide-body {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -199,9 +199,9 @@ function decorateVideos(block) {
     };
 
     dots.forEach((d, i) => {
-      d.onclick = () => {
+      d.addEventListener('click', () => {
         ul.scrollTo({ left: Math.round(i * spv) * getSlideW(), behavior: 'smooth' });
-      };
+      });
     });
 
     ul.addEventListener('scroll', sync);

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -1,5 +1,5 @@
 import { toClassName } from '../../scripts/aem.js';
-import { buildCarousel, buildVideo } from '../../scripts/scripts.js';
+import { buildCarousel, buildIcon, buildVideo } from '../../scripts/scripts.js';
 
 /**
  * Calculates max height needed to display any slide in expanded state.
@@ -126,8 +126,7 @@ function decorateVideos(block) {
     playBtn.className = 'videos-play-btn';
     playBtn.setAttribute('aria-label', 'Play');
     playBtn.setAttribute('aria-pressed', false);
-    playBtn.innerHTML = '<svg class="icon-play" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>'
-      + '<svg class="icon-pause" viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>';
+    playBtn.append(buildIcon('play'), buildIcon('pause'));
     mediaWrap.append(playBtn);
     if (vid) {
       wirePlayBtn(playBtn, vid, block);

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -201,6 +201,8 @@ async function decorateVideos(block) {
     ul.addEventListener('scroll', sync);
     window.addEventListener('resize', sync);
     sync();
+    // Re-sync after layout has fully settled to correct initial arrow disabled state
+    setTimeout(sync, 100);
   });
 }
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -125,7 +125,7 @@ async function decorateVideos(block) {
     // Media
     const mediaWrap = document.createElement('div');
     mediaWrap.className = 'slide-media';
-    if (mediaCell) buildVideo(mediaCell);
+    if (mediaCell) buildVideo(mediaCell, false);
     const vid = mediaCell && mediaCell.querySelector('video');
     const img = mediaCell && mediaCell.querySelector('img, picture');
     if (vid) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -138,35 +138,15 @@ function decorateVideos(block) {
       });
     }
 
-    // Text overlay
-    const slideBody = document.createElement('div');
-    slideBody.className = 'videos-slide-body';
-    let titleText = '';
-    let linkHref = '';
-    let linkText = '';
-    [...(bodyCell?.children || [])].forEach((child) => {
-      const a = child.querySelector('a');
-      if (a) {
-        linkHref = a.href;
-        linkText = a.textContent.trim() || a.href;
-      } else if (!titleText) {
-        titleText = child.textContent.trim();
-      }
-    });
-    if (!titleText && bodyCell) titleText = bodyCell.textContent.trim();
-    const titleEl = document.createElement('p');
-    titleEl.className = 'slide-title';
-    titleEl.textContent = titleText || 'Title goes here...';
-    slideBody.append(titleEl);
-    if (linkHref || linkText) {
-      const linkEl = document.createElement('a');
-      linkEl.className = 'slide-link';
-      linkEl.href = linkHref || '#';
-      linkEl.textContent = linkText || linkHref;
-      slideBody.append(linkEl);
+    if (bodyCell) {
+      bodyCell.className = 'videos-slide-body';
+      bodyCell.querySelectorAll('.button').forEach((b) => {
+        b.removeAttribute('class');
+        b.parentElement.classList.remove('button-wrapper');
+      });
     }
 
-    li.append(mediaWrap, slideBody);
+    li.append(mediaWrap, ...(bodyCell ? [bodyCell] : []));
     track.append(li);
   });
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -68,11 +68,6 @@ function autoRotate(carousel, interval = 6000) {
 
 // ── Videos variant ──────────────────────────────────────────────────────
 
-/**
- * Wire play/pause button to a video element.
- * @param {HTMLButtonElement} btn
- * @param {HTMLVideoElement} vid
- */
 function wirePlayBtn(btn, vid) {
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -99,10 +94,6 @@ function wirePlayBtn(btn, vid) {
   }));
 }
 
-/**
- * Decorate the Carousel Videos variant.
- * @param {HTMLElement} block
- */
 function decorateVideos(block) {
   const rows = [...block.children];
   block.innerHTML = '';
@@ -216,8 +207,6 @@ function decorateVideos(block) {
     sync();
   });
 }
-
-// ── Main decorate export ────────────────────────────────────────────────────
 
 export default function decorate(block) {
   const variants = [...block.classList].filter((c) => c !== 'block' && c !== 'carousel');

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -68,10 +68,10 @@ function autoRotate(carousel, interval = 6000) {
 
 // ── Videos variant ──────────────────────────────────────────────────────
 
-function wirePlayBtn(btn, vid) {
+function wirePlayBtn(btn, vid, block) {
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
-    document.querySelectorAll('.carousel.videos video').forEach((v) => {
+    block.querySelectorAll('video').forEach((v) => {
       if (v !== vid) {
         v.pause();
         const b = v.closest('li')?.querySelector('.videos-play-btn');
@@ -129,11 +129,11 @@ function decorateVideos(block) {
       + '<svg class="icon-pause" viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>';
     mediaWrap.append(playBtn);
     if (vid) {
-      wirePlayBtn(playBtn, vid);
+      wirePlayBtn(playBtn, vid, block);
     } else {
       requestAnimationFrame(() => {
         const lazyVid = li.querySelector('video');
-        if (lazyVid) wirePlayBtn(playBtn, lazyVid);
+        if (lazyVid) wirePlayBtn(playBtn, lazyVid, block);
         else playBtn.style.display = 'none';
       });
     }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -75,21 +75,21 @@ function wirePlayBtn(btn, vid, block) {
       if (v !== vid) {
         v.pause();
         const b = v.closest('li')?.querySelector('.videos-play-btn');
-        if (b) b.classList.remove('is-playing');
+        if (b) b.setAttribute('aria-pressed', false);
       }
     });
     if (vid.paused) {
       vid.play();
-      btn.classList.add('is-playing');
+      btn.setAttribute('aria-pressed', true);
       btn.setAttribute('aria-label', 'Pause');
     } else {
       vid.pause();
-      btn.classList.remove('is-playing');
+      btn.setAttribute('aria-pressed', false);
       btn.setAttribute('aria-label', 'Play');
     }
   });
   ['ended', 'pause'].forEach((ev) => vid.addEventListener(ev, () => {
-    btn.classList.remove('is-playing');
+    btn.setAttribute('aria-pressed', false);
     btn.setAttribute('aria-label', 'Play');
   }));
 }
@@ -125,6 +125,7 @@ function decorateVideos(block) {
     playBtn.type = 'button';
     playBtn.className = 'videos-play-btn';
     playBtn.setAttribute('aria-label', 'Play');
+    playBtn.setAttribute('aria-pressed', false);
     playBtn.innerHTML = '<svg class="icon-play" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>'
       + '<svg class="icon-pause" viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>';
     mediaWrap.append(playBtn);

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -138,21 +138,14 @@ async function decorateVideos(block) {
       mediaWrap.append(img);
     }
 
-    // Play button
-    const playBtn = document.createElement('button');
-    playBtn.type = 'button';
-    playBtn.setAttribute('aria-label', labels.play);
-    playBtn.setAttribute('aria-pressed', false);
-    playBtn.append(buildIcon('play'), buildIcon('pause'));
-    mediaWrap.append(playBtn);
     if (vid) {
+      const playBtn = document.createElement('button');
+      playBtn.type = 'button';
+      playBtn.setAttribute('aria-label', labels.play);
+      playBtn.setAttribute('aria-pressed', false);
+      playBtn.append(buildIcon('play'), buildIcon('pause'));
+      mediaWrap.append(playBtn);
       wirePlayBtn(playBtn, vid, block, labels);
-    } else {
-      requestAnimationFrame(() => {
-        const lazyVid = li.querySelector('video');
-        if (lazyVid) wirePlayBtn(playBtn, lazyVid, block, labels);
-        else playBtn.style.display = 'none';
-      });
     }
 
     if (bodyCell) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -66,8 +66,12 @@ function autoRotate(carousel, interval = 6000) {
   }, interval);
 }
 
-// ── Videos variant ──────────────────────────────────────────────────────
-
+/**
+ * Wires play/pause toggle behaviour to a button for a given video.
+ * @param {HTMLButtonElement} btn - Play/pause button element
+ * @param {HTMLVideoElement} vid - Video element controlled by the button
+ * @param {HTMLElement} block - Carousel block, used to scope sibling video queries
+ */
 function wirePlayBtn(btn, vid, block) {
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -94,6 +98,10 @@ function wirePlayBtn(btn, vid, block) {
   }));
 }
 
+/**
+ * Decorates the videos variant of the carousel block.
+ * @param {HTMLElement} block - Carousel block element
+ */
 function decorateVideos(block) {
   const rows = [...block.children];
   block.innerHTML = '';

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -134,11 +134,7 @@ async function decorateVideos(block) {
       vid.setAttribute('preload', 'metadata');
       vid.loop = false;
       mediaWrap.append(vid);
-    } else if (img) {
-      mediaWrap.append(img);
-    }
-
-    if (vid) {
+      // Play button
       const playBtn = document.createElement('button');
       playBtn.type = 'button';
       playBtn.setAttribute('aria-label', labels.play);
@@ -146,6 +142,8 @@ async function decorateVideos(block) {
       playBtn.append(buildIcon('play'), buildIcon('pause'));
       mediaWrap.append(playBtn);
       wirePlayBtn(playBtn, vid, block, labels);
+    } else if (img) {
+      mediaWrap.append(img);
     }
 
     if (bodyCell) {

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -1,5 +1,5 @@
-import { toClassName } from '../../scripts/aem.js';
-import { buildCarousel, buildIcon, buildVideo } from '../../scripts/scripts.js';
+import { fetchPlaceholders, toClassName } from '../../scripts/aem.js';
+import { buildCarousel, buildIcon, buildVideo, getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 /**
  * Calculates max height needed to display any slide in expanded state.
@@ -71,8 +71,9 @@ function autoRotate(carousel, interval = 6000) {
  * @param {HTMLButtonElement} btn - Play/pause button element
  * @param {HTMLVideoElement} vid - Video element controlled by the button
  * @param {HTMLElement} block - Carousel block, used to scope sibling video queries
+ * @param {{ play: string, pause: string }} labels - Localized button labels
  */
-function wirePlayBtn(btn, vid, block) {
+function wirePlayBtn(btn, vid, block, labels) {
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
     block.querySelectorAll('video').forEach((v) => {
@@ -85,16 +86,16 @@ function wirePlayBtn(btn, vid, block) {
     if (vid.paused) {
       vid.play();
       btn.setAttribute('aria-pressed', true);
-      btn.setAttribute('aria-label', 'Pause');
+      btn.setAttribute('aria-label', labels.pause);
     } else {
       vid.pause();
       btn.setAttribute('aria-pressed', false);
-      btn.setAttribute('aria-label', 'Play');
+      btn.setAttribute('aria-label', labels.play);
     }
   });
   ['ended', 'pause'].forEach((ev) => vid.addEventListener(ev, () => {
     btn.setAttribute('aria-pressed', false);
-    btn.setAttribute('aria-label', 'Play');
+    btn.setAttribute('aria-label', labels.play);
   }));
 }
 
@@ -102,7 +103,14 @@ function wirePlayBtn(btn, vid, block) {
  * Decorates the videos variant of the carousel block.
  * @param {HTMLElement} block - Carousel block element
  */
-function decorateVideos(block) {
+async function decorateVideos(block) {
+  const { locale, language } = getLocaleAndLanguage();
+  const ph = await fetchPlaceholders(`/${locale}/${language}`);
+  const labels = {
+    play: ph.play || 'Play',
+    pause: ph.pause || 'Pause',
+  };
+
   const rows = [...block.children];
   block.innerHTML = '';
   const track = document.createElement('ul');
@@ -130,16 +138,16 @@ function decorateVideos(block) {
     // Play button
     const playBtn = document.createElement('button');
     playBtn.type = 'button';
-    playBtn.setAttribute('aria-label', 'Play');
+    playBtn.setAttribute('aria-label', labels.play);
     playBtn.setAttribute('aria-pressed', false);
     playBtn.append(buildIcon('play'), buildIcon('pause'));
     mediaWrap.append(playBtn);
     if (vid) {
-      wirePlayBtn(playBtn, vid, block);
+      wirePlayBtn(playBtn, vid, block, labels);
     } else {
       requestAnimationFrame(() => {
         const lazyVid = li.querySelector('video');
-        if (lazyVid) wirePlayBtn(playBtn, lazyVid, block);
+        if (lazyVid) wirePlayBtn(playBtn, lazyVid, block, labels);
         else playBtn.style.display = 'none';
       });
     }
@@ -194,12 +202,12 @@ function decorateVideos(block) {
   });
 }
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const variants = [...block.classList].filter((c) => c !== 'block' && c !== 'carousel');
 
   // Handle videos variant separately
   if (variants.includes('videos')) {
-    decorateVideos(block);
+    await decorateVideos(block);
     return;
   }
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -74,7 +74,7 @@ function wirePlayBtn(btn, vid, block) {
     block.querySelectorAll('video').forEach((v) => {
       if (v !== vid) {
         v.pause();
-        const b = v.closest('li')?.querySelector('.videos-play-btn');
+        const b = v.closest('li')?.querySelector('button');
         if (b) b.setAttribute('aria-pressed', false);
       }
     });
@@ -102,11 +102,10 @@ function decorateVideos(block) {
   rows.forEach((row) => {
     const [mediaCell, bodyCell] = [...row.children];
     const li = document.createElement('li');
-    li.className = 'videos-carousel-slide';
 
     // Media
     const mediaWrap = document.createElement('div');
-    mediaWrap.className = 'videos-slide-media';
+    mediaWrap.className = 'slide-media';
     if (mediaCell) buildVideo(mediaCell);
     const vid = mediaCell?.querySelector('video');
     const img = mediaCell?.querySelector('img, picture');
@@ -123,7 +122,6 @@ function decorateVideos(block) {
     // Play button
     const playBtn = document.createElement('button');
     playBtn.type = 'button';
-    playBtn.className = 'videos-play-btn';
     playBtn.setAttribute('aria-label', 'Play');
     playBtn.setAttribute('aria-pressed', false);
     playBtn.append(buildIcon('play'), buildIcon('pause'));
@@ -139,7 +137,7 @@ function decorateVideos(block) {
     }
 
     if (bodyCell) {
-      bodyCell.className = 'videos-slide-body';
+      bodyCell.className = 'slide-body';
       bodyCell.querySelectorAll('.button').forEach((b) => {
         b.removeAttribute('class');
         b.parentElement.classList.remove('button-wrapper');

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -1,5 +1,7 @@
 import { fetchPlaceholders, toClassName } from '../../scripts/aem.js';
-import { buildCarousel, buildIcon, buildVideo, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import {
+  buildCarousel, buildIcon, buildVideo, getLocaleAndLanguage,
+} from '../../scripts/scripts.js';
 
 /**
  * Calculates max height needed to display any slide in expanded state.
@@ -79,7 +81,8 @@ function wirePlayBtn(btn, vid, block, labels) {
     block.querySelectorAll('video').forEach((v) => {
       if (v !== vid) {
         v.pause();
-        const b = v.closest('li')?.querySelector('button');
+        const li = v.closest('li');
+        const b = li && li.querySelector('button');
         if (b) b.setAttribute('aria-pressed', false);
       }
     });
@@ -93,7 +96,7 @@ function wirePlayBtn(btn, vid, block, labels) {
       btn.setAttribute('aria-label', labels.play);
     }
   });
-  ['ended', 'pause'].forEach((ev) => vid.addEventListener(ev, () => {
+  ['ended', 'pause'].forEach((e) => vid.addEventListener(e, () => {
     btn.setAttribute('aria-pressed', false);
     btn.setAttribute('aria-label', labels.play);
   }));
@@ -123,8 +126,8 @@ async function decorateVideos(block) {
     const mediaWrap = document.createElement('div');
     mediaWrap.className = 'slide-media';
     if (mediaCell) buildVideo(mediaCell);
-    const vid = mediaCell?.querySelector('video');
-    const img = mediaCell?.querySelector('img, picture');
+    const vid = mediaCell && mediaCell.querySelector('video');
+    const img = mediaCell && mediaCell.querySelector('img, picture');
     if (vid) {
       vid.removeAttribute('controls');
       vid.setAttribute('playsinline', '');
@@ -173,19 +176,19 @@ async function decorateVideos(block) {
     const radioGroup = block.querySelector('[role="radiogroup"]');
     if (!ul || !radioGroup) return;
 
-    const spv = 3.5;
-    const pageCount = Math.ceil(ul.children.length / spv);
+    const slidesPerViewport = 3.5;
+    const pageCount = Math.ceil(ul.children.length / slidesPerViewport);
     [...radioGroup.querySelectorAll('button')].forEach((d, i) => { if (i >= pageCount) d.remove(); });
 
     const dots = [...radioGroup.querySelectorAll('button')];
     const prev = block.querySelector('.nav-arrow-previous');
     const next = block.querySelector('.nav-arrow-next');
 
-    const getSlideW = () => (ul.children[0]?.offsetWidth || 0) + parseFloat(getComputedStyle(ul).gap || '0');
+    const getSlideW = () => (ul.children[0] ? ul.children[0].offsetWidth : 0) + parseFloat(getComputedStyle(ul).gap || '0');
 
     const sync = () => {
       const sw = getSlideW() || 1;
-      const page = Math.min(Math.round(ul.scrollLeft / (sw * spv)), dots.length - 1);
+      const page = Math.min(Math.round(ul.scrollLeft / (sw * slidesPerViewport)), dots.length - 1);
       dots.forEach((d, i) => d.setAttribute('aria-checked', i === page ? 'true' : 'false'));
       if (prev) prev.disabled = ul.scrollLeft <= 0;
       if (next) next.disabled = ul.scrollLeft + ul.clientWidth >= ul.scrollWidth - 1;
@@ -193,7 +196,7 @@ async function decorateVideos(block) {
 
     dots.forEach((d, i) => {
       d.addEventListener('click', () => {
-        ul.scrollTo({ left: Math.round(i * spv) * getSlideW(), behavior: 'smooth' });
+        ul.scrollTo({ left: Math.round(i * slidesPerViewport) * getSlideW(), behavior: 'smooth' });
       });
     });
 

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -163,37 +163,45 @@ async function decorateVideos(block) {
   block.append(track);
   buildCarousel(block, true);
 
-  // Trim dots to page count and sync arrow disabled state
+  // Sync dots and arrow disabled state
   requestAnimationFrame(() => {
     const ul = block.querySelector('ul');
     const radioGroup = block.querySelector('[role="radiogroup"]');
     if (!ul || !radioGroup) return;
 
-    const slidesPerViewport = 3.5;
-    const pageCount = Math.ceil(ul.children.length / slidesPerViewport);
-    [...radioGroup.querySelectorAll('button')].forEach((d, i) => { if (i >= pageCount) d.remove(); });
-
-    const dots = [...radioGroup.querySelectorAll('button')];
+    const allDots = [...radioGroup.querySelectorAll('button')];
     const prev = block.querySelector('.nav-arrow-previous');
     const next = block.querySelector('.nav-arrow-next');
+
+    const getSlidesPerViewport = () => {
+      if (window.matchMedia('(width >= 1200px)').matches) return 3.5;
+      if (window.matchMedia('(width >= 900px)').matches) return 2.5;
+      if (window.matchMedia('(width >= 600px)').matches) return 1.5;
+      return 1;
+    };
 
     const getSlideW = () => (ul.children[0] ? ul.children[0].offsetWidth : 0) + parseFloat(getComputedStyle(ul).gap || '0');
 
     const sync = () => {
+      const spv = getSlidesPerViewport();
       const sw = getSlideW() || 1;
-      const page = Math.min(Math.round(ul.scrollLeft / (sw * slidesPerViewport)), dots.length - 1);
+      const pageCount = Math.ceil(ul.children.length / spv);
+      const dots = allDots.slice(0, pageCount);
+      allDots.forEach((d, i) => { d.hidden = i >= pageCount; });
+      const page = Math.min(Math.round(ul.scrollLeft / (sw * spv)), dots.length - 1);
       dots.forEach((d, i) => d.setAttribute('aria-checked', i === page ? 'true' : 'false'));
       if (prev) prev.disabled = ul.scrollLeft <= 0;
       if (next) next.disabled = ul.scrollLeft + ul.clientWidth >= ul.scrollWidth - 1;
     };
 
-    dots.forEach((d, i) => {
+    allDots.forEach((d, i) => {
       d.addEventListener('click', () => {
-        ul.scrollTo({ left: Math.round(i * slidesPerViewport) * getSlideW(), behavior: 'smooth' });
+        ul.scrollTo({ left: Math.round(i * getSlidesPerViewport()) * getSlideW(), behavior: 'smooth' });
       });
     });
 
     ul.addEventListener('scroll', sync);
+    window.addEventListener('resize', sync);
     sync();
   });
 }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -66,8 +66,168 @@ function autoRotate(carousel, interval = 6000) {
   }, interval);
 }
 
+// ── Videos variant ──────────────────────────────────────────────────────
+
+/**
+ * Wire play/pause button to a video element.
+ * @param {HTMLButtonElement} btn
+ * @param {HTMLVideoElement} vid
+ */
+function wirePlayBtn(btn, vid) {
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    document.querySelectorAll('.carousel.videos video').forEach((v) => {
+      if (v !== vid) {
+        v.pause();
+        const b = v.closest('li')?.querySelector('.videos-play-btn');
+        if (b) b.classList.remove('is-playing');
+      }
+    });
+    if (vid.paused) {
+      vid.play();
+      btn.classList.add('is-playing');
+      btn.setAttribute('aria-label', 'Pause');
+    } else {
+      vid.pause();
+      btn.classList.remove('is-playing');
+      btn.setAttribute('aria-label', 'Play');
+    }
+  });
+  ['ended', 'pause'].forEach((ev) => vid.addEventListener(ev, () => {
+    btn.classList.remove('is-playing');
+    btn.setAttribute('aria-label', 'Play');
+  }));
+}
+
+/**
+ * Decorate the Carousel Videos variant.
+ * @param {HTMLElement} block
+ */
+function decorateVideos(block) {
+  const rows = [...block.children];
+  block.innerHTML = '';
+  const track = document.createElement('ul');
+
+  rows.forEach((row) => {
+    const [mediaCell, bodyCell] = [...row.children];
+    const li = document.createElement('li');
+    li.className = 'videos-carousel-slide';
+
+    // Media
+    const mediaWrap = document.createElement('div');
+    mediaWrap.className = 'videos-slide-media';
+    if (mediaCell) buildVideo(mediaCell);
+    const vid = mediaCell?.querySelector('video');
+    const img = mediaCell?.querySelector('img, picture');
+    if (vid) {
+      vid.removeAttribute('controls');
+      vid.setAttribute('playsinline', '');
+      vid.setAttribute('preload', 'metadata');
+      vid.loop = false;
+      mediaWrap.append(vid);
+    } else if (img) {
+      mediaWrap.append(img);
+    }
+
+    // Play button
+    const playBtn = document.createElement('button');
+    playBtn.type = 'button';
+    playBtn.className = 'videos-play-btn';
+    playBtn.setAttribute('aria-label', 'Play');
+    playBtn.innerHTML = '<svg class="icon-play" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>'
+      + '<svg class="icon-pause" viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>';
+    mediaWrap.append(playBtn);
+    if (vid) {
+      wirePlayBtn(playBtn, vid);
+    } else {
+      requestAnimationFrame(() => {
+        const lazyVid = li.querySelector('video');
+        if (lazyVid) wirePlayBtn(playBtn, lazyVid);
+        else playBtn.style.display = 'none';
+      });
+    }
+
+    // Text overlay
+    const slideBody = document.createElement('div');
+    slideBody.className = 'videos-slide-body';
+    let titleText = '';
+    let linkHref = '';
+    let linkText = '';
+    [...(bodyCell?.children || [])].forEach((child) => {
+      const a = child.querySelector('a');
+      if (a) {
+        linkHref = a.href;
+        linkText = a.textContent.trim() || a.href;
+      } else if (!titleText) {
+        titleText = child.textContent.trim();
+      }
+    });
+    if (!titleText && bodyCell) titleText = bodyCell.textContent.trim();
+    const titleEl = document.createElement('p');
+    titleEl.className = 'slide-title';
+    titleEl.textContent = titleText || 'Title goes here...';
+    slideBody.append(titleEl);
+    if (linkHref || linkText) {
+      const linkEl = document.createElement('a');
+      linkEl.className = 'slide-link';
+      linkEl.href = linkHref || '#';
+      linkEl.textContent = linkText || linkHref;
+      slideBody.append(linkEl);
+    }
+
+    li.append(mediaWrap, slideBody);
+    track.append(li);
+  });
+
+  block.append(track);
+  buildCarousel(block, true);
+
+  // Trim dots to page count and sync arrow disabled state
+  requestAnimationFrame(() => {
+    const ul = block.querySelector('ul');
+    const radioGroup = block.querySelector('[role="radiogroup"]');
+    if (!ul || !radioGroup) return;
+
+    const spv = 3.5;
+    const pageCount = Math.ceil(ul.children.length / spv);
+    [...radioGroup.querySelectorAll('button')].forEach((d, i) => { if (i >= pageCount) d.remove(); });
+
+    const dots = [...radioGroup.querySelectorAll('button')];
+    const prev = block.querySelector('.nav-arrow-previous');
+    const next = block.querySelector('.nav-arrow-next');
+
+    const getSlideW = () => (ul.children[0]?.offsetWidth || 0) + parseFloat(getComputedStyle(ul).gap || '0');
+
+    const sync = () => {
+      const sw = getSlideW() || 1;
+      const page = Math.min(Math.round(ul.scrollLeft / (sw * spv)), dots.length - 1);
+      dots.forEach((d, i) => d.setAttribute('aria-checked', i === page ? 'true' : 'false'));
+      if (prev) prev.disabled = ul.scrollLeft <= 0;
+      if (next) next.disabled = ul.scrollLeft + ul.clientWidth >= ul.scrollWidth - 1;
+    };
+
+    dots.forEach((d, i) => {
+      d.onclick = () => {
+        ul.scrollTo({ left: Math.round(i * spv) * getSlideW(), behavior: 'smooth' });
+      };
+    });
+
+    ul.addEventListener('scroll', sync);
+    sync();
+  });
+}
+
+// ── Main decorate export ────────────────────────────────────────────────────
+
 export default function decorate(block) {
   const variants = [...block.classList].filter((c) => c !== 'block' && c !== 'carousel');
+
+  // Handle videos variant separately
+  if (variants.includes('videos')) {
+    decorateVideos(block);
+    return;
+  }
+
   const indicatedSlides = variants.find((v) => v.startsWith('slides-'));
   if (indicatedSlides) {
     block.parentElement.classList.add('items');

--- a/icons/pause.svg
+++ b/icons/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <title>Pause</title>
+  <path d="M6 4h4v16H6zm8 0h4v16h-4z" fill="currentcolor"/>
+</svg>

--- a/icons/play.svg
+++ b/icons/play.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <title>Play</title>
+  <path d="M8 5v14l11-7z" fill="currentcolor"/>
+</svg>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -629,40 +629,45 @@ function buildAutoBlocks(main) {
 /**
  * Replaces an MP4 anchor element with a <video> element.
  * @param {HTMLElement} el - Container element
+ * @param {boolean} [autoplay=true] - Whether to autoplay the video on intersection
  * @returns {HTMLVideoElement|null} Created <video> element (or `null` if no video link found)
  */
-export function buildVideo(el) {
+export function buildVideo(el, autoplay = true) {
   const vid = el.querySelector('a[href*=".mp4"]');
   if (vid) {
     const imgWrapper = vid.closest('.img-wrapper');
     if (imgWrapper) imgWrapper.classList.add('vid-wrapper');
     // create video element
     const video = document.createElement('video');
-    video.loop = true;
-    video.muted = true;
-    video.autoplay = true;
     video.playsInline = true;
-    video.setAttribute('autoplay', '');
-    video.setAttribute('muted', '');
-    video.setAttribute('preload', 'none');
+    video.setAttribute('preload', autoplay ? 'none' : 'metadata');
+    if (autoplay) {
+      video.loop = true;
+      video.muted = true;
+      video.autoplay = true;
+      video.setAttribute('autoplay', '');
+      video.setAttribute('muted', '');
+    }
     // create source element
     const source = document.createElement('source');
     source.type = 'video/mp4';
     source.dataset.src = vid.href;
     video.append(source);
-    // load and play video on observation
+    // load (and optionally play) video on observation
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting && !source.dataset.loaded) {
           source.src = source.dataset.src;
           video.load();
-          // handle play promise to catch autoplay blocks
-          const playPromise = video.play();
-          if (playPromise !== undefined) {
-            playPromise.catch((error) => {
-              // eslint-disable-next-line no-console
-              console.log('video autoplay prevented:', error);
-            });
+          if (autoplay) {
+            // handle play promise to catch autoplay blocks
+            const playPromise = video.play();
+            if (playPromise !== undefined) {
+              playPromise.catch((error) => {
+                // eslint-disable-next-line no-console
+                console.log('video autoplay prevented:', error);
+              });
+            }
           }
           source.dataset.loaded = true;
           observer.disconnect();


### PR DESCRIPTION
Adds a carousel block videos variant for vertically-oriented (9:16) video content. Slides scroll horizontally with 1-3.5 visible per viewport depending on breakpoint.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/drafts/ashleya/carousel
- After: https://carousel-video--vitamix--aemsites.aem.page/drafts/ashleya/carousel
