### PR TITLE
feat: integrate reCAPTCHA on frontend

### DIFF
--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -206,6 +206,7 @@ apple-pay-button {
   --apple-pay-button-height: 40px;
   --apple-pay-button-border-radius: 5px;
   --apple-pay-button-padding: 5px 0px;
+
   pointer-events: none;
 }
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -517,6 +517,29 @@ export default async function decorate(block) {
     }
   }
 
+  // reCAPTCHA Enterprise attribution. The badge itself is hidden globally
+  // in styles.css; this notice satisfies Google's Terms of Service
+  // requirement to disclose reCAPTCHA usage.
+  const noticeAnchor = formColumn.querySelector('form .button-wrapper');
+  if (noticeAnchor && !formColumn.querySelector('.recaptcha-notice')) {
+    const notice = document.createElement('p');
+    notice.className = 'recaptcha-notice';
+    notice.append(document.createTextNode('This site is protected by reCAPTCHA and the Google '));
+    const privacyLink = document.createElement('a');
+    privacyLink.href = 'https://policies.google.com/privacy';
+    privacyLink.target = '_blank';
+    privacyLink.rel = 'noopener noreferrer';
+    privacyLink.textContent = 'Privacy Policy';
+    notice.append(privacyLink, document.createTextNode(' and '));
+    const termsLink = document.createElement('a');
+    termsLink.href = 'https://policies.google.com/terms';
+    termsLink.target = '_blank';
+    termsLink.rel = 'noopener noreferrer';
+    termsLink.textContent = 'Terms of Service';
+    notice.append(termsLink, document.createTextNode(' apply.'));
+    noticeAnchor.insertAdjacentElement('afterend', notice);
+  }
+
   const submitButtons = [...formColumn.querySelectorAll('form .button-wrapper button[type="submit"]')];
   submitButtons.forEach((button) => {
     let paymentMethod = 'Credit Card';

--- a/blocks/header/auth-panel.js
+++ b/blocks/header/auth-panel.js
@@ -21,6 +21,11 @@ function buildEmailStep() {
       <button type="submit" class="auth-submit">Continue</button>
       <p class="auth-error"></p>
     </form>
+    <p class="recaptcha-notice">
+      This site is protected by reCAPTCHA and the Google
+      <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and
+      <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a> apply.
+    </p>
   `;
   return step;
 }

--- a/scripts/auth-api.js
+++ b/scripts/auth-api.js
@@ -1,4 +1,5 @@
 import { ORDERS_API_ORIGIN } from './scripts.js';
+import { mintRecaptchaToken, RECAPTCHA_ACTIONS, RECAPTCHA_HEADER } from './recaptcha.js';
 
 /** sessionStorage key for the JWT issued after OTP verification */
 export const AUTH_TOKEN_KEY = 'auth_token';
@@ -31,9 +32,12 @@ function dispatchAuthEvent(loggedIn, email) {
  * @throws {Error} If the request fails or the API returns an error
  */
 export async function login(email, country, locale) {
+  const headers = { 'Content-Type': 'application/json' };
+  const recaptchaToken = await mintRecaptchaToken(RECAPTCHA_ACTIONS.AUTH_LOGIN);
+  if (recaptchaToken) headers[RECAPTCHA_HEADER] = recaptchaToken;
   const resp = await fetch(`${ORDERS_API_ORIGIN}/auth/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ email, country, locale }),
   });
   if (!resp.ok) {

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -1,4 +1,6 @@
 import { ORDERS_API_ORIGIN } from './scripts.js';
+import { AUTH_TOKEN_KEY } from './auth-api.js';
+import { mintRecaptchaToken, RECAPTCHA_ACTIONS, RECAPTCHA_HEADER } from './recaptcha.js';
 
 /**
  * Error thrown when the Commerce API returns a non-2xx response.
@@ -17,16 +19,25 @@ class CommerceApiError extends Error {
  * Makes an authenticated POST request to the Commerce API.
  * Attaches a Bearer token from sessionStorage if one is present, so orders
  * created while a user is logged in are associated with their account.
+ * When `recaptchaAction` is provided AND no Bearer token is available,
+ * mints a reCAPTCHA Enterprise token and attaches it as `X-Recaptcha-Token`.
+ * Bypass if authenticated.
  *
  * @param {string} path - API path relative to ORDERS_API_ORIGIN (e.g. '/orders')
  * @param {Object} body - Request payload, serialised as JSON
+ * @param {string} [recaptchaAction] - One of RECAPTCHA_ACTIONS, or undefined to skip
  * @returns {Promise<Object>} Parsed JSON response body
  * @throws {CommerceApiError} If the response status is not 2xx
  */
-async function post(path, body) {
+async function post(path, body, recaptchaAction) {
   const headers = { 'Content-Type': 'application/json' };
-  const token = sessionStorage.getItem('auth_token');
+  const token = sessionStorage.getItem(AUTH_TOKEN_KEY);
   if (token) headers.Authorization = `Bearer ${token}`;
+
+  if (recaptchaAction && !token) {
+    const recaptchaToken = await mintRecaptchaToken(recaptchaAction);
+    if (recaptchaToken) headers[RECAPTCHA_HEADER] = recaptchaToken;
+  }
 
   const resp = await fetch(`${ORDERS_API_ORIGIN}${path}`, {
     method: 'POST',
@@ -72,7 +83,7 @@ export async function estimateShipping(country, state, items) {
  * @throws {CommerceApiError}
  */
 export async function previewOrder(orderBody) {
-  return post('/orders/preview', orderBody);
+  return post('/orders/preview', orderBody, RECAPTCHA_ACTIONS.ORDERS_PREVIEW);
 }
 
 /**
@@ -86,7 +97,7 @@ export async function previewOrder(orderBody) {
  * @throws {CommerceApiError}
  */
 export async function createOrder(orderBody) {
-  return post('/orders', orderBody);
+  return post('/orders', orderBody, RECAPTCHA_ACTIONS.ORDERS_CREATE);
 }
 
 /**

--- a/scripts/recaptcha.js
+++ b/scripts/recaptcha.js
@@ -1,0 +1,138 @@
+import { loadScript } from './aem.js';
+
+/**
+ * Google reCAPTCHA Enterprise integration for the protected unauthenticated
+ * write endpoints on the Commerce API:
+ *
+ *   POST /auth/login         → action 'auth_login'
+ *   POST /orders/preview     → action 'orders_preview'
+ *   POST /orders             → action 'orders_create'
+ *
+ * When `RECAPTCHA_SITE_KEY` is empty (e.g. a
+ * dev environment without the secret provisioned) this module degrades
+ * gracefully and the request goes out without a token.
+ */
+
+/**
+ * reCAPTCHA Enterprise site key. Public — safe to expose client-side.
+ *
+ * Empty string disables the integration (graceful degradation).
+ */
+// TODO: Sitekey for api-stage only for Vitamix.
+export const RECAPTCHA_SITE_KEY = '6LfaNtosAAAAABpYKw5c-zu9FWjxxfZJDpVu4JjG';
+
+/** Action name constants mirroring the server's RECAPTCHA_ACTIONS. */
+export const RECAPTCHA_ACTIONS = Object.freeze({
+  AUTH_LOGIN: 'auth_login',
+  ORDERS_PREVIEW: 'orders_preview',
+  ORDERS_CREATE: 'orders_create',
+});
+
+export const RECAPTCHA_HEADER = 'X-Recaptcha-Token';
+
+/**
+ * Maximum time (ms) to wait for the SDK script to load before giving up.
+ */
+const SDK_LOAD_TIMEOUT_MS = 5000;
+
+let sdkPromise = null;
+
+/**
+ * Lazily inject the reCAPTCHA Enterprise SDK and wait until it is fully
+ * initialized — not just until the script tag has loaded. Returns the same
+ * promise on every call so concurrent callers share a single load.
+ *
+ * Important: reCAPTCHA Enterprise has two-stage initialization. After the
+ * script's `onload` fires, `grecaptcha.enterprise.ready` is available but
+ * `grecaptcha.enterprise.execute` is not. `execute` only becomes callable
+ * once the SDK's internal bootstrap completes, which is signalled via the
+ * `enterprise.ready(callback)` queue. We chain both stages so this promise
+ * represents "SDK is ready to mint tokens", letting callers skip race-prone
+ * existence checks. Rejects on load error or after {@link SDK_LOAD_TIMEOUT_MS}
+ * so callers don't hang indefinitely on a third-party outage.
+ *
+ * @param {string} [siteKey=RECAPTCHA_SITE_KEY]
+ * @returns {Promise<void>}
+ */
+export function loadRecaptchaSdk(siteKey = RECAPTCHA_SITE_KEY) {
+  if (!siteKey) return Promise.resolve();
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (window.grecaptcha?.enterprise?.execute) return Promise.resolve();
+  if (sdkPromise) return sdkPromise;
+
+  const src = `https://www.google.com/recaptcha/enterprise.js?render=${encodeURIComponent(siteKey)}`;
+  const load = loadScript(src, { async: 'true', defer: 'true' })
+    .then(() => new Promise((resolve, reject) => {
+      if (!window.grecaptcha?.enterprise?.ready) {
+        reject(new Error('grecaptcha.enterprise.ready unavailable after SDK load'));
+        return;
+      }
+      window.grecaptcha.enterprise.ready(resolve);
+    }));
+
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error('reCAPTCHA SDK load timed out')),
+      SDK_LOAD_TIMEOUT_MS,
+    );
+  });
+
+  sdkPromise = Promise.race([load, timeout])
+    .then(() => { clearTimeout(timer); })
+    .catch((err) => {
+      clearTimeout(timer);
+      sdkPromise = null;
+      throw err;
+    });
+
+  return sdkPromise;
+}
+
+/**
+ * Mint a single-use reCAPTCHA Enterprise token for the given action.
+ *
+ * Lazily ensures the SDK is loaded — first call awaits the script load
+ * (~150 KB), subsequent calls are instant.
+ *
+ * The third parameter is an optional injection point for tests. Pass an
+ * object with the same shape as `window.grecaptcha` to bypass the real
+ * SDK; leave undefined in production to use the lazy-loaded SDK.
+ *
+ * @param {string} action - One of {@link RECAPTCHA_ACTIONS}.
+ * @param {string} [siteKey=RECAPTCHA_SITE_KEY] - Override for tests.
+ * @param {object} [grecaptcha] - Override for tests; production reads window.grecaptcha.
+ * @returns {Promise<string>} A token string, or '' on any failure.
+ */
+export async function mintRecaptchaToken(
+  action,
+  siteKey = RECAPTCHA_SITE_KEY, // eslint-disable-line default-param-last
+  grecaptcha,
+) {
+  if (!siteKey) return '';
+  let sdk = grecaptcha;
+  if (sdk === undefined) {
+    if (typeof window === 'undefined') return '';
+    // Always await loadRecaptchaSdk — it short-circuits when the SDK is
+    // already fully initialized, and otherwise chains through both the
+    // script load AND enterprise.ready() so callers don't race the
+    // SDK's two-stage init.
+    try {
+      await loadRecaptchaSdk(siteKey);
+    } catch {
+      return '';
+    }
+    sdk = window.grecaptcha;
+  }
+  if (!sdk?.enterprise?.execute) return '';
+  try {
+    // ready() is a no-op queue when SDK is already initialized (production
+    // path via loadRecaptchaSdk), but kept as a safety net for the test
+    // injection path where the caller passes a fresh mock SDK.
+    await new Promise((resolve) => { sdk.enterprise.ready(resolve); });
+    const token = await sdk.enterprise.execute(siteKey, { action });
+    return token || '';
+  } catch {
+    return '';
+  }
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,7 +25,7 @@ export const ORDERS_API_ORIGIN = 'https://api-stage.adobecommerce.live/aemsites/
 // Add locale codes here as each region goes live (e.g., 'ca', 'fr_ca').
 const EDGE_CART_LOCALES = [];
 
-const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-orders') || hostname.includes('integration.vitamix.com');
+const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-orders') || hostname.includes('recaptcha') || hostname.includes('integration.vitamix.com') || hostname.includes('uat.vitamix.com');
 const isProdHost = hostname.includes('vitamix.com');
 
 // Affirm public API key — safe to expose client-side (used for PDP promo widgets).

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -25,7 +25,7 @@ export const ORDERS_API_ORIGIN = 'https://api-stage.adobecommerce.live/aemsites/
 // Add locale codes here as each region goes live (e.g., 'ca', 'fr_ca').
 const EDGE_CART_LOCALES = [];
 
-const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-orders') || hostname.includes('recaptcha') || hostname.includes('integration.vitamix.com') || hostname.includes('uat.vitamix.com');
+const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-orders') || hostname.includes('integration.vitamix.com') || hostname.includes('uat.vitamix.com');
 const isProdHost = hostname.includes('vitamix.com');
 
 // Affirm public API key — safe to expose client-side (used for PDP promo widgets).

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -899,3 +899,26 @@ body.corp main .default-content-wrapper h1 {
 body.corp main .default-content-wrapper h2 {
   font-size: var(--font-size-500);
 }
+
+/*
+ * reCAPTCHA Enterprise badge — hidden globally. Google's Terms of Service
+ * permit hiding the badge as long as attribution text is shown near every
+ * form that uses reCAPTCHA. The required `.recaptcha-notice` block is
+ * rendered inside the auth panel and the checkout form for that purpose.
+ */
+.grecaptcha-badge {
+  visibility: hidden !important;
+}
+
+.recaptcha-notice {
+  font-size: var(--font-size-100);
+  color: #666;
+  margin-top: 12px;
+  line-height: 1.4;
+}
+
+.recaptcha-notice a {
+  color: inherit;
+  text-decoration: underline;
+}
+

--- a/tests/scripts/recaptcha.spec.js
+++ b/tests/scripts/recaptcha.spec.js
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Unit tests for mintRecaptchaToken (from scripts/recaptcha.js).
+ *
+ * The function is inlined here because scripts/recaptcha.js imports
+ * loadScript from aem.js, and aem.js cannot be imported in the Node
+ * test runner — it sets `window.hlx = ...` at module load. This mirrors
+ * the existing pattern in pricing.spec.js for the same reason.
+ *
+ * Keep this copy in sync with the real module's behavior. The contract:
+ * returns '' on any failure (missing site key, missing SDK, execute()
+ * rejection, falsy token); otherwise returns the token from
+ * grecaptcha.enterprise.execute(siteKey, { action }).
+ */
+
+async function mintRecaptchaToken(action, siteKey, grecaptcha) {
+  if (!siteKey) return '';
+  if (!grecaptcha?.enterprise?.execute) return '';
+  try {
+    await new Promise((resolve) => { grecaptcha.enterprise.ready(resolve); });
+    const token = await grecaptcha.enterprise.execute(siteKey, { action });
+    return token || '';
+  } catch {
+    return '';
+  }
+}
+
+function makeFakeGrecaptcha({ token = 'fake-token', execute, ready } = {}) {
+  return {
+    enterprise: {
+      ready: ready || ((cb) => cb()),
+      execute: execute || (async () => token),
+    },
+  };
+}
+
+test.describe('mintRecaptchaToken', () => {
+  test('returns empty string when site key is empty (graceful degradation)', async () => {
+    const grecaptcha = makeFakeGrecaptcha();
+    const result = await mintRecaptchaToken('auth_login', '', grecaptcha);
+    expect(result).toBe('');
+  });
+
+  test('returns empty string when grecaptcha is undefined', async () => {
+    const result = await mintRecaptchaToken('auth_login', 'site-key', undefined);
+    expect(result).toBe('');
+  });
+
+  test('returns empty string when grecaptcha.enterprise is missing', async () => {
+    const result = await mintRecaptchaToken('auth_login', 'site-key', {});
+    expect(result).toBe('');
+  });
+
+  test('returns the token from grecaptcha.enterprise.execute on happy path', async () => {
+    const grecaptcha = makeFakeGrecaptcha({ token: 'real-token-123' });
+    const result = await mintRecaptchaToken('auth_login', 'site-key', grecaptcha);
+    expect(result).toBe('real-token-123');
+  });
+
+  test('passes the action and site key to grecaptcha.enterprise.execute', async () => {
+    let observedSiteKey;
+    let observedAction;
+    const grecaptcha = makeFakeGrecaptcha({
+      execute: async (siteKey, opts) => {
+        observedSiteKey = siteKey;
+        observedAction = opts.action;
+        return 'token';
+      },
+    });
+    await mintRecaptchaToken('orders_create', 'site-key-abc', grecaptcha);
+    expect(observedSiteKey).toBe('site-key-abc');
+    expect(observedAction).toBe('orders_create');
+  });
+
+  test('waits for grecaptcha.enterprise.ready before executing', async () => {
+    const callOrder = [];
+    const grecaptcha = makeFakeGrecaptcha({
+      ready: (cb) => {
+        callOrder.push('ready');
+        setTimeout(cb, 10);
+      },
+      execute: async () => {
+        callOrder.push('execute');
+        return 'token';
+      },
+    });
+    await mintRecaptchaToken('auth_login', 'site-key', grecaptcha);
+    expect(callOrder).toEqual(['ready', 'execute']);
+  });
+
+  test('returns empty string when execute throws (fail-open)', async () => {
+    const grecaptcha = makeFakeGrecaptcha({
+      execute: async () => { throw new Error('execute failed'); },
+    });
+    const result = await mintRecaptchaToken('auth_login', 'site-key', grecaptcha);
+    expect(result).toBe('');
+  });
+
+  test('returns empty string when execute returns falsy', async () => {
+    const grecaptcha = makeFakeGrecaptcha({ execute: async () => '' });
+    const result = await mintRecaptchaToken('auth_login', 'site-key', grecaptcha);
+    expect(result).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/recaptcha.js` — lazy SDK loader + `mintRecaptchaToken()` that mints a single-use reCAPTCHA Enterprise token for each protected action
- Wires `auth_login` token into `scripts/auth-api.js` `login()` so the login POST carries `X-Recaptcha-Token`
- Wires `orders_preview` / `orders_create` tokens into `scripts/commerce-api.js` `post()` helper; token is skipped automatically when a Bearer JWT is present (authenticated users bypass the gate server-side)
- Fixes a two-stage SDK init race: `loadRecaptchaSdk` now chains `script.onload → enterprise.ready()` so the promise only resolves once `execute` is callable — prevents a missing token on the first cold call
- Hides `.grecaptcha-badge` globally in `styles/styles.css`; adds required Google ToS attribution notice in the login panel (`auth-panel.js`) and checkout form (`checkout.js`)
- Unit tests for `mintRecaptchaToken` covering happy path, graceful degradation (no site key, SDK failure), and error cases
- Whitelists `recaptcha` hostname in `scripts/scripts.js` for edge cart mode on the test branch

## Test URL:
https://recaptcha--vitamix--aemsites.aem.network/ca/fr_ca/products/vx1

## How to test

1. Open the after URL, open Network tab
2. Click **Log In** in the header → enter email → verify `POST /auth/login` carries `X-Recaptcha-Token`
3. Add an item to cart, go to `/ca/fr_ca/order/checkout`, fill in name + email + province → verify `POST /orders/preview` carries `X-Recaptcha-Token`
4. Complete the Log in first (including callback), repeat steps 2–3 → verify **no** `X-Recaptcha-Token` header is sent (authenticated bypass)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://edge-orders-demo--vitamix--aemsites.aem.network/ca/fr_ca/products/vx1
- After: https://recaptcha--vitamix--aemsites.aem.network/ca/fr_ca/products/vx1