### PR TITLE
fix(checkout-progress): correct cart link and confirmation step styling

### DIFF
--- a/blocks/checkout-progress/checkout-progress.js
+++ b/blocks/checkout-progress/checkout-progress.js
@@ -1,7 +1,7 @@
 import { loadCSS } from '../../scripts/aem.js';
 import { getConfig } from '../../scripts/commerce-config.js';
 
-const STEP_KEYS = ['cart-new', 'checkout', 'complete'];
+const STEP_KEYS = ['cart', 'checkout', 'complete'];
 
 export default async function decorate(block) {
   await loadCSS('/styles/commerce-tokens.css');
@@ -10,7 +10,7 @@ export default async function decorate(block) {
   const currentPath = window.location.pathname;
 
   const steps = [
-    { key: 'cart-new', label: s.stepCart },
+    { key: 'cart', label: s.stepCart },
     { key: 'checkout', label: s.stepCheckout },
     { key: 'complete', label: s.stepConfirmation },
   ];
@@ -26,7 +26,7 @@ export default async function decorate(block) {
   steps.forEach(({ key, label }, i) => {
     const li = document.createElement('li');
     li.className = 'step';
-    li.classList.add(`step-${key}`);
+    li.classList.add(`step-page-${key}`);
 
     if (i < activeIndex) {
       li.classList.add('step-complete');


### PR DESCRIPTION
The cart step key was 'cart-new', causing the link to route to /order/cart-new instead of /order/cart. The step-${key} class for the 'complete' step generated step-complete, which collided with the CSS class used to style past steps with a checkmark — making confirmation always appear completed. Changed the per-step identifier class to step-page-${key} to avoid the collision.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://checkout-progress--vitamix--aemsites.aem.network/
