### PR TITLE
chore: update sitekey to be for vitamix stage (test mode)

### DIFF
--- a/scripts/recaptcha.js
+++ b/scripts/recaptcha.js
@@ -1,5 +1,6 @@
 import { loadScript } from './aem.js';
 
+import { isEdgeHost, isProdHost } from './scripts.js';
 /**
  * Google reCAPTCHA Enterprise integration for the protected unauthenticated
  * write endpoints on the Commerce API:
@@ -17,9 +18,11 @@ import { loadScript } from './aem.js';
  * reCAPTCHA Enterprise site key. Public — safe to expose client-side.
  *
  * Empty string disables the integration (graceful degradation).
+ * Edge/stage hosts (localhost, UAT, integration) use the stage key;
+ * production vitamix.com uses the live key.
  */
-// TODO: Sitekey for api-stage only for Vitamix.
-export const RECAPTCHA_SITE_KEY = '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9';
+// eslint-disable-next-line no-nested-ternary
+export const RECAPTCHA_SITE_KEY = isProdHost ? '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9' : (isEdgeHost ? '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9' : '');
 
 /** Action name constants mirroring the server's RECAPTCHA_ACTIONS. */
 export const RECAPTCHA_ACTIONS = Object.freeze({

--- a/scripts/recaptcha.js
+++ b/scripts/recaptcha.js
@@ -1,6 +1,6 @@
 import { loadScript } from './aem.js';
 
-import { isEdgeHost, isProdHost } from './scripts.js';
+import { isProdHost } from './scripts.js';
 /**
  * Google reCAPTCHA Enterprise integration for the protected unauthenticated
  * write endpoints on the Commerce API:

--- a/scripts/recaptcha.js
+++ b/scripts/recaptcha.js
@@ -22,7 +22,7 @@ import { isEdgeHost, isProdHost } from './scripts.js';
  * production vitamix.com uses the live key.
  */
 // eslint-disable-next-line no-nested-ternary
-export const RECAPTCHA_SITE_KEY = isProdHost ? '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9' : (isEdgeHost ? '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9' : '');
+export const RECAPTCHA_SITE_KEY = isProdHost ? '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9' : '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9';
 
 /** Action name constants mirroring the server's RECAPTCHA_ACTIONS. */
 export const RECAPTCHA_ACTIONS = Object.freeze({

--- a/scripts/recaptcha.js
+++ b/scripts/recaptcha.js
@@ -19,7 +19,7 @@ import { loadScript } from './aem.js';
  * Empty string disables the integration (graceful degradation).
  */
 // TODO: Sitekey for api-stage only for Vitamix.
-export const RECAPTCHA_SITE_KEY = '6LfaNtosAAAAABpYKw5c-zu9FWjxxfZJDpVu4JjG';
+export const RECAPTCHA_SITE_KEY = '6LcITfcsAAAAADNTZV_Y2sKZAvdQa38GX4s29gS9';
 
 /** Action name constants mirroring the server's RECAPTCHA_ACTIONS. */
 export const RECAPTCHA_ACTIONS = Object.freeze({

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -24,8 +24,8 @@ const { hostname } = window.location;
 // Format: '<locale>/<language>' (e.g., 'ca/fr_ca'). Add pairs as each region goes live.
 const EDGE_CHECKOUT_LOCALES = ['ca/fr_ca', 'ca/en_us', 'us/en_us'];
 
-const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-accounts') || hostname.includes('edge-orders') || hostname.includes('integration.vitamix.com') || hostname.includes('uat.vitamix.com');
-const isProdHost = hostname.includes('vitamix.com');
+export const isEdgeHost = hostname.includes('localhost') || hostname.includes('edge-accounts') || hostname.includes('edge-orders') || hostname.includes('integration.vitamix.com') || hostname.includes('uat.vitamix.com');
+export const isProdHost = hostname.includes('vitamix.com');
 
 // Affirm public API key — safe to expose client-side (used for PDP promo widgets).
 // Checkout gets its key from the server's checkout object so it always matches the


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://recaptcha-preview-error--vitamix--aemsites.aem.network/
