### PR TITLE
fix(pdp): cap per-SKU quantity at maxCartQty on repeated add-to-cart

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -76,6 +76,17 @@ function toggleFixedAddToCart(container) {
 }
 
 /**
+ * Returns how many units may be added given what is already in the cart.
+ * @param {number} requested - Quantity the user selected
+ * @param {number} existing - Quantity already in the cart for this SKU
+ * @param {number} max - Per-product maximum allowed quantity
+ * @returns {number}
+ */
+export function computeAllowedQty(requested, existing, max) {
+  return Math.max(0, Math.min(requested, max - existing));
+}
+
+/**
  * Normalize a price into a number for the edge cart line item.
  * Offers expose a flat numeric price (string or number); simple products
  * without offers expose the Product Bus shape `{ currency, regular, final }`.
@@ -230,6 +241,18 @@ export default function renderAddToCart(ph, block, parent) {
         const cartApi = (await import('../../scripts/cart.js')).default;
 
         const { sku: variantSku, name } = selectedVariant;
+        const targetSku = variantSku ?? sku;
+
+        // Clamp requested quantity so the cart line never exceeds maxQuantity.
+        const requestedQty = parseInt(quantity, 10);
+        const existingQty = cartApi.items.find((i) => i.sku === targetSku)?.quantity ?? 0;
+        const allowedQty = computeAllowedQty(requestedQty, existingQty, maxQuantity);
+        if (allowedQty <= 0) {
+          addToCartButton.textContent = ph.addToCart || 'Add to Cart';
+          addToCartButton.removeAttribute('aria-disabled');
+          return;
+        }
+
         // Prefer the selected variant's price so variant-specific pricing
         // wins; fall back to offers[0] for simple products, where
         // selectedVariant is the parent and has no top-level price.
@@ -261,9 +284,9 @@ export default function renderAddToCart(ph, block, parent) {
         const availableWarranties = warrantyOptions.length > 0 ? warrantyOptions : null;
 
         const item = {
-          sku: variantSku ?? sku,
+          sku: targetSku,
           parentSku: variantSku ? sku : undefined,
-          quantity: parseInt(quantity, 10),
+          quantity: allowedQty,
           price,
           name,
           url: selectedVariant.url,
@@ -284,11 +307,11 @@ export default function renderAddToCart(ph, block, parent) {
           await cartApi.addItem({
             sku: selectedTier.sku,
             path: selectedTier.path,
-            quantity: parseInt(quantity, 10),
+            quantity: allowedQty,
             price: selectedTier.price,
             name: selectedTier.name,
             custom: {
-              linkedTo: variantSku ?? sku,
+              linkedTo: targetSku,
               ...(selectedTier.coverageYears
                 ? { coverageYears: selectedTier.coverageYears }
                 : {}),

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -6,7 +6,7 @@
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeCartPrice, isVariantAvailableForSale } from '../../blocks/pdp/add-to-cart.js';
+import { normalizeCartPrice, isVariantAvailableForSale, computeAllowedQty } from '../../blocks/pdp/add-to-cart.js';
 import { __setMetadata, __resetMetadata } from './mocks/aem.mjs';
 import { __setOutOfStockSkus, __resetScripts } from './mocks/scripts.mjs';
 
@@ -103,4 +103,26 @@ test('isVariantAvailableForSale: page metadata gate wins over variant flags', ()
     isVariantAvailableForSale(inStockVariant({ managedStock: '0' })),
     false,
   );
+});
+
+// --- computeAllowedQty -------------------------------------------------------
+
+test('computeAllowedQty: full quantity allowed when cart is empty', () => {
+  assert.equal(computeAllowedQty(3, 0, 3), 3);
+});
+
+test('computeAllowedQty: zero allowed when already at max', () => {
+  assert.equal(computeAllowedQty(3, 3, 3), 0);
+});
+
+test('computeAllowedQty: partial quantity allowed when cart is partially full', () => {
+  assert.equal(computeAllowedQty(3, 1, 3), 2);
+});
+
+test('computeAllowedQty: normal single-unit add', () => {
+  assert.equal(computeAllowedQty(1, 0, 3), 1);
+});
+
+test('computeAllowedQty: clamps to zero, not negative, when existing exceeds max', () => {
+  assert.equal(computeAllowedQty(1, 4, 3), 0);
 });


### PR DESCRIPTION
Clicking "Add to Cart" multiple times from the PDP could push a SKU's
cart quantity past the configured maximum. The click handler now checks
the existing line quantity and clamps the amount added so the total
never exceeds maxQuantity. Only affects the edge checkout path.

Fix #

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-pdp-cart-qty-cap--vitamix--aemsites.aem.network/