### PR TITLE
fix(order-summary): hide discounts container when empty

### DIFF
--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -76,7 +76,7 @@ function buildTemplate(s) {
         <span>${s.subtotal}</span>
         <span class="order-summary-subtotal"></span>
       </div>
-      <div class="order-summary-discounts"></div>
+      <div class="order-summary-discounts" hidden></div>
       <div class="order-summary-row">
         <span>${s.shipping}</span>
         <span class="order-summary-shipping"></span>
@@ -234,6 +234,7 @@ export default async function decorate(block) {
     sessionStorage.removeItem('checkout_coupon_code');
     discountInput.value = '';
     discountsEl.innerHTML = '';
+    discountsEl.hidden = true;
     couponErrorEl.hidden = true;
     document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
   };
@@ -249,6 +250,7 @@ export default async function decorate(block) {
 
   const showPendingDiscount = (code) => {
     discountsEl.innerHTML = '';
+    discountsEl.hidden = false;
     const row = document.createElement('div');
     row.className = 'order-summary-row order-summary-discount-item order-summary-discount-pending';
     const labelGroup = document.createElement('span');
@@ -275,6 +277,7 @@ export default async function decorate(block) {
     if (!code) {
       sessionStorage.removeItem('checkout_coupon_code');
       discountsEl.innerHTML = '';
+      discountsEl.hidden = true;
       return;
     }
 
@@ -400,7 +403,9 @@ export default async function decorate(block) {
     subtotalEl.textContent = formatPrice(subtotal, currency);
 
     discountsEl.innerHTML = '';
+    discountsEl.hidden = true;
     discounts.filter((d) => d.amount > 0).forEach((d) => {
+      discountsEl.hidden = false;
       const row = document.createElement('div');
       row.className = 'order-summary-row order-summary-discount-item';
       if (d.source === 'coupon') {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

The `.order-summary-discounts` div was always present in the DOM even when no discounts applied, causing extra vertical space between Subtotal and Shipping. Added `hidden` to the element in the template and toggle it across all code paths that add or clear discount rows.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-order-summary-discounts--vitamix--aemsites.aem.network/