### PR TITLE
fix: preserve quantity selection when switching product variants

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -1,5 +1,6 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { checkVariantOutOfStock, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getConfig } from '../../scripts/commerce-config.js';
 
 /**
  * Renders "Find Locally" button container.
@@ -184,8 +185,9 @@ export default function renderAddToCart(ph, block, parent) {
   const quantitySelect = document.createElement('select');
   quantitySelect.id = 'pdp-quantity-select';
 
-  // set maximum quantity (default to 3 if not specified)
-  const maxQuantity = custom.maxCartQty ? +custom.maxCartQty : 3;
+  // per-product override (custom.maxCartQty) wins, otherwise use the global
+  // commerce-config default
+  const maxQuantity = custom.maxCartQty ? +custom.maxCartQty : (getConfig().maxCartQty || 3);
 
   // populate quantity dropdown with options from 1 to maxQuantity
   for (let i = 1; i <= maxQuantity; i += 1) {

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -28,6 +28,7 @@ const defaults = {
   },
   currency: (locale) => (locale === 'ca' ? 'CAD' : 'USD'),
   cardProvider: 'chase',
+  maxCartQty: 3,
   getFraudToken() {
     try { return sessionStorage.getItem('forter_token') || undefined; } catch { return undefined; }
   },

--- a/scripts/commerce/cart-item.js
+++ b/scripts/commerce/cart-item.js
@@ -1,5 +1,5 @@
 import { loadCSS, createOptimizedPicture } from '../aem.js';
-import { formatPrice } from '../commerce-config.js';
+import { formatPrice, getConfig } from '../commerce-config.js';
 
 loadCSS('/scripts/commerce/cart-item.css');
 
@@ -33,6 +33,12 @@ export default function buildCartItem(item, {
 }, strings = {}) {
   const { remove = 'Remove', removeItem = 'Remove item' } = strings;
 
+  // Per-item override (custom.maxCartQty) takes precedence over the global
+  // commerce-config default.
+  const configMax = getConfig().maxCartQty;
+  const itemMax = item.custom?.maxCartQty != null ? +item.custom.maxCartQty : null;
+  const maxQty = itemMax || configMax || Infinity;
+
   const el = document.createElement('div');
   el.className = `cart-item cart-item-${item.sku}`;
   el.innerHTML = /* html */`
@@ -42,7 +48,7 @@ export default function buildCartItem(item, {
       <div class="cart-item-actions">
         <div class="cart-item-qty-control">
           <button class="qty-dec" aria-label="Decrease quantity">&ndash;</button>
-          <input class="qty-input" type="number" value="1" min="1">
+          <input class="qty-input" type="number" value="1" min="1"${Number.isFinite(maxQty) ? ` max="${maxQty}"` : ''}>
           <button class="qty-inc" aria-label="Increase quantity">+</button>
         </div>
       </div>
@@ -97,6 +103,12 @@ export default function buildCartItem(item, {
   // Qty
   const qtyInput = el.querySelector('.qty-input');
   qtyInput.value = item.quantity;
+  const incBtn = el.querySelector('.qty-inc');
+
+  const syncIncDisabled = (qty) => {
+    incBtn.disabled = qty >= maxQty;
+  };
+  syncIncDisabled(item.quantity);
 
   const handleQtyChange = (newQty) => {
     if (newQty < 1) {
@@ -104,13 +116,15 @@ export default function buildCartItem(item, {
       el.remove();
       return;
     }
-    qtyInput.value = newQty;
-    updatePrice(newQty);
-    onQtyChange(item.sku, newQty);
+    const clamped = Math.min(newQty, maxQty);
+    qtyInput.value = clamped;
+    updatePrice(clamped);
+    syncIncDisabled(clamped);
+    onQtyChange(item.sku, clamped);
   };
 
   el.querySelector('.qty-dec').addEventListener('click', () => handleQtyChange(+qtyInput.value - 1));
-  el.querySelector('.qty-inc').addEventListener('click', () => handleQtyChange(+qtyInput.value + 1));
+  incBtn.addEventListener('click', () => handleQtyChange(+qtyInput.value + 1));
   qtyInput.addEventListener('change', (e) => handleQtyChange(+e.target.value));
 
   el.querySelector('.cart-item-remove').addEventListener('click', (ev) => {


### PR DESCRIPTION
When switching color variants on the PDP, onOptionChange re-rendered the add-to-cart section with the quantity selector reset to 1. If the user had selected qty 3 and then switched colors, clicking Add to Cart would add qty 1 instead, causing the mini-cart badge to increment by 1 regardless of the chosen quantity.

- options.js: read the current qty before replacing the add-to-cart container and restore it on the new selector after the swap
- add-to-cart.js: read qty from the closed-over quantitySelect element instead of a document-wide querySelector

Fix #463

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://qty-limit-config--vitamix--aemsites.aem.network/
