### PR TITLE
fix(checkout): populate shipping name from payer in PayPal Express

### DIFF
--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -262,8 +262,16 @@ export default {
               email: session.payer.email,
               phone: '',
             },
-            shipping: { ...session.shippingAddress, email: session.payer.email },
-            billing: { ...session.shippingAddress, email: session.payer.email },
+            shipping: {
+              name: `${session.payer.firstName} ${session.payer.lastName}`.trim(),
+              ...session.shippingAddress,
+              email: session.payer.email,
+            },
+            billing: {
+              name: `${session.payer.firstName} ${session.payer.lastName}`.trim(),
+              ...session.shippingAddress,
+              email: session.payer.email,
+            },
             items: cart.getItemsForAPI(),
             shippingMethod: { id: session.selectedOptionId },
             estimateToken: state.currentEstimateToken,

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -448,8 +448,8 @@ test.describe('onApprove callback', () => {
     expect(orderBody.customer.lastName).toBe('Doe');
     expect(orderBody.customer.email).toBe('john@example.com');
     expect(orderBody.customer.phone).toBe('');
-    expect(orderBody.shipping).toEqual(SESSION.shippingAddress);
-    expect(orderBody.billing).toEqual(SESSION.shippingAddress);
+    expect(orderBody.shipping).toEqual({ name: 'John Doe', ...SESSION.shippingAddress, email: 'john@example.com' });
+    expect(orderBody.billing).toEqual({ name: 'John Doe', ...SESSION.shippingAddress, email: 'john@example.com' });
     expect(orderBody.shippingMethod.id).toBe('std');
     expect(orderBody.estimateToken).toBe('est-tok');
     expect(orderBody.country).toBe('us');


### PR DESCRIPTION
PayPal does not always return `shipping.name.full_name` (notably for CA sandbox accounts), causing order creation to fail validation with `shipping.name` missing.

Fall back to constructing the name from `payer.firstName`/`lastName`, placed before the address spread so PayPal's own value still wins when present.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-paypal-ca-shipping-name--vitamix--aemsites.aem.network/