### PR TITLE
feat: navigation block variant

### DIFF
--- a/blocks/navigation/navigation.css
+++ b/blocks/navigation/navigation.css
@@ -1,6 +1,6 @@
 main > .navigation-container.section {
   position: sticky;
-  top: var(--header-height); 
+  top: var(--header-height);
   z-index: 9;
 }
 
@@ -10,18 +10,7 @@ main > .navigation-container.section ~ .section h3,
 main > .navigation-container.section ~ .section h4,
 main > .navigation-container.section ~ .section h5,
 main > .navigation-container.section ~ .section h6 {
-  scroll-margin-top: calc(56px + 1em);
-}
-
-@media (width >= 800px) {
-  main > .navigation-container.section ~ .section h1,
-  main > .navigation-container.section ~ .section h2,
-  main > .navigation-container.section ~ .section h3,
-  main > .navigation-container.section ~ .section h4,
-  main > .navigation-container.section ~ .section h5,
-  main > .navigation-container.section ~ .section h6 {
-    scroll-margin-top: calc(83px + 1em);
-  }
+  scroll-margin-top: calc(74px + 1em);
 }
 
 .hero-container + .navigation-container {
@@ -34,30 +23,38 @@ main > .navigation-container.section ~ .section h6 {
 }
 
 .navigation {
-  padding: var(--spacing-100) var(--spacing-400);
-  background-color: var(--color-charcoal);
-  color: var(--color-white);
-  font-size: 0.875rem;
-}
-
-@media (width >= 800px) {
-  .navigation {
-    padding: 0 var(--spacing-400);
-  }
-}
-
-@media (width >= 1000px) {
-  .navigation {
-    padding: 0 var(--spacing-800);
-  }
-}
-
-.navigation > div {
-  display: grid;
-  grid-template-columns: 1fr min-content;
-  align-items: center;
-  gap: var(--spacing-100);
   position: relative;
+  background-color: var(--color-gray-300);
+  color: var(--color-charcoal);
+  font-size: var(--body-size-s);
+}
+
+.navigation > * {
+  padding: 0 var(--horizontal-spacing);
+}
+
+.navigation a:not(.button) {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+.navigation a:not(.button):hover,
+.navigation a:not(.button):focus-visible {
+  text-decoration: underline;
+}
+
+.navigation button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 1em 2em;
+  color: inherit;
+  cursor: pointer;
+}
+
+.navigation button:focus {
+  box-shadow: none;
 }
 
 .navigation ul {
@@ -66,49 +63,342 @@ main > .navigation-container.section ~ .section h6 {
   padding: 0;
 }
 
-.navigation ul a:any-link {
-  color: var(--color-white);
-  text-decoration: none;
-  font-weight: normal;
-  cursor: pointer;
+/* MENU */
+.navigation .menu {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+  gap: 1ch;
 }
 
-.navigation nav ul a:any-link {
-  display: block;
-  font-weight: 500;
-  letter-spacing: var(--letter-spacing-m);
+.navigation .menu .pre-nav {
+  align-self: stretch;
+  align-items: center;
+  position: relative;
+  margin: 0;
+}
+
+.navigation .menu .pre-nav .button,
+.navigation .menu .toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 30px;
+  line-height: 0;
+}
+
+.navigation .menu .pre-nav [aria-current]::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 28px;
+  height: 5px;
+  background-color: var(--color-red);
+  transform: translateX(-50%);
+}
+
+.navigation .menu .post-nav {
+  margin-left: auto;
+}
+
+@media (width >= 1000px) {
+  .navigation .menu {
+    grid-template-columns: 44px 1fr max-content;
+    gap: var(--horizontal-spacing);
+  }
+
+  .navigation .menu .pre-nav::after {
+    content: "";
+    position: absolute;
+    top: 1em;
+    bottom: 1em;
+    left: calc(100% + (var(--horizontal-spacing) / 2));
+    width: 1px;
+    background-color: var(--color-gray-400);
+  }
+}
+
+/* menu nav */
+.navigation .menu nav {
+  display: none;
+  align-self: stretch;
+}
+
+.navigation .menu nav .list-wrapper,
+.navigation .menu nav ul {
+  display: flex;
+  align-items: stretch;
+}
+
+.navigation .menu nav ul {
+  gap: 1ch;
+}
+
+.navigation .menu nav ul > li {
+  display: flex;
+  align-items: center;
+}
+
+.navigation .menu nav button {
+  align-self: stretch;
+  position: relative;
   text-transform: uppercase;
+  transition: color 0.2s;
 }
 
-.navigation nav ul > li {
+.navigation .menu nav button[data-current]::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 28px;
+  height: 5px;
+  background-color: var(--color-red);
+  transform: translateX(-50%);
+}
+
+.navigation .menu nav button:hover,
+.navigation .menu nav button:focus-visible,
+.navigation .menu nav button[aria-expanded="true"] {
+  color: var(--color-red);
+}
+
+@media (width >= 1000px) {
+  .navigation .menu nav {
+    display: flex;
+  }
+}
+
+/* toggle */
+.navigation .menu .toggle i {
+  width: 28px;
+}
+
+.navigation .menu .symbol-hamburger,
+.navigation .menu .symbol-hamburger::before,
+.navigation .menu .symbol-hamburger::after {
+  width: 100%;
+  height: 5px;
+  border-radius: 1px;
+  background-color: currentcolor;
+  transition: transform 0.4s, top 0.4s, bottom 0.4s, width 0.4s, height 0.4s, border-radius 0.4s, background-color 0.4s;
+}
+
+.navigation .menu .symbol-hamburger::before,
+.navigation .menu .symbol-hamburger::after {
+  left: 0;
+  width: 100%;
+  height: 5px;
+  background-color: currentcolor;
+  transform: rotate(0);
+}
+
+.navigation .menu .symbol-hamburger::before {
+  top: -8px;
+}
+
+.navigation .menu .symbol-hamburger::after {
+  bottom: -8px;
+}
+
+.navigation .menu .toggle[aria-expanded="true"] .symbol-hamburger {
+  height: 28px;
+  border-radius: 50%;
+}
+
+.navigation .menu .toggle[aria-expanded="true"] .symbol-hamburger::before,
+.navigation .menu .toggle[aria-expanded="true"] .symbol-hamburger::after {
+  width: 18px;
+  height: 4px;
+  left: 5px;
+  background-color: var(--color-background);
+}
+
+.navigation .menu .toggle[aria-expanded="true"] .symbol-hamburger::before {
+  transform: rotate(45deg);
+  top: 12px;
+}
+
+.navigation .menu .toggle[aria-expanded="true"] .symbol-hamburger::after {
+  transform: rotate(-45deg);
+  bottom: 12px;
+}
+
+@media (width >= 1000px) {
+  .navigation .menu .toggle {
+    display: none;
+  }
+}
+
+/* stylelint-disable no-descending-specificity */
+
+/* SUBMENU */
+.navigation .submenu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: var(--color-gray-100);
+  border-bottom: 1px solid var(--color-gray-300);
+}
+
+.navigation .submenu ul {
+  display: flex;
+  gap: var(--horizontal-spacing);
+}
+
+.navigation .submenu a {
+  border-bottom: 1px solid transparent;
+  padding: 2em 0;
+}
+
+.navigation .submenu a:hover,
+.navigation .submenu a:focus-visible,
+.navigation .submenu a[aria-current] {
+  border-bottom: 1px solid;
+  text-decoration: none;
+}
+
+/* POPOVER */
+.navigation .popover {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--color-white);
+}
+
+.navigation .popover > ul,
+.navigation .popover a:any-link {
+  margin: var(--spacing-200) 0;
+}
+
+.navigation .popover a[aria-current] {
+  font-weight: bold;
+}
+
+.navigation .popover button {
+  display: flex;
+  justify-content: space-between;
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-s);
+}
+
+.navigation .popover button::after {
+  content: "";
+  transform: rotate(-45deg);
+  width: 14px;
+  height: 14px;
+  margin-top: 0.25em;
+  border: 3px solid transparent;
+  border-top-color: currentcolor;
+  border-right-color: currentcolor;
+  border-radius: var(--rounding-s);
+  transition: transform 0.2s;
+}
+
+.navigation .popover button[aria-expanded="true"]::after {
+  margin-top: 0;
+  transform: rotate(135deg);
+}
+
+.navigation .popover button + ul {
+  display: none;
+  padding: 0 2em;
+}
+
+.navigation .popover button[aria-expanded="true"] + ul {
+  display: block;
+}
+
+.navigation .popover > ul > li {
+  border-top: 1px solid var(--color-gray-300);
+}
+
+.navigation .popover > ul > li:last-of-type {
+  border-bottom: 1px solid var(--color-gray-300);
+}
+
+/* JUMP VARIANT */
+.navigation.jump {
+  background: var(--color-charcoal);
+  color: var(--color-white);
+}
+
+.navigation.jump .menu {
+  grid-template-columns: 1fr max-content;
+}
+
+.navigation.jump .menu nav {
+  display: flex;
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-s);
+}
+
+.navigation.jump .menu nav .list-wrapper,
+.navigation.jump .menu nav ul {
+  width: 100%;
+}
+
+.navigation.jump .menu nav ul {
+  gap: var(--horizontal-spacing);
+}
+
+.navigation.jump .menu nav ul > li {
   display: none;
 }
 
