### PR TITLE
fix: normalize price for simple products in edge add-to-cart

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -75,6 +75,21 @@ function toggleFixedAddToCart(container) {
 }
 
 /**
+ * Normalize a price into a number for the edge cart line item.
+ * Offers expose a flat numeric price (string or number); simple products
+ * without offers expose the Product Bus shape `{ currency, regular, final }`.
+ * Returns `NaN` if no usable value can be extracted.
+ * @param {string|number|{final?: string|number, regular?: string|number}} value
+ * @returns {number}
+ */
+export function normalizeCartPrice(value) {
+  if (value && typeof value === 'object') {
+    return parseFloat(value.final ?? value.regular);
+  }
+  return parseFloat(value);
+}
+
+/**
  * Checks if a variant is available for sale.
  * @param {Object} variant - The variant object
  * @returns {boolean} True if the variant is available for sale, false otherwise
@@ -212,7 +227,8 @@ export default function renderAddToCart(ph, block, parent) {
       if (window.useEdgeCheckout) {
         const cartApi = (await import('../../scripts/cart.js')).default;
 
-        const { sku: variantSku, price, name } = selectedVariant;
+        const { sku: variantSku, price: rawPrice, name } = selectedVariant;
+        const price = normalizeCartPrice(rawPrice);
 
         // Semantic {id, value} options for the edge cart. The edge cart
         // carries no Magento-specific data — UIDs stay on the Magento side.

--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -227,7 +227,11 @@ export default function renderAddToCart(ph, block, parent) {
       if (window.useEdgeCheckout) {
         const cartApi = (await import('../../scripts/cart.js')).default;
 
-        const { sku: variantSku, price: rawPrice, name } = selectedVariant;
+        const { sku: variantSku, name } = selectedVariant;
+        // Prefer the selected variant's price so variant-specific pricing
+        // wins; fall back to offers[0] for simple products, where
+        // selectedVariant is the parent and has no top-level price.
+        const rawPrice = selectedVariant.price ?? parent.offers?.[0]?.price;
         const price = normalizeCartPrice(rawPrice);
 
         // Semantic {id, value} options for the edge cart. The edge cart

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for blocks/pdp/add-to-cart.js helpers.
+ *
+ * Run with `npm run test:unit`. The setup file registers mocks for aem.js and
+ * scripts.js so this module can be imported without browser bootstrap.
+ */
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeCartPrice, isVariantAvailableForSale } from '../../blocks/pdp/add-to-cart.js';
+import { __setMetadata, __resetMetadata } from './mocks/aem.mjs';
+import { __setOutOfStockSkus, __resetScripts } from './mocks/scripts.mjs';
+
+beforeEach(() => {
+  __resetMetadata();
+  __resetScripts();
+});
+
+test('normalizeCartPrice: numeric string from an offer', () => {
+  assert.equal(normalizeCartPrice('249.95'), 249.95);
+});
+
+test('normalizeCartPrice: number passes through', () => {
+  assert.equal(normalizeCartPrice(249.95), 249.95);
+});
+
+test('normalizeCartPrice: Product Bus price object uses final', () => {
+  assert.equal(
+    normalizeCartPrice({ currency: 'USD', regular: '299.95', final: '249.95' }),
+    249.95,
+  );
+});
+
+test('normalizeCartPrice: falls back to regular when final is missing', () => {
+  assert.equal(
+    normalizeCartPrice({ currency: 'USD', regular: '299.95' }),
+    299.95,
+  );
+});
+
+test('normalizeCartPrice: regression for simple-product NaN bug', () => {
+  // Repro: a simple product with no `offers[]` returns the Product Bus price
+  // object directly. Before the fix this object was passed straight into the
+  // cart item, so `price * qty` evaluated to NaN and the cart rendered "$NaN".
+  const simpleProductPrice = {
+    currency: 'USD',
+    regular: '249.95',
+    final: '249.95',
+  };
+  const normalized = normalizeCartPrice(simpleProductPrice);
+  assert.equal(Number.isNaN(normalized), false);
+  assert.equal(normalized * 2, 499.9);
+});
+
+test('normalizeCartPrice: null returns NaN', () => {
+  assert.equal(Number.isNaN(normalizeCartPrice(null)), true);
+});
+
+test('normalizeCartPrice: undefined returns NaN', () => {
+  assert.equal(Number.isNaN(normalizeCartPrice(undefined)), true);
+});
+
+// --- isVariantAvailableForSale ---------------------------------------------
+
+const inStockVariant = (overrides = {}) => ({
+  sku: 'SKU-1',
+  custom: { managedStock: '1', addToCart: 'Yes', ...overrides },
+});
+
+test('isVariantAvailableForSale: false when page metadata disables add-to-cart', () => {
+  __setMetadata({ addToCart: 'No' });
+  assert.equal(isVariantAvailableForSale(inStockVariant()), false);
+});
+
+test('isVariantAvailableForSale: false when variant.custom.addToCart is "No"', () => {
+  assert.equal(
+    isVariantAvailableForSale(inStockVariant({ addToCart: 'No' })),
+    false,
+  );
+});
+
+test('isVariantAvailableForSale: true when managedStock is "0" (stock not tracked)', () => {
+  // managedStock "0" means stock is not managed — variant is always purchasable,
+  // even if the out-of-stock list happens to include the SKU.
+  __setOutOfStockSkus(['SKU-1']);
+  assert.equal(
+    isVariantAvailableForSale(inStockVariant({ managedStock: '0' })),
+    true,
+  );
+});
+
+test('isVariantAvailableForSale: true when managed stock and SKU is in stock', () => {
+  __setOutOfStockSkus([]);
+  assert.equal(isVariantAvailableForSale(inStockVariant()), true);
+});
+
+test('isVariantAvailableForSale: false when managed stock and SKU is out of stock', () => {
+  __setOutOfStockSkus(['SKU-1']);
+  assert.equal(isVariantAvailableForSale(inStockVariant()), false);
+});
+
+test('isVariantAvailableForSale: page metadata gate wins over variant flags', () => {
+  // Even a fully-available variant must be blocked if the page disables ATC.
+  __setMetadata({ addToCart: 'No' });
+  __setOutOfStockSkus([]);
+  assert.equal(
+    isVariantAvailableForSale(inStockVariant({ managedStock: '0' })),
+    false,
+  );
+});

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -38,15 +38,12 @@ test('normalizeCartPrice: falls back to regular when final is missing', () => {
 });
 
 test('normalizeCartPrice: regression for simple-product NaN bug', () => {
-  // Repro: a simple product with no `offers[]` returns the Product Bus price
-  // object directly. Before the fix this object was passed straight into the
-  // cart item, so `price * qty` evaluated to NaN and the cart rendered "$NaN".
-  const simpleProductPrice = {
-    currency: 'USD',
-    regular: '249.95',
-    final: '249.95',
-  };
-  const normalized = normalizeCartPrice(simpleProductPrice);
+  // Simple products' JSON-LD offer carries a numeric-string `price`. The cart
+  // line item used to receive `undefined` (parent fallback had no `price` and
+  // we weren't reading offers[0].price), serialize as null in localStorage,
+  // and render as "$NaN". After the fix the offer's string price flows in.
+  const offerPrice = '249.95';
+  const normalized = normalizeCartPrice(offerPrice);
   assert.equal(Number.isNaN(normalized), false);
   assert.equal(normalized * 2, 499.9);
 });

