### PR TITLE
fix(cart): correct order summary subtotal dividing price by 100

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -76,18 +76,17 @@ function toggleFixedAddToCart(container) {
 }
 
 /**
- * Normalize a price into a number for the edge cart line item.
- * Offers expose a flat numeric price (string or number); simple products
+ * Normalize a price into a string for the edge cart line item.
+ * Offers expose a flat price (string or number); simple products
  * without offers expose the Product Bus shape `{ currency, regular, final }`.
- * Returns `NaN` if no usable value can be extracted.
  * @param {string|number|{final?: string|number, regular?: string|number}} value
- * @returns {number}
+ * @returns {string}
  */
 export function normalizeCartPrice(value) {
   if (value && typeof value === 'object') {
-    return parseFloat(value.final ?? value.regular);
+    return String(value.final ?? value.regular);
   }
-  return parseFloat(value);
+  return String(value);
 }
 
 /**

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -108,9 +108,7 @@ export class Cart {
 
   get subtotal() {
     return this.#items.reduce(
-      (acc, item) => acc + item.quantity * (typeof item.price === 'string'
-        ? parseFloat(item.price)
-        : item.price / 100),
+      (acc, item) => acc + item.quantity * parseFloat(item.price),
       0,
     );
   }

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -15,45 +15,38 @@ beforeEach(() => {
   __resetScripts();
 });
 
-test('normalizeCartPrice: numeric string from an offer', () => {
-  assert.equal(normalizeCartPrice('249.95'), 249.95);
+test('normalizeCartPrice: numeric string from an offer passes through', () => {
+  assert.equal(normalizeCartPrice('249.95'), '249.95');
 });
 
-test('normalizeCartPrice: number passes through', () => {
-  assert.equal(normalizeCartPrice(249.95), 249.95);
+test('normalizeCartPrice: number is coerced to string', () => {
+  assert.equal(normalizeCartPrice(249.95), '249.95');
 });
 
 test('normalizeCartPrice: Product Bus price object uses final', () => {
   assert.equal(
     normalizeCartPrice({ currency: 'USD', regular: '299.95', final: '249.95' }),
-    249.95,
+    '249.95',
   );
 });
 
 test('normalizeCartPrice: falls back to regular when final is missing', () => {
   assert.equal(
     normalizeCartPrice({ currency: 'USD', regular: '299.95' }),
-    299.95,
+    '299.95',
   );
 });
 
-test('normalizeCartPrice: regression for simple-product NaN bug', () => {
-  // Simple products' JSON-LD offer carries a numeric-string `price`. The cart
-  // line item used to receive `undefined` (parent fallback had no `price` and
-  // we weren't reading offers[0].price), serialize as null in localStorage,
-  // and render as "$NaN". After the fix the offer's string price flows in.
-  const offerPrice = '249.95';
-  const normalized = normalizeCartPrice(offerPrice);
-  assert.equal(Number.isNaN(normalized), false);
-  assert.equal(normalized * 2, 499.9);
+test('normalizeCartPrice: preserves decimal precision without parseFloat roundtrip', () => {
+  assert.equal(normalizeCartPrice('449.90'), '449.90');
 });
 
-test('normalizeCartPrice: null returns NaN', () => {
-  assert.equal(Number.isNaN(normalizeCartPrice(null)), true);
+test('normalizeCartPrice: null returns "null"', () => {
+  assert.equal(normalizeCartPrice(null), 'null');
 });
 
-test('normalizeCartPrice: undefined returns NaN', () => {
-  assert.equal(Number.isNaN(normalizeCartPrice(undefined)), true);
+test('normalizeCartPrice: undefined returns "undefined"', () => {
+  assert.equal(normalizeCartPrice(undefined), 'undefined');
 });
 
 // --- isVariantAvailableForSale ---------------------------------------------

--- a/tests/unit/cart.test.js
+++ b/tests/unit/cart.test.js
@@ -171,11 +171,10 @@ test('subtotal multiplies quantity by string price', () => {
   assert.equal(cart.subtotal, 36.5);
 });
 
-test('subtotal treats numeric price as integer cents', () => {
+test('subtotal handles numeric price the same as string price', () => {
   const cart = new Cart();
-  // 1099 cents = $10.99
-  cart.addItem(sampleItem({ sku: 'foo', quantity: 2, price: 1099 }));
-  assert.equal(cart.subtotal, 21.98);
+  cart.addItem(sampleItem({ sku: 'foo', quantity: 2, price: 449.95 }));
+  assert.equal(cart.subtotal, 899.9);
 });
 
 // --- toJSON / persistence shape --------------------------------------------


### PR DESCRIPTION
cart.subtotal was dividing numeric prices by 100, treating dollar amounts as cents — introduced when normalizeCartPrice started returning numbers instead of strings. normalizeCartPrice now returns a String so prices enter the cart losslessly; subtotal uses parseFloat unconditionally.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://subtotal-fix--vitamix--aemsites.aem.network/
