### PR TITLE
fix: prefer exact path match in related-recipes

### DIFF
--- a/blocks/related-recipes/related-recipes.js
+++ b/blocks/related-recipes/related-recipes.js
@@ -52,12 +52,16 @@ function findMatchingRecipe(href, data) {
     return data.find((recipe) => recipe.path === pathForMatch);
   }
 
-  // Match base path (without r-ID suffix)
+  // Match base path (without r-ID suffix) — prefer exact over equipment-stripped
+  const exact = data.find((recipe) => {
+    const lastIndex = recipe.path.lastIndexOf('-r');
+    return recipe.path.substring(0, lastIndex) === pathForMatch;
+  });
+  if (exact) return exact;
+
   return data.find((recipe) => {
     const lastIndex = recipe.path.lastIndexOf('-r');
-    const recipePath = recipe.path.substring(0, lastIndex);
-    if (recipePath === pathForMatch) return true;
-    return stripEquipmentSuffix(recipePath) === pathForMatch;
+    return stripEquipmentSuffix(recipe.path.substring(0, lastIndex)) === pathForMatch;
   });
 }
 


### PR DESCRIPTION
**Problem:**
`findMatchingRecipe` used a single `data.find()` pass that treated exact recipe path matches and equipment-suffix-stripped matches as equally valid, so whichever entry appeared first in the index array won

**Proposed solution:** 
fix splits the lookup into two passes: exact match first, equipment-suffix fallback only if no exact match exists

**Test URLs:**
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/meet-5200
- After: https://recipe-exact-match--vitamix--aemsites.aem.page/us/en_us/meet-5200
- Before: https://main--vitamix--aemsites.aem.page/ca/en_us/meet-5200
- After: https://recipe-exact-match--vitamix--aemsites.aem.page/ca/en_us/meet-5200
