### PR TITLE
Full cards made into clickable links

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -57,6 +57,22 @@
   text-transform: uppercase;
 }
 
+/* Make the entire captioned card clickable via stretched link */
+.cards li.captioned {
+  position: relative;
+}
+
+.cards li.captioned .card-captioned a[href] {
+  text-decoration: none;
+  color: inherit;
+}
+
+.cards li.captioned .card-captioned a[href]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+
 .cards .card-click {
   cursor: pointer;
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -49,6 +49,8 @@ function setCardDefaults(block, ul, variants) {
       li.classList.add('filled');
     } else if (captioned && !body && !image) {
       li.classList.add('captioned');
+      if (!variants.includes('captioned')) variants.push('captioned');
+      block.classList.add('captioned');
     }
 
     if (body) {
@@ -161,7 +163,7 @@ export default function decorate(block) {
     variants = setCardDefaults(block, ul, variants);
   }
 
-  const clickable = ['knockout', 'articles', 'linked', 'overlay', 'highlight'];
+  const clickable = ['knockout', 'articles', 'linked', 'overlay', 'highlight', 'captioned'];
   if (variants.some((v) => clickable.includes(v))) {
     enableClick(ul);
   }


### PR DESCRIPTION
We needed to make the entire card clickable and not just the text.  

Test URLs:
BEFORE: https://main--vitamix--aemsites.aem.page/us/en_us/drafts/aanness/cards
AFTER: https://card-links--vitamix--aemsites.aem.page/us/en_us/drafts/aanness/cards

BEFORE: https://main--vitamix--aemsites.aem.page/us/en_us/recipes
AFTER: https://card-links--vitamix--aemsites.aem.page/us/en_us/recipes
