### PR TITLE
fix: dont render atc on unavailable for sale products

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -150,6 +150,11 @@ export default function renderAddToCart(ph, block, parent) {
     return renderFindDealer(ph, block);
   }
 
+  // fallback, not available for sale, don't allow add to cart
+  if (!isAvailableForSale) {
+    return '';
+  }
+
   // create main add to cart container
   const addToCartContainer = document.createElement('div');
   addToCartContainer.classList.add('add-to-cart');


### PR DESCRIPTION
dont render the add to cart button when product is unavailable for sale

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/propel-series-410
- After: https://hotfix-na-atc--vitamix--aemsites.aem.network/us/en_us/products/propel-series-410
