### PR TITLE
fix(pdp): preserve selected qty when switching color variant

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -192,7 +192,7 @@ export default function renderAddToCart(ph, block, parent) {
     addToCartButton.setAttribute('aria-disabled', 'true');
 
     // get selected quantity and product SKU
-    const quantity = document.querySelector('.quantity-container select')?.value || 1;
+    const quantity = quantitySelect.value || 1;
     const sku = getMetadata('sku');
 
     // build array of selected options (variants, warranties, required bundles)

--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -134,10 +134,15 @@ export function onOptionChange(ph, block, variants, color, isParentOutOfStock = 
 
   window.selectedVariant = variant;
 
-  // update add to cart
+  // update add to cart, preserving the user's current quantity selection
+  const currentQty = block.querySelector('.quantity-container select')?.value;
   const addToCartContainer = renderAddToCart(ph, block, window.jsonLdData);
   if (addToCartContainer) {
     block.querySelector('.add-to-cart').replaceWith(addToCartContainer);
+    if (currentQty) {
+      const newQtySelect = addToCartContainer.querySelector('.quantity-container select');
+      if (newQtySelect) newQtySelect.value = currentQty;
+    }
   }
 }
 


### PR DESCRIPTION
When switching color variants on the PDP, onOptionChange re-rendered the add-to-cart section with the quantity selector reset to 1. If the user had selected qty 3 and then switched colors, clicking Add to Cart would add qty 1 instead, causing the mini-cart badge to increment by 1 regardless of the chosen quantity.

- options.js: read the current qty before replacing the add-to-cart container and restore it on the new selector after the swap
- add-to-cart.js: read qty from the closed-over quantitySelect element instead of a document-wide querySelector

Fix #464 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://worktree-minicart-qty-badge--vitamix--aemsites.aem.network/