--- a/tests/unit/loader.mjs
+++ b/tests/unit/loader.mjs
@@ -1,10 +1,10 @@
 /**
  * Node ESM loader hook for the unit-test runner.
  *
- * Intercepts any import that resolves to `commerce-config.js` and redirects it
- * to tests/unit/mocks/commerce-config.mjs. This lets cart.js (and any other
- * module under test) be imported without pulling in the real config — which
- * depends on browser globals and Helix-specific bootstrapping.
+ * Intercepts imports that pull in browser-only bootstrap code and redirects
+ * them to lightweight mocks under tests/unit/mocks. This lets modules under
+ * test be imported without depending on browser globals or Helix-specific
+ * bootstrapping.
  *
  * Registered from tests/unit/setup.mjs via `module.register`.
  */
@@ -12,11 +12,19 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve as resolvePath } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const mockUrl = pathToFileURL(resolvePath(here, 'mocks/commerce-config.mjs')).href;
+const mockUrl = (file) => pathToFileURL(resolvePath(here, 'mocks', file)).href;
+
+const redirects = [
+  { match: (s) => s === './commerce-config.js' || s.endsWith('/commerce-config.js'), file: 'commerce-config.mjs' },
+  { match: (s) => s.endsWith('/scripts/aem.js'), file: 'aem.mjs' },
+  { match: (s) => s.endsWith('/scripts/scripts.js'), file: 'scripts.mjs' },
+];
 
 export async function resolve(specifier, context, nextResolve) {
-  if (specifier === './commerce-config.js' || specifier.endsWith('/commerce-config.js')) {
-    return { url: mockUrl, shortCircuit: true, format: 'module' };
+  for (const { match, file } of redirects) {
+    if (match(specifier)) {
+      return { url: mockUrl(file), shortCircuit: true, format: 'module' };
+    }
   }
   return nextResolve(specifier, context);
 }

--- a/tests/unit/mocks/aem.mjs
+++ b/tests/unit/mocks/aem.mjs
@@ -1,0 +1,21 @@
+/**
+ * Minimal mock of scripts/aem.js for unit tests.
+ *
+ * The real module performs RUM bootstrapping and DOM queries at import time,
+ * which crashes outside a browser. add-to-cart.js only needs `getMetadata`
+ * from this module; tests can override its return value per-case.
+ */
+
+let metadata = {};
+
+export function __setMetadata(values) {
+  metadata = { ...values };
+}
+
+export function __resetMetadata() {
+  metadata = {};
+}
+
+export function getMetadata(name) {
+  return metadata[name] ?? '';
+}

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -1,0 +1,31 @@
+/**
+ * Minimal mock of scripts/scripts.js for unit tests.
+ *
+ * The real module bootstraps the page at import time, which crashes outside
+ * a browser. add-to-cart.js only needs `checkVariantOutOfStock` and
+ * `getLocaleAndLanguage` from this module.
+ */
+
+let outOfStockSkus = new Set();
+let locale = { locale: 'us', language: 'en_us' };
+
+export function __setOutOfStockSkus(skus) {
+  outOfStockSkus = new Set(skus);
+}
+
+export function __setLocale(value) {
+  locale = { ...value };
+}
+
+export function __resetScripts() {
+  outOfStockSkus = new Set();
+  locale = { locale: 'us', language: 'en_us' };
+}
+
+export function checkVariantOutOfStock(sku) {
+  return outOfStockSkus.has(sku);
+}
+
+export function getLocaleAndLanguage() {
+  return locale;
+}


### PR DESCRIPTION
Fix add to cart for simple products (without a selectedVariant)

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/simply-entertaining-cookbook
- After: https://simple-nan--vitamix--aemsites.aem.network/us/en_us/products/simply-entertaining-cookbook
