### PR TITLE
fix: update cj coupon handling

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -206,7 +206,7 @@ export function getCookies() {
 
 function setAffiliateCoupon() {
   const urlParams = new URLSearchParams(window.location.search);
-  const { cjevent, COUPON } = Object.fromEntries(urlParams);
+  const { cjdata, cjevent, COUPON } = Object.fromEntries(urlParams);
 
   if (cjevent) {
     localStorage.setItem('cjevent', JSON.stringify({ value: cjevent, ts: Date.now() }));
@@ -219,7 +219,8 @@ function setAffiliateCoupon() {
     const { locale, language } = getLocaleAndLanguage();
     if (!(locale === 'ca' && language === 'fr_ca')) {
       const cartUrl = new URL(`https://www.vitamix.com/${locale}/${language}/checkout/cart`);
-      cartUrl.searchParams.set('cjevent', cjevent || '');
+      if (cjdata) cartUrl.searchParams.set('cjdata', cjdata);
+      if (cjevent) cartUrl.searchParams.set('cjevent', cjevent);
       cartUrl.searchParams.set('COUPON', COUPON);
       fetch(cartUrl.toString());
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -206,17 +206,15 @@ export function getCookies() {
 
 function setAffiliateCoupon() {
   const urlParams = new URLSearchParams(window.location.search);
-  const { cjdata, cjevent, COUPON } = Object.fromEntries(urlParams);
+  const { cjevent, COUPON } = Object.fromEntries(urlParams);
 
-  if (!cjdata || !cjevent || !COUPON) return;
+  if (cjevent) {
+    localStorage.setItem('cjevent', JSON.stringify({ value: cjevent, ts: Date.now() }));
+  }
 
-  const { locale, language } = getLocaleAndLanguage();
-  const loginUrl = new URL(`https://www.vitamix.com/${locale}/${language}/checkout/cart`);
-  Object.entries({ cjdata, cjevent, COUPON }).forEach(([key, value]) => {
-    loginUrl.searchParams.set(key, value);
-  });
-
-  fetch(loginUrl.toString());
+  if (COUPON) {
+    sessionStorage.setItem('checkout_coupon_code', COUPON);
+  }
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -217,7 +217,7 @@ function setAffiliateCoupon() {
 
     // TODO: remove once all locales migrate off Magento — applies the coupon to the PHP cart
     const { locale, language } = getLocaleAndLanguage();
-    if (!(locale === 'ca' && language === 'fr_ca')) {
+    if (!EDGE_CHECKOUT_LOCALES.includes(`${locale}/${language}`)) {
       const cartUrl = new URL(`https://www.vitamix.com/${locale}/${language}/checkout/cart`);
       if (cjdata) cartUrl.searchParams.set('cjdata', cjdata);
       if (cjevent) cartUrl.searchParams.set('cjevent', cjevent);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -214,6 +214,15 @@ function setAffiliateCoupon() {
 
   if (COUPON) {
     sessionStorage.setItem('checkout_coupon_code', COUPON);
+
+    // TODO: remove once all locales migrate off Magento — applies the coupon to the PHP cart
+    const { locale, language } = getLocaleAndLanguage();
+    if (!(locale === 'ca' && language === 'fr_ca')) {
+      const cartUrl = new URL(`https://www.vitamix.com/${locale}/${language}/checkout/cart`);
+      cartUrl.searchParams.set('cjevent', cjevent || '');
+      cartUrl.searchParams.set('COUPON', COUPON);
+      fetch(cartUrl.toString());
+    }
   }
 }
 


### PR DESCRIPTION
- Dropped the requirement for all three params (cjdata, cjevent, COUPON) to be present — each is now handled independently, since a CJ link may carry cjevent without a coupon (and vice versa for other affiliate links)
 - cjevent → stored in localStorage as { value, ts } for timestamped attribution window checking
 - COUPON → stored directly into sessionStorage.checkout_coupon_code, which updatePreview() and buildOrderJSON() already read
 - Skips the old PHP /checkout/cart fetch, only on `ca/fr_ca`

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://cj-coupon--vitamix--aemsites.aem.network/
