### PR TITLE
fix(checkout): hide Affirm for orders below minimum total

### DIFF
--- a/blocks/checkout/checkout-payment.js
+++ b/blocks/checkout/checkout-payment.js
@@ -217,7 +217,7 @@ export function renderPaymentSection(container, activeProviders, callbacks, stri
  * @param {Object} config
  * @param {Object} strings
  */
-export async function initPayment(container, providers, callbacks, config, strings) {
+export async function initPayment(container, providers, callbacks, config, strings, cartTotal) {
   const active = getActiveProviders(providers);
 
   await Promise.all(
@@ -229,7 +229,7 @@ export async function initPayment(container, providers, callbacks, config, strin
   );
 
   const available = active.filter((p) => {
-    try { return p.isAvailable(); } catch { return false; }
+    try { return p.isAvailable(cartTotal, config); } catch { return false; }
   });
 
   renderPaymentSection(container, available, callbacks, strings, config);

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -283,7 +283,7 @@ export default async function decorate(block) {
 
   // Register providers, check availability, render buttons
   const paymentContainer = form.querySelector('.payment-method-section');
-  await initPayment(paymentContainer, ALL_PROVIDERS, callbacks, config, strings);
+  await initPayment(paymentContainer, ALL_PROVIDERS, callbacks, config, strings, cart.subtotal);
 
   // Re-run preview on payment method change — tax may vary by type (e.g. Avalara surcharge)
   paymentContainer.addEventListener('change', (e) => {

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -29,6 +29,7 @@ const defaults = {
   currency: (locale) => (locale === 'ca' ? 'CAD' : 'USD'),
   cardProvider: 'chase',
   maxCartQty: 3,
+  affirmMinOrderTotal: 50,
   getFraudToken() {
     try { return sessionStorage.getItem('forter_token') || undefined; } catch { return undefined; }
   },

--- a/scripts/payments/affirm.js
+++ b/scripts/payments/affirm.js
@@ -10,7 +10,7 @@ export default {
   // Affirm SDK is bootstrapped after initiatePayment returns env-specific config
   load: async () => {},
 
-  isAvailable: () => true,
+  isAvailable: (total, config) => total == null || total >= (config?.affirmMinOrderTotal ?? 50),
 
   renderExpressButton: () => {},
 


### PR DESCRIPTION
`isAvailable` now receives `cartTotal` and `config`, allowing providers to gate on order value. Affirm's threshold defaults to $50 and is configurable via `affirmMinOrderTotal` in `commerce-config`.

fixes: #506 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://affirm-min-total--vitamix--aemsites.aem.network/