### PR TITLE
feat(checkout): add inline field validation

### DIFF
--- a/blocks/checkout/checkout-form.js
+++ b/blocks/checkout/checkout-form.js
@@ -1,4 +1,5 @@
 import { getMetadata } from '../../scripts/aem.js';
+import { attachFieldValidation } from './checkout-validation.js';
 
 const SUBMIT_LOCK_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>';
 
@@ -136,6 +137,8 @@ function buildField(field, namePrefix = '') {
   input.id = fullName;
   if (field.required) input.required = true;
 
+  attachFieldValidation(input);
+
   const label = document.createElement('label');
   label.htmlFor = fullName;
   label.textContent = field.label;
@@ -181,6 +184,8 @@ export default function buildForm(container, config, strings) {
   const form = document.createElement('form');
   form.className = 'checkout-form';
   form.noValidate = true;
+  form.dataset.locale = config.getLocale();
+  form.dataset.lang = (config.getLanguage?.() || 'en').split('_')[0].toLowerCase();
 
   // Express checkout section (populated by checkout-payment.js)
   const expressSection = document.createElement('div');

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -3,6 +3,7 @@ import { collectAddress } from './checkout-address.js';
 import { updatePreview } from './checkout-shipping.js';
 import { FORMS_ENDPOINT, getLocaleAndLanguage } from '../../scripts/scripts.js';
 import { validateLinkIntegrity } from './link-integrity.js';
+import { validateForm } from './checkout-validation.js';
 
 export { validateLinkIntegrity };
 
@@ -196,10 +197,7 @@ export function initOrder(form, cart, state, config, strings) {
       e.preventDefault();
       clearError(form);
 
-      if (!form.checkValidity()) {
-        form.reportValidity();
-        return;
-      }
+      if (!validateForm(form)) return;
 
       if (!state.selectedShippingMethodId) {
         showError(form, strings.errorSelectShipping);

--- a/blocks/checkout/checkout-validation.js
+++ b/blocks/checkout/checkout-validation.js
@@ -1,0 +1,164 @@
+const MESSAGES = {
+  en: {
+    required: 'This field is required.',
+    name: 'Please use only letters, spaces, hyphens, or apostrophes.',
+    street: 'Please use only letters, numbers, and standard address characters (# . , -).',
+    city: 'Please use only letters, spaces, hyphens, or periods.',
+    zip: 'Please enter a valid 5-digit ZIP code.',
+    postalCode: 'Please enter a valid postal code (e.g. A1B 2C3).',
+    phone: 'Please enter a valid 10-digit phone number.',
+    email: 'Please enter a valid email address.',
+  },
+  fr: {
+    required: 'Ce champ est requis.',
+    name: 'Veuillez utiliser uniquement des lettres, espaces, tirets ou apostrophes.',
+    street: "Veuillez utiliser uniquement des lettres, chiffres et caractères d'adresse standard (# . , -).",
+    city: 'Veuillez utiliser uniquement des lettres, espaces, tirets ou points.',
+    zip: 'Veuillez entrer un code postal à 5 chiffres valide.',
+    postalCode: 'Veuillez entrer un code postal valide (ex. A1B 2C3).',
+    phone: 'Veuillez entrer un numéro de téléphone à 10 chiffres valide.',
+    email: 'Veuillez entrer une adresse courriel valide.',
+  },
+};
+
+// Letters (including accented), spaces, hyphens, apostrophes
+const NAME_RE = /^[A-Za-zÀ-ÖØ-öø-ÿ''\- ]+$/;
+// Letters, numbers, spaces, and common address punctuation (#, ., ,, -, /)
+const STREET_RE = /^[A-Za-z0-9 #.,\-/]+$/;
+// Letters (including accented), spaces, hyphens, periods, apostrophes
+const CITY_RE = /^[A-Za-zÀ-ÖØ-öø-ÿ''\-. ]+$/;
+// US ZIP: 5 digits, optional +4, not all zeros
+const ZIP_US_RE = /^\d{5}(-\d{4})?$/;
+// Canadian postal code
+const ZIP_CA_RE = /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i;
+// Basic email
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getMessages(form) {
+  const lang = form?.dataset.lang || 'en';
+  return MESSAGES[lang] || MESSAGES.en;
+}
+
+function showFieldError(input, message) {
+  const wrapper = input.closest('.form-field');
+  if (!wrapper) return;
+  wrapper.classList.add('has-error');
+  let errorEl = wrapper.querySelector('.field-error');
+  if (!errorEl) {
+    errorEl = document.createElement('span');
+    errorEl.className = 'field-error';
+    // Insert after the label so it appears below the input/label stack
+    const label = wrapper.querySelector('label');
+    if (label) label.after(errorEl);
+    else wrapper.appendChild(errorEl);
+  }
+  errorEl.textContent = message;
+  input.setAttribute('aria-invalid', 'true');
+  input.setAttribute('aria-describedby', `${input.id}-error`);
+  errorEl.id = `${input.id}-error`;
+}
+
+export function clearFieldError(input) {
+  const wrapper = input.closest('.form-field');
+  if (!wrapper) return;
+  wrapper.classList.remove('has-error');
+  wrapper.querySelector('.field-error')?.remove();
+  input.removeAttribute('aria-invalid');
+  input.removeAttribute('aria-describedby');
+}
+
+/**
+ * Validates a single form input. Returns an error message string, or null if valid.
+ * Reads locale/language from the ancestor form's dataset.
+ */
+export function validateField(input) {
+  const { name, value, required } = input;
+  const trimmed = value.trim();
+  const isCanada = input.form?.dataset.locale === 'ca';
+  const msgs = getMessages(input.form);
+
+  if (required && !trimmed) return msgs.required;
+  if (!trimmed) return null;
+
+  const baseName = name.replace(/^(shipping-|billing-)/, '');
+
+  switch (baseName) {
+    case 'firstname':
+    case 'lastname':
+      return NAME_RE.test(trimmed) ? null : msgs.name;
+
+    case 'street-0':
+      return STREET_RE.test(trimmed) ? null : msgs.street;
+
+    case 'city':
+      return CITY_RE.test(trimmed) ? null : msgs.city;
+
+    case 'zip': {
+      if (isCanada) return ZIP_CA_RE.test(trimmed) ? null : msgs.postalCode;
+      return ZIP_US_RE.test(trimmed) && trimmed.replace(/\D/g, '') !== '00000' ? null : msgs.zip;
+    }
+
+    case 'telephone': {
+      const digits = trimmed.replace(/\D/g, '');
+      const nanp = digits.length === 11 && digits[0] === '1' ? digits.slice(1) : digits;
+      return nanp.length === 10 ? null : msgs.phone;
+    }
+
+    case 'email':
+      return EMAIL_RE.test(trimmed) ? null : msgs.email;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Attaches blur/input/change validation handlers to a form input or select.
+ */
+export function attachFieldValidation(input) {
+  const isSelect = input.tagName === 'SELECT';
+
+  // Validate on blur (text) or change (select)
+  input.addEventListener(isSelect ? 'change' : 'blur', () => {
+    const error = validateField(input);
+    if (error) showFieldError(input, error);
+    else clearFieldError(input);
+  });
+
+  // Clear error on typing so feedback is immediate
+  if (!isSelect) {
+    input.addEventListener('input', () => {
+      if (input.closest('.form-field')?.classList.contains('has-error')) {
+        clearFieldError(input);
+      }
+    });
+  }
+}
+
+/**
+ * Validates the entire form. Shows inline errors for all invalid fields,
+ * clears errors for valid fields, focuses the first invalid field.
+ * Returns true if the form is valid.
+ */
+export function validateForm(form) {
+  let firstInvalid = null;
+
+  form.querySelectorAll('input, select, textarea').forEach((input) => {
+    if (input.disabled || input.type === 'hidden' || input.type === 'radio' || input.type === 'checkbox') return;
+
+    const error = validateField(input);
+    if (error) {
+      showFieldError(input, error);
+      if (!firstInvalid) firstInvalid = input;
+    } else {
+      clearFieldError(input);
+    }
+  });
+
+  if (firstInvalid) {
+    firstInvalid.focus();
+    firstInvalid.closest('.form-section')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  return !firstInvalid;
+}

--- a/blocks/checkout/checkout-validation.js
+++ b/blocks/checkout/checkout-validation.js
@@ -2,7 +2,7 @@ const MESSAGES = {
   en: {
     required: 'This field is required.',
     name: 'Please use only letters, spaces, hyphens, or apostrophes.',
-    street: 'Please use only letters, numbers, and standard address characters (# . , -).',
+    street: 'Please use only letters, numbers, and standard address characters (. , -).',
     city: 'Please use only letters, spaces, hyphens, or periods.',
     zip: 'Please enter a valid 5-digit ZIP code.',
     postalCode: 'Please enter a valid postal code (e.g. A1B 2C3).',
@@ -12,7 +12,7 @@ const MESSAGES = {
   fr: {
     required: 'Ce champ est requis.',
     name: 'Veuillez utiliser uniquement des lettres, espaces, tirets ou apostrophes.',
-    street: "Veuillez utiliser uniquement des lettres, chiffres et caractères d'adresse standard (# . , -).",
+    street: "Veuillez utiliser uniquement des lettres, chiffres et caractères d'adresse standard (. , -).",
     city: 'Veuillez utiliser uniquement des lettres, espaces, tirets ou points.',
     zip: 'Veuillez entrer un code postal à 5 chiffres valide.',
     postalCode: 'Veuillez entrer un code postal valide (ex. A1B 2C3).',
@@ -23,8 +23,8 @@ const MESSAGES = {
 
 // Letters (including accented), spaces, hyphens, apostrophes
 const NAME_RE = /^[A-Za-zÀ-ÖØ-öø-ÿ''\- ]+$/;
-// Letters, numbers, spaces, and common address punctuation (#, ., ,, -, /)
-const STREET_RE = /^[A-Za-z0-9 #.,\-/]+$/;
+// Letters, numbers, spaces, and common address punctuation (., ,, -, /)
+const STREET_RE = /^[A-Za-z0-9 .,\-/]+$/;
 // Letters (including accented), spaces, hyphens, periods, apostrophes
 const CITY_RE = /^[A-Za-zÀ-ÖØ-öø-ÿ''\-. ]+$/;
 // US ZIP: 5 digits, optional +4, not all zeros

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -235,6 +235,19 @@ main > .section:has(.checkout-wrapper) {
   border-color: var(--commerce-input-border-focus);
 }
 
+.floating-label-field.has-error input,
+.floating-label-field.has-error select,
+.floating-label-field.has-error textarea {
+  border-color: var(--commerce-color-error, #c00);
+}
+
+.field-error {
+  display: block;
+  color: var(--commerce-color-error, #c00);
+  font-size: 0.7rem;
+  margin-top: 4px;
+}
+
 .floating-label-field input:-webkit-autofill,
 .floating-label-field input:-webkit-autofill:hover,
 .floating-label-field input:-webkit-autofill:focus {


### PR DESCRIPTION
Replaces the browser's native reportValidity() popup with per-field inline error messages shown on blur. Introduces checkout-validation.js with the following rules:

- firstname/lastname: letters, spaces, hyphens, apostrophes, accented chars — allows names like O'Brien and Mary-Jane
- street-0: letters, numbers, spaces, and common address punctuation (., ,, -, /) — allows 6559 Rosewood Trl 3A
- city: letters, spaces, hyphens, periods, accented chars
- zip (US): 5-digit ZIP, optional +4 extension, rejects all-zeros
- zip (CA): standard Canadian postal code pattern
- telephone (optional): 10 NANP digits; skipped when empty
- email: basic format check

Fix #460 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://checkout-validation--vitamix--aemsites.aem.network/