-.navigation nav ul > li[aria-current="true"] {
+.navigation.jump .menu nav ul > li:has(a[aria-current]) {
+  display: flex;
+  width: 100%;
+}
+
+.navigation.jump .menu nav ul > li a {
+  align-self: stretch;
   display: flex;
   align-items: center;
-  gap: var(--spacing-60);
+  gap: 1ch;
+  width: 100%;
+}
+
+.navigation.jump .menu nav ul > li a::after {
+  content: "";
+  transform: rotate(-45deg);
+  width: 14px;
+  height: 14px;
+  margin-top: 0.25em;
+  border: 3px solid transparent;
+  border-top-color: currentcolor;
+  border-right-color: currentcolor;
+  border-radius: var(--rounding-s);
+  transition: transform 0.2s;
+}
+
+.navigation.jump .menu nav ul > li[aria-expanded="true"] a::after {
+  margin-top: 0;
+  transform: rotate(135deg);
 }
 
 @media (width >= 800px) {
-  .navigation nav {
+  .navigation.jump .menu {
+    gap: 1ch;
+  }
+
+  .navigation.jump .menu nav {
     overflow: hidden;
   }
 
-  .navigation nav ul {
-    position: relative;
-    display: flex;
-    gap: var(--spacing-700);
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    max-width: 100%;
-  }
-
-  .navigation nav .navigation-list-wrapper {
+  .navigation.jump .menu nav .list-wrapper {
     position: relative;
   }
 
-  .navigation nav .navigation-list-wrapper::after {
+  .navigation.jump .menu nav .list-wrapper::after {
     content: "";
     position: absolute;
     inset: 0;
@@ -123,7 +413,7 @@ main > .navigation-container.section ~ .section h6 {
     transition: background 0.2s;
   }
 
-  .navigation nav .navigation-list-wrapper[data-scroll="start"]::after {
+  .navigation.jump .menu nav .list-wrapper[data-scroll="start"]::after {
     background: linear-gradient(
       to right,
       transparent calc(100% - var(--spacing-400)),
@@ -131,7 +421,7 @@ main > .navigation-container.section ~ .section h6 {
     );
   }
 
-  .navigation nav .navigation-list-wrapper[data-scroll="end"]::after {
+  .navigation.jump .menu nav .list-wrapper[data-scroll="end"]::after {
     background: linear-gradient(
       to right,
       var(--color-charcoal),
@@ -139,100 +429,51 @@ main > .navigation-container.section ~ .section h6 {
     );
   }
 
-  .navigation nav ul::-webkit-scrollbar {
+  .navigation.jump .menu nav ul {
+    position: relative;
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    max-width: 100%;
+  }
+
+  .navigation.jump .menu nav ul::-webkit-scrollbar {
     display: none;
   }
 
-  .navigation nav ul a:any-link {
-    padding: var(--spacing-400) 0;
+  .navigation.jump .menu nav ul > li:has(a[aria-current]) {
+    width: unset;
   }
 
-  .navigation nav ul > li {
-    display: unset;
+  .navigation.jump .menu nav ul > li {
+    display: flex;
     white-space: nowrap;
     scroll-snap-align: start;
   }
 
-  .navigation nav ul > li[aria-current="true"] {
+  .navigation.jump .menu nav ul > li a[aria-current] {
     position: relative;
   }
 
-  .navigation nav ul > li[aria-current="true"]::before {
+  .navigation.jump .menu nav ul > li a[aria-current]::after {
     content: "";
     position: absolute;
     top: 0;
     left: 50%;
     transform: translateX(-50%);
-    width: 26px;
+    width: 28px;
     height: 5px;
+    margin-top: 0;
+    border: 0;
+    border-radius: 0;
     background-color: var(--color-red);
   }
-}
 
-@media (width >= 345px) {
-  .navigation nav ul > li[aria-current="true"]::after {
-    content: "";
-    flex-shrink: 0;
-    display: inline-block;
-    transform: rotate(-45deg);
-    width: 14px;
-    height: 14px;
-    margin-top: 0.75em;
-    border: 3px solid transparent;
-    border-top-color: currentcolor;
-    border-right-color: currentcolor;
-    border-radius: var(--rounding-s);
-    transition: margin 0.2s, transform 0.2s;
-  }
-
-  .navigation nav ul > li[aria-expanded="true"]::after {
-    margin-top: 0;
-    margin-bottom: 0.75em;
-    transform: rotate(135deg);
-  }
-}
-
-@media (width >= 800px) {
-  .navigation nav ul > li[aria-current="true"]::after {
+  .navigation.jump .menu nav ul > li a::after {
     content: none;
   }
 }
 
-.navigation .navigation-popover {
-  display: block;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  background-color: var(--color-charcoal);
-  color: var(--color-white);
-}
-
-.navigation .navigation-popover[hidden] {
-  display: none;
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.navigation .navigation-popover a {
-  display: block;
-  padding: var(--spacing-100) var(--spacing-400);
-}
-
-.navigation .navigation-popover a:focus-visible {
-  outline: 2px solid var(--color-gray);
-  outline-offset: -2px;
-  background-color: rgb(255 255 255 / 10%);
-}
-
-.navigation .navigation-popover a:hover {
-  color: var(--color-white);
-  text-decoration: underline;
-}
-
-.navigation .navigation-popover ul > li {
-  border-top: 1px solid var(--color-gray-400);
-}
-
-.navigation .navigation-popover ul > li:last-child {
-  border-bottom: 1px solid var(--color-gray-400);
+.navigation.jump .popover {
+  background: var(--color-charcoal);
 }

--- a/blocks/navigation/navigation.js
+++ b/blocks/navigation/navigation.js
@@ -1,12 +1,21 @@
 /**
  * Creates and displays a navigation popover for mobile view.
  * @param {HTMLElement} block - Navigation block
- * @param {HTMLUListElement} ul - Navigation list
+ * @param {HTMLUListElement} ul - Navigation list (may include nested sub-lists)
  * @param {HTMLDivElement} popover - Popover container
  */
 function buildPopover(block, ul, popover) {
   const clone = ul.cloneNode(true);
-  clone.querySelectorAll('li').forEach((l) => l.removeAttribute('aria-current'));
+  clone.querySelectorAll('li').forEach((l) => {
+    l.removeAttribute('aria-current');
+    l.removeAttribute('aria-expanded');
+  });
+  clone.querySelectorAll('a').forEach((a) => a.removeAttribute('aria-current'));
+  const currentLink = ul.querySelector('a[aria-current]');
+  if (currentLink) {
+    const cloneLink = clone.querySelector(`a[href="${currentLink.getAttribute('href')}"]`);
+    if (cloneLink) cloneLink.setAttribute('aria-current', 'location');
+  }
   popover.append(clone);
   block.append(popover);
   popover.hidden = window.matchMedia('(width >= 800px)').matches;
@@ -16,119 +25,340 @@ function buildPopover(block, ul, popover) {
   });
 }
 
+/**
+ * Tracks horizontal scroll position on a list and updates data-scroll on the wrapper.
+ * @param {HTMLUListElement} ul - The scrollable list element
+ * @param {HTMLDivElement} wrapper - Wrapper element that receives the data-scroll attribute
+ */
+function attachScrollTracking(ul, wrapper) {
+  ul.addEventListener('scroll', () => {
+    const { scrollLeft, scrollWidth, clientWidth } = ul;
+    const scrollRight = scrollWidth - clientWidth - scrollLeft;
+    if (scrollLeft === 0) {
+      wrapper.dataset.scroll = 'start';
+    } else if (scrollRight <= 1) {
+      wrapper.dataset.scroll = 'end';
+    } else {
+      wrapper.removeAttribute('data-scroll');
+    }
+  });
+  ul.dispatchEvent(new Event('scroll'));
+}
+
+/**
+ * Replaces a <p> label inside a popover/nav li with a <button>, transferring text content.
+ * @param {HTMLLIElement} li
+ * @returns {HTMLButtonElement|null}
+ */
+function convertLabelToButton(li) {
+  const p = li.querySelector(':scope > p');
+  if (!p) return null;
+  const btn = document.createElement('button');
+  btn.textContent = p.textContent;
+  p.replaceWith(btn);
+  return btn;
+}
+
+/**
+ * Decorates the jump variant: highlights the most-visible on-page section via IntersectionObserver.
+ * @param {HTMLElement} block - Navigation block element
+ * @param {HTMLUListElement} ul - Navigation list containing anchor links to page sections
+ * @param {HTMLElement} row - First row of the block, used to prepend the nav element
+ */
+function decorateJump(block, ul, row) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'list-wrapper';
+
+  const nav = document.createElement('nav');
+  nav.setAttribute('aria-label', 'Jump navigation');
+
+  const popover = document.createElement('div');
+  popover.className = 'popover';
+  popover.hidden = true;
+  popover.setAttribute('role', 'region');
+  popover.setAttribute('aria-label', 'Navigation menu');
+
+  block.addEventListener('click', () => buildPopover(block, ul, popover), { once: true });
+
+  ul.addEventListener('click', (e) => {
+    const li = e.target.closest('li');
+    if (li) {
+      const link = li.querySelector('a[href]');
+      const mobile = !window.matchMedia('(width >= 800px)').matches;
+      if (mobile) {
+        e.preventDefault();
+        const expanded = li.hasAttribute('aria-expanded');
+        block.querySelectorAll('[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
+        popover.hidden = true;
+        if (!expanded) {
+          li.setAttribute('aria-expanded', true);
+          popover.hidden = false;
+        }
+      } else {
+        link.scrollIntoView({ behavior: 'smooth', inline: 'center' });
+      }
+    }
+  });
+
+  attachScrollTracking(ul, wrapper);
+
+  const mediaQuery = window.matchMedia('(width >= 800px)');
+  mediaQuery.addEventListener('change', (e) => {
+    if (e.matches) {
+      popover.hidden = true;
+      block.querySelectorAll('[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
+      ul.dispatchEvent(new Event('scroll'));
+    }
+  });
+
+  const links = ul.querySelectorAll('a[href*="#"]');
+  const sectionsToObserve = [];
+  links.forEach((link) => {
+    const hash = link.getAttribute('href').split('#')[1];
+    const section = document.getElementById(hash);
+    if (section) sectionsToObserve.push(section);
+  });
+
+  if (sectionsToObserve.length > 0) {
+    const sectionObserver = new IntersectionObserver(() => {
+      const visibleSections = sectionsToObserve
+        .map((section) => {
+          const rect = section.getBoundingClientRect();
+          const viewportHeight = window.innerHeight;
+          const visibleHeight = Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0);
+          const visiblePixels = visibleHeight > 0 ? visibleHeight * rect.width : 0;
+          return { section, visiblePixels };
+        })
+        .filter((item) => item.visiblePixels > 0)
+        .sort((a, b) => b.visiblePixels - a.visiblePixels);
+
+      if (visibleSections.length > 0) {
+        const mostVisible = visibleSections[0];
+        const link = [...links].find((l) => l.getAttribute('href').endsWith(`#${mostVisible.section.id}`));
+
+        if (link) {
+          links.forEach((l) => l.removeAttribute('aria-current'));
+          link.setAttribute('aria-current', 'location');
+
+          const popoverLinks = popover.querySelectorAll('a[href*="#"]');
+          if (popoverLinks.length) {
+            popoverLinks.forEach((l) => l.removeAttribute('aria-current'));
+            const popoverLink = [...popoverLinks].find((l) => l.getAttribute('href') === link.getAttribute('href'));
+            if (popoverLink) popoverLink.setAttribute('aria-current', 'location');
+          }
+
+          const mobile = !window.matchMedia('(width >= 800px)').matches;
+          const sticky = Math.abs(block.getBoundingClientRect().top) < 1;
+          if (!mobile && sticky) link.scrollIntoView({ behavior: 'smooth', inline: 'center' });
+        }
+      }
+    }, { threshold: [0, 0.25, 0.5, 0.75, 1.0] });
+
+    sectionsToObserve.forEach((section) => sectionObserver.observe(section));
+  }
+
+  const cell = ul.parentElement;
+  const cellChildren = [...cell.children];
+  wrapper.appendChild(ul);
+  const firstLink = ul.querySelector('a');
+  if (firstLink) firstLink.setAttribute('aria-current', 'location');
+  nav.appendChild(wrapper);
+  cell.remove();
+  cellChildren.forEach((child) => row.append(child === ul ? nav : child));
+}
+
+/**
+ * Decorates the default variant: top-level links with expandable sub-rows on desktop.
+ * @param {HTMLElement} block - Navigation block element
+ * @param {HTMLUListElement} ul - Navigation list; nested sub-lists become sub-row content
+ * @param {HTMLElement} row - First row of the block, used to prepend the nav element
+ */
+function decorateDefault(block, ul, row) {
+  const currentPath = window.location.pathname;
+
+  // Clone full ul (with nested sub-lists) before modifying, for use in mobile popover
+  const fullUl = ul.cloneNode(true);
+
+  const topItems = [...ul.querySelectorAll(':scope > li')];
+  const subLists = topItems.map((li) => {
+    const subUl = li.querySelector(':scope > ul');
+    return subUl ? subUl.cloneNode(true) : null;
+  });
+  ul.querySelectorAll(':scope > li > ul').forEach((subUl) => subUl.remove());
+
+  topItems.forEach((li, i) => {
+    if (subLists[i]) convertLabelToButton(li);
+  });
+
+  topItems.forEach((li, i) => {
+    const link = li.querySelector('a');
+    if (link && link.pathname === currentPath) {
+      li.setAttribute('data-current', '');
+      return;
+    }
+    const subUl = subLists[i];
+    if (subUl) {
+      const subMatch = [...subUl.querySelectorAll('a')].find((a) => a.pathname === currentPath);
+      if (subMatch) {
+        li.setAttribute('data-current', '');
+        const btn = li.querySelector(':scope > button');
+        if (btn) btn.setAttribute('data-current', 'section');
+      }
+    }
+  });
+
+  row.querySelectorAll('.pre-nav a').forEach((a) => {
+    if (a.pathname === currentPath) a.setAttribute('aria-current', 'page');
+  });
+
+  const subRow = document.createElement('div');
+  subRow.className = 'submenu';
+  subRow.hidden = true;
+
+  const popover = document.createElement('div');
+  popover.className = 'popover';
+  popover.hidden = true;
+  popover.setAttribute('role', 'region');
+  popover.setAttribute('aria-label', 'Navigation menu');
+
+  let popoverBuilt = false;
+
+  function closePopover() {
+    popover.hidden = true;
+    popover.querySelectorAll('[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
+    const toggle = block.querySelector('.toggle');
+    if (toggle) {
+      toggle.removeAttribute('aria-expanded');
+      toggle.setAttribute('aria-label', 'Open navigation menu');
+    }
+  }
+
+  function openPopover() {
+    if (!popoverBuilt) {
+      const clone = fullUl.cloneNode(true);
+      clone.querySelectorAll('li').forEach((l) => {
+        l.removeAttribute('aria-current');
+        l.removeAttribute('aria-expanded');
+      });
+      clone.querySelectorAll('a').forEach((a) => {
+        if (a.pathname === currentPath) a.setAttribute('aria-current', 'page');
+      });
+      [...clone.querySelectorAll(':scope > li')].forEach((li) => {
+        if (!li.querySelector(':scope > ul')) return;
+        const btn = convertLabelToButton(li);
+        if (!btn) return;
+        btn.addEventListener('click', () => {
+          const expanded = btn.hasAttribute('aria-expanded');
+          clone.querySelectorAll(':scope > li > button[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
+          if (!expanded) btn.setAttribute('aria-expanded', true);
+        });
+      });
+      clone.addEventListener('click', (e) => {
+        if (e.target.closest('a[href]')) closePopover();
+      });
+      popover.append(clone);
+      block.append(popover);
+      popoverBuilt = true;
+    }
+    popover.hidden = false;
+    const toggle = block.querySelector('.toggle');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', true);
+      toggle.setAttribute('aria-label', 'Close navigation menu');
+    }
+  }
+
+  const toggle = document.createElement('button');
+  toggle.className = 'button toggle';
+  toggle.setAttribute('aria-label', 'Open navigation menu');
+  const icon = document.createElement('i');
+  icon.className = 'symbol symbol-hamburger';
+  toggle.append(icon);
+  toggle.addEventListener('click', () => {
+    if (popover.hidden) {
+      openPopover();
+    } else {
+      closePopover();
+    }
+  });
+
+  ul.addEventListener('click', (e) => {
+    const li = e.target.closest('li');
+    if (!li) return;
+    if (!window.matchMedia('(width >= 1000px)').matches) return;
+    const index = topItems.indexOf(li);
+    const subUl = subLists[index];
+    if (subUl) {
+      const btn = li.querySelector(':scope > button');
+      const expanded = btn && btn.hasAttribute('aria-expanded');
+      topItems.forEach((el) => {
+        const b = el.querySelector(':scope > button');
+        if (b) b.removeAttribute('aria-expanded');
+      });
+      subRow.hidden = true;
+      if (!expanded) {
+        if (btn) btn.setAttribute('aria-expanded', true);
+        const subUlClone = subUl.cloneNode(true);
+        subUlClone.querySelectorAll('a').forEach((a) => {
+          if (a.pathname === currentPath) a.setAttribute('aria-current', 'page');
+        });
+        subRow.replaceChildren(subUlClone);
+        subRow.hidden = false;
+      }
+    }
+  });
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'list-wrapper';
+
+  const mediaQuery = window.matchMedia('(width >= 1000px)');
+  mediaQuery.addEventListener('change', (e) => {
+    if (e.matches) {
+      closePopover();
+    } else {
+      subRow.hidden = true;
+      topItems.forEach((el) => {
+        const btn = el.querySelector(':scope > button');
+        if (btn) btn.removeAttribute('aria-expanded');
+      });
+    }
+  });
+
+  const cell = ul.parentElement;
+  const cellChildren = [...cell.children];
+  wrapper.appendChild(ul);
+  const nav = document.createElement('nav');
+  nav.setAttribute('aria-label', 'Section navigation');
+  nav.appendChild(wrapper);
+  cell.remove();
+  cellChildren.forEach((child) => row.append(child === ul ? nav : child));
+  row.append(toggle);
+  block.append(subRow);
+}
+
+/**
+ * Decorates the navigation block, routing to jump or default behavior based on block variant.
+ * @param {HTMLElement} block - Navigation block element
+ */
 export default function decorate(block) {
   const variants = [...block.classList].filter((c) => c !== 'block' && c !== 'navigation');
   const row = block.firstElementChild;
+  row.classList.add('menu');
   const ul = row.querySelector('ul');
 
   if (ul) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'navigation-list-wrapper';
-
-    const nav = document.createElement('nav');
-    if (variants.includes('jump')) nav.setAttribute('aria-label', 'Jump navigation');
-
-    const popover = document.createElement('div');
-    popover.className = 'navigation-popover';
-    popover.hidden = true;
-    popover.setAttribute('role', 'region');
-    popover.setAttribute('aria-label', 'Navigation menu');
-
-    block.addEventListener('click', () => buildPopover(block, ul, popover), { once: true });
-
-    ul.addEventListener('click', (e) => {
-      const li = e.target.closest('li');
-      if (li) {
-        const link = li.querySelector('a[href]');
-        const mobile = !window.matchMedia('(width >= 800px)').matches;
-        if (mobile) { // enable mobile popover
-          e.preventDefault();
-          const expanded = li.hasAttribute('aria-expanded');
-          block.querySelectorAll('[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
-          popover.hidden = true;
-          if (!expanded) {
-            li.setAttribute('aria-expanded', true);
-            popover.hidden = false;
-          }
-        } else { // desktop scroll into view
-          link.scrollIntoView({ behavior: 'smooth', inline: 'center' });
-        }
+    const siblings = [...ul.parentElement.children];
+    const ulIndex = siblings.indexOf(ul);
+    siblings.forEach((el, i) => {
+      if (el.classList.contains('button-wrapper')) {
+        el.classList.add(i < ulIndex ? 'pre-nav' : 'post-nav');
       }
     });
 
-    ul.addEventListener('scroll', () => {
-      const { scrollLeft, scrollWidth, clientWidth } = ul;
-      const scrollRight = scrollWidth - clientWidth - scrollLeft;
-      if (scrollLeft === 0) {
-        wrapper.dataset.scroll = 'start';
-      } else if (scrollRight <= 1) {
-        wrapper.dataset.scroll = 'end';
-      } else {
-        wrapper.removeAttribute('data-scroll');
-      }
-    });
-
-    // set scroll state
-    ul.dispatchEvent(new Event('scroll'));
-
-    // handle switch from mobile to desktop
-    const mediaQuery = window.matchMedia('(width >= 800px)');
-    const handleResize = (e) => {
-      if (e.matches) {
-        popover.hidden = true;
-        block.querySelectorAll('[aria-expanded]').forEach((el) => el.removeAttribute('aria-expanded'));
-        ul.dispatchEvent(new Event('scroll'));
-      }
-    };
-    mediaQuery.addEventListener('change', handleResize);
-
-    const sectionsToObserve = [];
-
-    const links = ul.querySelectorAll('a[href*="#"]');
-    links.forEach((link) => {
-      const hash = link.getAttribute('href').split('#')[1];
-      const section = document.getElementById(hash);
-      if (section) sectionsToObserve.push(section);
-    });
-
-    // observe all sections
-    if (sectionsToObserve.length > 0) {
-      const sectionObserver = new IntersectionObserver(() => {
-        // check ALL sections every time (not just entries that changed)
-        const visibleSections = sectionsToObserve
-          .map((section) => {
-            const rect = section.getBoundingClientRect();
-            const viewportHeight = window.innerHeight;
-            const visibleHeight = Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0);
-            const visiblePixels = visibleHeight > 0 ? visibleHeight * rect.width : 0;
-            return { section, visiblePixels };
-          })
-          .filter((item) => item.visiblePixels > 0)
-          .sort((a, b) => b.visiblePixels - a.visiblePixels);
-
-        if (visibleSections.length > 0) {
-          const mostVisible = visibleSections[0];
-          const link = [...links].find((l) => l.getAttribute('href').endsWith(`#${mostVisible.section.id}`));
-
-          if (link) {
-            links.forEach((l) => l.closest('li').removeAttribute('aria-current'));
-            link.closest('li').setAttribute('aria-current', true);
-
-            // scroll nav into view if sticky on desktop
-            const mobile = !window.matchMedia('(width >= 800px)').matches;
-            const sticky = Math.abs(block.getBoundingClientRect().top) < 1;
-            if (!mobile && sticky) link.scrollIntoView({ behavior: 'smooth', inline: 'center' });
-          }
-        }
-      }, { threshold: [0, 0.25, 0.5, 0.75, 1.0] });
-
-      sectionsToObserve.forEach((section) => sectionObserver.observe(section));
+    if (variants.includes('jump')) {
+      decorateJump(block, ul, row);
+    } else {
+      decorateDefault(block, ul, row);
     }
-
-    wrapper.appendChild(ul);
-    const firstLi = ul.querySelector('li');
-    if (firstLi) firstLi.setAttribute('aria-current', true);
-    nav.appendChild(wrapper);
-    row.prepend(nav);
   }
 }


### PR DESCRIPTION
sets up `jump` as a proper navigation block variant (default with hamburger/desktop sub-rows, jump variant with scroll-spy).

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/why-vitamix
- After: https://nav-block--vitamix--aemsites.aem.page/us/en_us/why-vitamix
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/foundation
- After: https://nav-block--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/foundation