### PR TITLE
feat(order-complete): fetch order from API instead of session storage

### DIFF
--- a/blocks/order-complete/order-complete.js
+++ b/blocks/order-complete/order-complete.js
@@ -1,4 +1,5 @@
 import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
+import { getOrder } from '../../scripts/commerce-api.js';
 
 /**
  * Order confirmation / cancellation page.
@@ -7,7 +8,10 @@ import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
  * Cancel:  Chase / PayPal → API → redirect here with ?orderId=...&reason=...
  *   reason values: customer_cancelled | payment_failed | declined
  *
- * Order display data comes from sessionStorage (saved before the payment redirect).
+ * Order display data is fetched from the API using the orderId and email from
+ * the URL / sessionStorage. sessionStorage is used as a fallback when the API
+ * call fails, and for totals (preview) and enriched item display data (cartItems)
+ * which are not stored on the order.
  */
 export default async function decorate(block) {
   const config = getConfig();
@@ -81,6 +85,16 @@ export default async function decorate(block) {
     // cart may not be available
   }
 
+  // fetch authoritative order data from the API; fall back to sessionStorage on failure
+  if (orderId && email) {
+    try {
+      const result = await getOrder(email, orderId);
+      order = result.order;
+    } catch {
+      // use sessionStorage order as fallback
+    }
+  }
+
   // build confirmation page
   const container = document.createElement('div');
   container.className = 'order-result order-confirmed';
@@ -103,7 +117,7 @@ export default async function decorate(block) {
   const orderIdLabel = document.createElement('span');
   orderIdLabel.textContent = `${s.orderIdLabel} `;
   const orderIdValue = document.createElement('strong');
-  const friendlyOrderNumber = order?.number || order?.orderNumber
+  const friendlyOrderNumber = order?.friendlyId || order?.number || order?.orderNumber
     || `#${orderId.replace(/-/g, '').slice(-8).toUpperCase()}`;
   orderIdValue.textContent = friendlyOrderNumber;
   orderIdEl.append(orderIdLabel, orderIdValue);
@@ -140,11 +154,12 @@ export default async function decorate(block) {
       const itemEl = document.createElement('div');
       itemEl.className = 'order-item';
 
-      if (item.image) {
+      const itemImage = item.image || item.imageUrl;
+      if (itemImage) {
         const imgWrapper = document.createElement('div');
         imgWrapper.className = 'order-item-image';
         const img = document.createElement('img');
-        img.src = item.image;
+        img.src = itemImage;
         img.alt = item.name || '';
         imgWrapper.appendChild(img);
         itemEl.appendChild(imgWrapper);
@@ -158,10 +173,13 @@ export default async function decorate(block) {
       name.textContent = item.name || item.sku;
       details.appendChild(name);
 
-      if (item.variant) {
+      const variantLabel = item.variant
+        || item.selectedOptions?.map((o) => o.value).join(' / ')
+        || null;
+      if (variantLabel) {
         const variant = document.createElement('p');
         variant.className = 'order-item-variant';
-        variant.textContent = item.variant;
+        variant.textContent = variantLabel;
         details.appendChild(variant);
       }
 
@@ -183,23 +201,32 @@ export default async function decorate(block) {
     leftCol.appendChild(itemsSection);
   }
 
-  // totals
-  if (preview) {
+  // totals — read from order.estimates (API); fall back to sessionStorage preview
+  const est = order?.estimates;
+  const totalsSubtotal = est
+    ? order.items?.reduce((acc, i) => acc + parseFloat(i.price?.final || 0) * i.quantity, 0) ?? 0
+    : parseFloat(preview?.subtotal);
+  const totalsShippingMethod = est ? (est.shippingMethod || {}) : (preview?.shippingMethod || {});
+  const totalsDiscounts = est ? (est.discounts || []) : (preview?.discounts || []);
+  const totalsTax = parseFloat(est ? (est.tax?.amount || 0) : (preview?.taxAmount || 0));
+  const totalsTotal = parseFloat(est ? (order.payment?.amount || 0) : (preview?.total || 0));
+
+  if (est || preview) {
     const totalsSection = document.createElement('div');
     totalsSection.className = 'order-totals';
 
-    const shippingRate = preview.shippingMethod?.rate;
+    const shippingRate = totalsShippingMethod.rate;
     const shippingDisplay = shippingRate === 0
       ? s.free
       : formatPrice(parseFloat(shippingRate || 0), currencyCode);
 
     const rows = [
-      [s.subtotal, formatPrice(parseFloat(preview.subtotal), currencyCode)],
+      [s.subtotal, formatPrice(totalsSubtotal, currencyCode)],
       [s.shipping, shippingDisplay],
     ];
 
-    if (preview.discounts?.length) {
-      preview.discounts.forEach((discount) => {
+    if (totalsDiscounts.length) {
+      totalsDiscounts.forEach((discount) => {
         const label = discount.name || s.discount;
         const amount = discount.freeShipping
           ? parseFloat(shippingRate || 0)
@@ -209,7 +236,7 @@ export default async function decorate(block) {
       });
     }
 
-    rows.push([s.orderTax, formatPrice(parseFloat(preview.taxAmount), currencyCode)]);
+    rows.push([s.orderTax, formatPrice(totalsTax, currencyCode)]);
 
     rows.forEach(([label, value, extraClass]) => {
       const row = document.createElement('div');
@@ -227,7 +254,7 @@ export default async function decorate(block) {
     const totalLabel = document.createElement('strong');
     totalLabel.textContent = s.total;
     const totalValue = document.createElement('strong');
-    totalValue.textContent = formatPrice(parseFloat(preview.total), currencyCode);
+    totalValue.textContent = formatPrice(totalsTotal, currencyCode);
     totalRow.append(totalLabel, totalValue);
     totalsSection.appendChild(totalRow);
 

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -268,6 +268,20 @@ export async function validateApplePayMerchant(validationUrl, country, locale) {
 }
 
 /**
+ * Fetches a single order by order ID and customer email.
+ * No authentication required — knowing the email and order ID is sufficient
+ * proof for guest order lookups (post-checkout confirmation, order status).
+ *
+ * @param {string} email - Customer email address
+ * @param {string} orderId - The order ID returned by createOrder
+ * @returns {Promise<{ order: Object }>}
+ * @throws {CommerceApiError} If order not found or email doesn't match
+ */
+export async function getOrder(email, orderId) {
+  return request(`/customers/${email}/orders/${orderId}`, null, 'GET');
+}
+
+/**
  * Normalises a checkout:preview payload into scalar price values.
  * @param {Object} preview
  * @param {number} cartSubtotal - fallback when preview.subtotal is absent

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for scripts/commerce-api.js — getOrder function.
+ *
+ * Run with `npm run test:unit`. The setup file installs the fetch mock and
+ * browser globals (sessionStorage) that commerce-api.js depends on.
+ */
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { getOrder } from '../../scripts/commerce-api.js';
+
+const API_ORIGIN = 'https://api.test.com/test-org/sites/test-site';
+
+/** Captured details from the most recent fetch() call. */
+let lastUrl;
+let lastInit;
+
+/**
+ * Installs a fetch mock that returns the given status and body.
+ * Captures url/init for assertion.
+ */
+function mockFetch(status, body) {
+  globalThis.__setFetchMock(async (url, init) => {
+    lastUrl = url;
+    lastInit = init;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      headers: { get: () => null },
+    };
+  });
+}
+
+beforeEach(() => {
+  lastUrl = undefined;
+  lastInit = undefined;
+  globalThis.__resetTestState();
+});
+
+// --- URL construction -------------------------------------------------------
+
+test('getOrder: builds the correct URL from email and orderId', async () => {
+  mockFetch(200, { order: { id: 'ord-1' } });
+  await getOrder('user@example.com', 'ord-1');
+  assert.equal(lastUrl, `${API_ORIGIN}/customers/user@example.com/orders/ord-1`);
+});
+
+test('getOrder: does not percent-encode @ in email', async () => {
+  mockFetch(200, { order: {} });
+  await getOrder('buyer@test.com', 'ord-2');
+  assert.ok(lastUrl.includes('buyer@test.com'), 'URL should contain raw @ character');
+  assert.ok(!lastUrl.includes('buyer%40test.com'), '@ must not be encoded as %40');
+});
+
+// --- HTTP method ------------------------------------------------------------
+
+test('getOrder: uses GET method', async () => {
+  mockFetch(200, { order: {} });
+  await getOrder('user@example.com', 'ord-3');
+  assert.equal(lastInit.method, 'GET');
+});
+
+// --- Response handling ------------------------------------------------------
+
+test('getOrder: returns the full { order } payload on success', async () => {
+  const order = {
+    id: 'ord-abc',
+    friendlyId: 'XYZ123',
+    state: 'completed',
+    customer: { email: 'user@example.com' },
+  };
+  mockFetch(200, { order });
+  const result = await getOrder('user@example.com', 'ord-abc');
+  assert.deepEqual(result, { order });
+});
+
+// --- Authentication ---------------------------------------------------------
+
+test('getOrder: attaches Bearer token from sessionStorage when present', async () => {
+  sessionStorage.setItem('auth_token', 'test-jwt');
+  mockFetch(200, { order: {} });
+  await getOrder('user@example.com', 'ord-4');
+  assert.equal(lastInit.headers.Authorization, 'Bearer test-jwt');
+});
+
+test('getOrder: omits Authorization header when no token in sessionStorage', async () => {
+  mockFetch(200, { order: {} });
+  await getOrder('user@example.com', 'ord-5');
+  assert.equal(lastInit.headers.Authorization, undefined);
+});
+
+// --- Error handling ---------------------------------------------------------
+
+test('getOrder: throws with status 404 when order is not found', async () => {
+  mockFetch(404, { message: 'Not found' });
+  await assert.rejects(
+    () => getOrder('user@example.com', 'missing'),
+    (err) => {
+      assert.equal(err.status, 404);
+      return true;
+    },
+  );
+});
+
+test('getOrder: throws with status 404 when email does not match order', async () => {
+  mockFetch(404, { message: 'Not found' });
+  await assert.rejects(
+    () => getOrder('wrong@example.com', 'ord-6'),
+    (err) => {
+      assert.equal(err.status, 404);
+      return true;
+    },
+  );
+});
+
+test('getOrder: throws with status 500 on server error', async () => {
+  mockFetch(500, { message: 'Internal Server Error' });
+  await assert.rejects(
+    () => getOrder('user@example.com', 'ord-7'),
+    (err) => {
+      assert.equal(err.status, 500);
+      return true;
+    },
+  );
+});

--- a/tests/unit/loader.mjs
+++ b/tests/unit/loader.mjs
@@ -16,8 +16,8 @@ const mockUrl = (file) => pathToFileURL(resolvePath(here, 'mocks', file)).href;
 
 const redirects = [
   { match: (s) => s === './commerce-config.js' || s.endsWith('/commerce-config.js'), file: 'commerce-config.mjs' },
-  { match: (s) => s.endsWith('/scripts/aem.js'), file: 'aem.mjs' },
-  { match: (s) => s.endsWith('/scripts/scripts.js'), file: 'scripts.mjs' },
+  { match: (s) => s === './aem.js' || s.endsWith('/scripts/aem.js'), file: 'aem.mjs' },
+  { match: (s) => s === './scripts.js' || s.endsWith('/scripts/scripts.js'), file: 'scripts.mjs' },
 ];
 
 export async function resolve(specifier, context, nextResolve) {

--- a/tests/unit/mocks/aem.mjs
+++ b/tests/unit/mocks/aem.mjs
@@ -19,3 +19,8 @@ export function __resetMetadata() {
 export function getMetadata(name) {
   return metadata[name] ?? '';
 }
+
+// eslint-disable-next-line no-empty-function
+export async function loadScript() {}
+// eslint-disable-next-line no-empty-function
+export async function loadCSS() {}

--- a/tests/unit/mocks/commerce-config.mjs
+++ b/tests/unit/mocks/commerce-config.mjs
@@ -25,5 +25,6 @@ export function getConfig() {
     currency: currencyOverride !== undefined ? currencyOverride : 'USD',
     getStrings: () => ({}),
     getOrderPath: (key) => `/${key}`,
+    apiOrigin: 'https://api.test.com/test-org/sites/test-site',
   };
 }

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -29,3 +29,5 @@ export function checkVariantOutOfStock(sku) {
 export function getLocaleAndLanguage() {
   return locale;
 }
+
+export const isProdHost = false;

--- a/tests/unit/setup.mjs
+++ b/tests/unit/setup.mjs
@@ -4,10 +4,10 @@
  *
  *   1. Register the ESM loader (loader.mjs) so imports of commerce-config.js
  *      resolve to the test mock.
- *   2. Install browser-shaped globals (localStorage, document, window,
- *      CustomEvent) that the modules under test depend on.
- *   3. Expose `globalThis.__events` (dispatch log) and `globalThis.__resetTestState`
- *      (per-test isolation helper) for use in test files.
+ *   2. Install browser-shaped globals (localStorage, sessionStorage, document,
+ *      window, CustomEvent, fetch) that the modules under test depend on.
+ *   3. Expose `globalThis.__events` (dispatch log), `globalThis.__setFetchMock`,
+ *      and `globalThis.__resetTestState` (per-test isolation helper).
  */
 import { register } from 'node:module';
 
@@ -25,6 +25,25 @@ globalThis.localStorage = {
   setItem(key, value) { storage.set(key, String(value)); },
   removeItem(key) { storage.delete(key); },
   clear() { storage.clear(); },
+};
+
+// sessionStorage — same surface, separate backing store.
+const session = new Map();
+globalThis.sessionStorage = {
+  getItem(key) { return session.has(key) ? session.get(key) : null; },
+  setItem(key, value) { session.set(key, String(value)); },
+  removeItem(key) { session.delete(key); },
+  clear() { session.clear(); },
+};
+
+// fetch — configurable mock. Test files call __setFetchMock(fn) to install a
+// handler; the default handler throws so unconfigured calls are caught early.
+let fetchHandler = null;
+globalThis.__setFetchMock = (fn) => { fetchHandler = fn; };
+globalThis.__clearFetchMock = () => { fetchHandler = null; };
+globalThis.fetch = async (url, init) => {
+  if (!fetchHandler) throw new Error(`fetch called without a mock: ${url}`);
+  return fetchHandler(url, init);
 };
 
 // document.cookie — minimal jar that supports `key=value; attr=...; attr=...`.
@@ -64,7 +83,9 @@ globalThis.CustomEvent = class CustomEvent {
 globalThis.__events = [];
 globalThis.__resetTestState = () => {
   storage.clear();
+  session.clear();
   cookies.clear();
   globalThis.__events.length = 0;
+  fetchHandler = null;
   __resetConfig();
 };


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Replace session storage as the source of truth on the order confirmation
page with a live API fetch using the orderId + email from the URL.
Fixes item images and variant labels for the API response shape, and
reads totals directly from order.estimates. Falls back to session storage
when the API call fails.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://order-complete-api-fetch--vitamix--aemsites.aem.network/