### PR TITLE
WIP: fix: add x-env header to pdp simulation fetch

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1251,7 +1251,18 @@ async function simulatePDPPreview() {
     const corsProxy = 'https://fcors.org/?url=';
     const corsKey = '&key=Mg23N96GgR8O3NjU';
     const fullUrl = `https://main--vitamix--aemsites.aem.network${url}`;
-    return fetch(`${corsProxy}${encodeURIComponent(fullUrl)}${corsKey}`);
+    const { origin } = window.location;
+    const staging = (
+      origin.endsWith('.aem.page')
+      || origin === 'http://localhost:3000'
+      || window.location.search.includes('stage=true')
+    ) && !window.location.search.includes('stage=false');
+
+    return fetch(`${corsProxy}${encodeURIComponent(fullUrl)}${corsKey}`, {
+      headers: {
+        ...(staging ? { 'x-env': 'stage' } : {}),
+      },
+    });
   };
   const { pathname } = new URL(window.location.href);
   const resp = await corsProxyFetch(pathname);


### PR DESCRIPTION
- adds `x-env: stage` when fetching PDP from localhost/aem.page

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/ca/en_us/products/vx1
- After: https://staging-switch--vitamix--aemsites.aem.network/ca/en_us/products/vx1
