### PR TITLE
fix(cart): remove duplicate Pay Later button in express checkout

### DIFF
--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -303,18 +303,6 @@ export default {
     };
 
     window.paypal.Buttons(buttonConfig).render(container);
-
-    const payLaterBtn = window.paypal.Buttons({
-      ...buttonConfig,
-      fundingSource: window.paypal.FUNDING.PAYLATER,
-      style: { ...buttonConfig.style, color: 'silver' },
-    });
-    if (payLaterBtn.isEligible()) {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'paypal-paylater-wrapper';
-      container.appendChild(wrapper);
-      payLaterBtn.render(wrapper);
-    }
   },
 
   renderCheckoutButton(container, callbacks) {

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -574,7 +574,6 @@ test.describe('button style config', () => {
     expect(BASE_STYLE.label).toBe('paypal');
     expect(BASE_STYLE.layout).toBe('horizontal');
   });
-
 });
 
 // Pay Later is included automatically by the horizontal layout when eligible

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -575,38 +575,10 @@ test.describe('button style config', () => {
     expect(BASE_STYLE.layout).toBe('horizontal');
   });
 
-  test('Pay Later button overrides color to silver and label to pay_later', () => {
-    const payLaterStyle = { ...BASE_STYLE, color: 'silver', label: 'pay_later' };
-    expect(payLaterStyle.color).toBe('silver');
-    expect(payLaterStyle.label).toBe('pay_later');
-    expect(payLaterStyle.layout).toBe('horizontal');
-  });
 });
 
-// ---------------------------------------------------------------------------
-// Pay Later eligibility
-// ---------------------------------------------------------------------------
-
-test.describe('Pay Later eligibility', () => {
-  function makePaypalMock(isEligible) {
-    return {
-      Buttons: () => ({ isEligible: () => isEligible, render: () => {} }),
-      FUNDING: { PAYLATER: 'paylater' },
-    };
-  }
-
-  test('renders Pay Later button when isEligible() returns true', () => {
-    const paypal = makePaypalMock(true);
-    const btn = paypal.Buttons({ fundingSource: paypal.FUNDING.PAYLATER });
-    expect(btn.isEligible()).toBe(true);
-  });
-
-  test('does not render Pay Later button when isEligible() returns false', () => {
-    const paypal = makePaypalMock(false);
-    const btn = paypal.Buttons({ fundingSource: paypal.FUNDING.PAYLATER });
-    expect(btn.isEligible()).toBe(false);
-  });
-});
+// Pay Later is included automatically by the horizontal layout when eligible
+// (via enable-funding=paylater in the SDK URL) — no separate button is rendered.
 
 // ---------------------------------------------------------------------------
 // Stub fallback (no window.paypal)


### PR DESCRIPTION
The horizontal layout renders Pay Later inline when eligible — a separate explicit `PAYLATER` button was also being rendered, causing it to appear twice in markets where Pay Later is eligible (e.g. US).

fix: #462 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-duplicate-paylater-button--vitamix--aemsites.aem.network/