### PR TITLE
feat(order-cancel): add dedicated cancel block with i18n

### DIFF
--- a/blocks/order-cancel/order-cancel.css
+++ b/blocks/order-cancel/order-cancel.css
@@ -1,0 +1,47 @@
+.section > .order-cancel-wrapper {
+  margin-top: 32px;
+}
+
+.order-cancel-result {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 80px 24px 64px;
+  text-align: center;
+}
+
+.order-cancel-icon {
+  margin-bottom: 24px;
+  color: #c62828;
+}
+
+.order-cancel-result h2 {
+  margin: 0 0 12px;
+  font-size: 28px;
+}
+
+.order-cancel-reason {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: #333;
+}
+
+.order-cancel-detail {
+  margin: 0 0 32px;
+  font-size: 14px;
+  color: #777;
+}
+
+.order-cancel-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+@media (width >= 480px) {
+  .order-cancel-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}

--- a/blocks/order-cancel/order-cancel.js
+++ b/blocks/order-cancel/order-cancel.js
@@ -1,0 +1,81 @@
+import { getConfig } from '../../scripts/commerce-config.js';
+
+/**
+ * Order cancellation page block.
+ *
+ * Rendered when a payment processor redirects back to /{locale}/{language}/order/cancel
+ * after a user-initiated cancellation or a payment failure.
+ *
+ * Expected URL parameters:
+ *   reason  – one of: customer_cancelled | payment_failed | declined
+ *   message – optional human-readable message from the payment processor
+ *   orderId – optional, for display / future use
+ *
+ * Payment processors and what they send on cancel:
+ *   Chase (card)  → reason=declined | payment_failed
+ *   PayPal        → reason=customer_cancelled (user dismissed sheet)
+ *                   reason=payment_failed     (processor error)
+ *   Apple Pay     → reason=customer_cancelled (user cancelled sheet)
+ *   Affirm        → reason=customer_cancelled | payment_failed
+ */
+export default async function decorate(block) {
+  const config = getConfig();
+  const strings = config.getStrings();
+  const params = Object.fromEntries(new URLSearchParams(window.location.search).entries());
+
+  const reason = params.reason || '';
+  const processorMessage = params.message || '';
+
+  let bodyText;
+  if (reason === 'customer_cancelled') {
+    bodyText = strings.cancelCustomerCancelled;
+  } else if (reason === 'declined') {
+    bodyText = strings.cancelDeclined;
+  } else {
+    bodyText = strings.cancelPaymentFailed;
+  }
+
+  const container = document.createElement('div');
+  container.className = 'order-cancel-result';
+
+  const icon = document.createElement('div');
+  icon.className = 'order-cancel-icon';
+  icon.innerHTML = '<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg>';
+  container.appendChild(icon);
+
+  const heading = document.createElement('h2');
+  heading.textContent = strings.cancelHeading;
+  container.appendChild(heading);
+
+  const msg = document.createElement('p');
+  msg.className = 'order-cancel-reason';
+  msg.textContent = bodyText;
+  container.appendChild(msg);
+
+  // Show the processor's own message when present and different from our mapped text.
+  if (processorMessage && processorMessage !== bodyText) {
+    const detail = document.createElement('p');
+    detail.className = 'order-cancel-detail';
+    detail.textContent = processorMessage;
+    container.appendChild(detail);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'order-cancel-actions';
+
+  const returnLink = document.createElement('a');
+  returnLink.href = config.getOrderPath('checkout');
+  returnLink.className = 'button emphasis';
+  returnLink.textContent = strings.cancelReturnToCheckout;
+  actions.appendChild(returnLink);
+
+  const shopLink = document.createElement('a');
+  shopLink.href = `/${config.getLocale()}/${config.getLanguage()}`;
+  shopLink.className = 'button secondary';
+  shopLink.textContent = strings.continueShopping;
+  actions.appendChild(shopLink);
+
+  container.appendChild(actions);
+
+  block.replaceChildren(container);
+}

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -52,13 +52,11 @@ const defaults = {
       or: 'or',
       orderSummary: 'Order summary',
       discountPlaceholder: 'Discount code or gift card',
-<<<<<<< worktree-order-cancel-block
       cancelHeading: 'Payment not completed',
       cancelCustomerCancelled: 'You cancelled the payment.',
       cancelPaymentFailed: 'Your payment could not be processed. Please try again.',
       cancelDeclined: 'Your payment was declined. Please try a different payment method.',
       cancelReturnToCheckout: 'Return to checkout',
-=======
       orderPaymentNotCompleted: 'Payment not completed',
       orderPaymentCancelled: 'You cancelled the payment.',
       orderPaymentFailed: 'Payment could not be processed. Please try again.',
@@ -71,7 +69,6 @@ const defaults = {
       orderTax: 'Tax',
       orderShippingAddress: 'Shipping address',
       orderContact: 'Contact',
->>>>>>> staginguat
     },
     'fr-ca': {
       stepCart: 'Panier',
@@ -92,13 +89,11 @@ const defaults = {
       or: 'ou',
       orderSummary: 'Récapitulatif de commande',
       discountPlaceholder: 'Code de réduction ou carte-cadeau',
-<<<<<<< worktree-order-cancel-block
       cancelHeading: 'Paiement non effectué',
       cancelCustomerCancelled: 'Vous avez annulé le paiement.',
       cancelPaymentFailed: "Votre paiement n'a pas pu être traité. Veuillez réessayer.",
       cancelDeclined: 'Votre paiement a été refusé. Veuillez essayer un autre mode de paiement.',
       cancelReturnToCheckout: 'Retourner à la caisse',
-=======
       orderPaymentNotCompleted: 'Paiement non complété',
       orderPaymentCancelled: 'Vous avez annulé le paiement.',
       orderPaymentFailed: 'Le paiement n\'a pas pu être traité. Veuillez réessayer.',
@@ -111,7 +106,6 @@ const defaults = {
       orderTax: 'Taxe',
       orderShippingAddress: 'Adresse de livraison',
       orderContact: 'Contact',
->>>>>>> staginguat
     },
   },
   getStrings() {

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -51,6 +51,11 @@ const defaults = {
       or: 'or',
       orderSummary: 'Order summary',
       discountPlaceholder: 'Discount code or gift card',
+      cancelHeading: 'Payment not completed',
+      cancelCustomerCancelled: 'You cancelled the payment.',
+      cancelPaymentFailed: 'Your payment could not be processed. Please try again.',
+      cancelDeclined: 'Your payment was declined. Please try a different payment method.',
+      cancelReturnToCheckout: 'Return to checkout',
     },
     'fr-ca': {
       stepCart: 'Panier',
@@ -71,6 +76,11 @@ const defaults = {
       or: 'ou',
       orderSummary: 'Récapitulatif de commande',
       discountPlaceholder: 'Code de réduction ou carte-cadeau',
+      cancelHeading: 'Paiement non effectué',
+      cancelCustomerCancelled: 'Vous avez annulé le paiement.',
+      cancelPaymentFailed: "Votre paiement n'a pas pu être traité. Veuillez réessayer.",
+      cancelDeclined: 'Votre paiement a été refusé. Veuillez essayer un autre mode de paiement.',
+      cancelReturnToCheckout: 'Retourner à la caisse',
     },
   },
   getStrings() {


### PR DESCRIPTION
Adds `blocks/order-cancel` to replace the `order-summary` block that was rendering on the `/order/cancel` route.

- Reads `?reason=` (`customer_cancelled` | `payment_failed` | `declined`) and optional `?message=` from the payment-processor redirect URL
- Maps reason codes to localized copy via `config.getStrings()` — covers `en-us` and `fr-ca`
- Shows primary "Return to checkout" CTA and secondary "Continue shopping" link
- Adds cancel string keys to `commerce-config.js` for both locales

Payment processors covered: Chase (card), PayPal, Apple Pay, Affirm.

fix: #470 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://worktree-order-cancel-block--vitamix--aemsites.aem.network/