### PR TITLE
feat(cart-summary): render authored terms link below checkout button

### DIFF
--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -390,6 +390,23 @@ dialog.paypal-not-configured-dialog::backdrop {
   box-sizing: border-box;
 }
 
+/* Terms link below checkout button */
+.cart-summary-terms {
+  margin-top: 12px;
+  margin-bottom: 0;
+  text-align: center;
+  font-size: var(--commerce-font-size-sm);
+}
+
+.cart-summary-terms a {
+  color: var(--commerce-color-text-muted);
+  text-decoration: underline;
+}
+
+.cart-summary-terms a:hover {
+  color: var(--commerce-color-text);
+}
+
 /* Loading state */
 .cart-summary-content.loading {
   position: relative;

--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -126,6 +126,12 @@ export default async function decorate(block) {
   const config = getConfig();
   const s = getStrings();
 
+  // Capture any authored link (e.g. Terms and Conditions) before innerHTML is replaced
+  const authoredLink = block.querySelector('a');
+  const termsLink = authoredLink
+    ? { href: authoredLink.href, text: authoredLink.textContent.trim() }
+    : null;
+
   // 1. Colocate with the cart section for two-column CSS layout
   colocateWithCart(block);
   block.innerHTML = buildTemplate(s);
@@ -145,6 +151,17 @@ export default async function decorate(block) {
   // 2. Set checkout href and currency
   checkoutBtn.href = config.getOrderPath('checkout');
   currencyEl.textContent = getCurrencyCode();
+
+  // Render terms link below the checkout button if authored
+  if (termsLink) {
+    const termsEl = document.createElement('p');
+    termsEl.className = 'cart-summary-terms';
+    const a = document.createElement('a');
+    a.href = termsLink.href;
+    a.textContent = termsLink.text;
+    termsEl.appendChild(a);
+    checkoutBtn.insertAdjacentElement('afterend', termsEl);
+  }
 
   // 3. Bind cart:change to keep totals in sync
   const updateTotals = () => {


### PR DESCRIPTION
Adds support for displaying a terms link directly below the checkout button in the cart summary. Legal requested this placement in addition to the existing footer link.

The feature is opt-in and customer-agnostic: authors add a hyperlink row to the `Cart Summary` block in the document. If no link is authored, nothing renders. No Vitamix-specific code.

**Authoring example:**

| Cart Summary |
|---|
| [Terms and Conditions of Sale](https://www.vitamix.com/us/en_us/terms) |

fix: #466  

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/order/cart
- After: https://cart-summary-terms-link--vitamix--aemsites.aem.network/us/en_us/order/cart