### PR TITLE
fix(cart): correct subtotal price — always parse as dollars not cents

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -85,9 +85,9 @@ function toggleFixedAddToCart(container) {
  */
 export function normalizeCartPrice(value) {
   if (value && typeof value === 'object') {
-    return parseFloat(value.final ?? value.regular);
+    return String(value.final ?? value.regular);
   }
-  return parseFloat(value);
+  return String(value);
 }
 
 /**

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -108,9 +108,7 @@ export class Cart {
 
   get subtotal() {
     return this.#items.reduce(
-      (acc, item) => acc + item.quantity * (typeof item.price === 'string'
-        ? parseFloat(item.price)
-        : item.price / 100),
+      (acc, item) => acc + item.quantity * parseFloat(item.price),
       0,
     );
   }

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -16,24 +16,24 @@ beforeEach(() => {
 });
 
 test('normalizeCartPrice: numeric string from an offer', () => {
-  assert.equal(normalizeCartPrice('249.95'), 249.95);
+  assert.equal(normalizeCartPrice('249.95'), '249.95');
 });
 
-test('normalizeCartPrice: number passes through', () => {
-  assert.equal(normalizeCartPrice(249.95), 249.95);
+test('normalizeCartPrice: number is stringified losslessly', () => {
+  assert.equal(normalizeCartPrice(249.95), '249.95');
 });
 
 test('normalizeCartPrice: Product Bus price object uses final', () => {
   assert.equal(
     normalizeCartPrice({ currency: 'USD', regular: '299.95', final: '249.95' }),
-    249.95,
+    '249.95',
   );
 });
 
 test('normalizeCartPrice: falls back to regular when final is missing', () => {
   assert.equal(
     normalizeCartPrice({ currency: 'USD', regular: '299.95' }),
-    299.95,
+    '299.95',
   );
 });
 
@@ -44,16 +44,16 @@ test('normalizeCartPrice: regression for simple-product NaN bug', () => {
   // and render as "$NaN". After the fix the offer's string price flows in.
   const offerPrice = '249.95';
   const normalized = normalizeCartPrice(offerPrice);
-  assert.equal(Number.isNaN(normalized), false);
-  assert.equal(normalized * 2, 499.9);
+  assert.equal(normalized, '249.95');
+  assert.equal(parseFloat(normalized) * 2, 499.9);
 });
 
-test('normalizeCartPrice: null returns NaN', () => {
-  assert.equal(Number.isNaN(normalizeCartPrice(null)), true);
+test('normalizeCartPrice: null stringifies to "null"', () => {
+  assert.equal(normalizeCartPrice(null), 'null');
 });
 
-test('normalizeCartPrice: undefined returns NaN', () => {
-  assert.equal(Number.isNaN(normalizeCartPrice(undefined)), true);
+test('normalizeCartPrice: undefined stringifies to "undefined"', () => {
+  assert.equal(normalizeCartPrice(undefined), 'undefined');
 });
 
 // --- isVariantAvailableForSale ---------------------------------------------

--- a/tests/unit/cart.test.js
+++ b/tests/unit/cart.test.js
@@ -171,10 +171,10 @@ test('subtotal multiplies quantity by string price', () => {
   assert.equal(cart.subtotal, 36.5);
 });
 
-test('subtotal treats numeric price as integer cents', () => {
+test('subtotal treats numeric price as dollar amount', () => {
   const cart = new Cart();
-  // 1099 cents = $10.99
-  cart.addItem(sampleItem({ sku: 'foo', quantity: 2, price: 1099 }));
+  // numeric 10.99 is parsed as dollars, not cents
+  cart.addItem(sampleItem({ sku: 'foo', quantity: 2, price: 10.99 }));
   assert.equal(cart.subtotal, 21.98);
 });
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-cart-subtotal-price--vitamix--aemsites.aem.network/