### PR TITLE
fix: navigation block controls margin behavior of surroundings

### DIFF
--- a/blocks/navigation/navigation.css
+++ b/blocks/navigation/navigation.css
@@ -1,6 +1,15 @@
+main > .section:first-of-type {
+  margin-bottom: 0;
+}
+
+main > .section:first-of-type > div:last-child {
+  margin-bottom: 0;
+}
+
 main > .navigation-container.section {
   position: sticky;
   top: var(--header-height);
+  margin-top: 0;
   z-index: 9;
 }
 
@@ -11,10 +20,6 @@ main > .navigation-container.section ~ .section h4,
 main > .navigation-container.section ~ .section h5,
 main > .navigation-container.section ~ .section h6 {
   scroll-margin-top: calc(74px + 1em);
-}
-
-.hero-container + .navigation-container {
-  margin-top: 0;
 }
 
 .navigation-container > .navigation-wrapper {


### PR DESCRIPTION
a bit of an anti-pattern, but given navigation's sticky behavior, having it control the section above it makes the most sense (whether it's hero, banner, or any other block above it). 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/foundation
- After: https://nav-spacing--vitamix--aemsites.aem.network/us/en_us/foundation
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/foundation/about/our-story
- After: https://nav-spacing--vitamix--aemsites.aem.network/us/en_us/foundation/about/our-story