### PR TITLE
fix: update tests to reflect edge cart rollout and intentional cart c…

### DIFF
--- a/blocks/cart/cart.js
+++ b/blocks/cart/cart.js
@@ -112,7 +112,7 @@ export default async function decorate(block) {
                   ...(tier.coverageYears ? { coverageYears: tier.coverageYears } : {}),
                 },
                 local: { showInCart: false },
-              });
+              }, { allowSeparateEntry: true });
             }
           },
           currencyCode,

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -325,7 +325,7 @@ export default async function decorate(block) {
                   ...(tier.coverageYears ? { coverageYears: tier.coverageYears } : {}),
                 },
                 local: { showInCart: false },
-              });
+              }, { allowSeparateEntry: true });
             }
           },
           currencyCode,

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -128,19 +128,30 @@ export class Cart {
   }
 
   /**
-   * Add an item to the cart. Merges quantity into an existing entry only when
-   * both SKU and `custom` payload match exactly. Items with the same SKU but
-   * different `custom` payloads (e.g. the same warranty SKU linked to two
-   * different parent products) are kept as separate entries.
+   * Add an item to the cart. If an entry with the same SKU already exists,
+   * the merge succeeds only when the existing and incoming `custom` payloads
+   * are deep-equal; on merge, quantity is incremented by the incoming
+   * quantity. A `custom` mismatch throws — defensive guard against UI bugs.
+   *
+   * Pass `{ allowSeparateEntry: true }` when the same SKU legitimately needs
+   * multiple distinct entries with different `custom` payloads (e.g. the same
+   * warranty SKU linked to two different parent products).
    *
    * @param {CartItem} item
+   * @param {{ allowSeparateEntry?: boolean }} [opts]
    */
-  addItem(item) {
-    const existing = this.#items.find(
-      (i) => i.sku === item.sku && deepEqual(i.custom, item.custom),
-    );
+  addItem(item, { allowSeparateEntry = false } = {}) {
+    const existing = this.#items.find((i) => i.sku === item.sku);
     if (existing) {
-      existing.quantity += item.quantity;
+      if (!deepEqual(existing.custom, item.custom)) {
+        if (allowSeparateEntry) {
+          this.#items.push(item);
+        } else {
+          throw new Error(`Cannot merge cart item ${item.sku}: incompatible custom payloads`);
+        }
+      } else {
+        existing.quantity += item.quantity;
+      }
     } else {
       this.#items.push(item);
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1348,6 +1348,11 @@ async function loadEager(doc) {
   if (localStorage.getItem('useEdgeCheckout') !== null) {
     window.useEdgeCheckout = localStorage.getItem('useEdgeCheckout') === 'true';
   }
+  // ?cart=magento or ?cart=edge overrides all other settings (useful for testing)
+  const cartModeParam = new URLSearchParams(window.location.search).get('cart');
+  if (cartModeParam !== null) {
+    window.useEdgeCheckout = cartModeParam !== 'magento';
+  }
 
   /* simulation date */
   const params = new URLSearchParams(window.location.search);

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -27,6 +27,10 @@ async function getCart(page, key = CART_KEY_US) {
   return raw ? JSON.parse(raw) : null;
 }
 
+// Header cart link locator: the cart icon's parent <a>. Stable across
+// edge/Magento modes (href changes but the icon-cart child does not).
+const CART_LINK_SELECTOR = 'header a:has(.icon-cart)';
+
 test.describe('Edge Checkout', () => {
   let currentBranch;
 
@@ -47,7 +51,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart).toHaveAttribute('aria-expanded', 'true');
       console.log('✓ Minicart opens after add-to-cart');
     });
@@ -77,7 +81,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).not.toHaveAttribute('data-cart-items');
 
       await page.locator('.quantity-container button').click();
@@ -92,7 +96,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
       console.log('✓ Minicart renders at least one cart item');
     });
@@ -104,7 +108,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       await minicart.locator('.slide-panel-close').click();
       await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
@@ -118,7 +122,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       // Click outside the dialog bounds (top-left corner of viewport)
       await page.mouse.click(5, 5);
@@ -133,7 +137,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       const checkoutBtn = minicart.locator('a[href*="/order/checkout"]');
       await expect(checkoutBtn.first()).toBeVisible({ timeout: 5000 });
@@ -145,7 +149,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await page.waitForLoadState('networkidle');
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
       console.log('✓ Cart icon href is /us/en_us/order/cart in edge mode');
     });
@@ -162,7 +166,7 @@ test.describe('Edge Checkout', () => {
 
       await page.locator('.quantity-container button').click();
 
-      await expect(page.locator('#minicart')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       const cart = await getCart(page);
       expect(cart.items).toHaveLength(1);
@@ -184,7 +188,7 @@ test.describe('Edge Checkout', () => {
 
       await page.locator('.quantity-container button').click();
 
-      await expect(page.locator('#minicart')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       const cart = await getCart(page);
       expect(cart.items).toHaveLength(1);
@@ -323,7 +327,7 @@ test.describe('Edge Checkout', () => {
       await page.waitForTimeout(500);
 
       // visibleItemCount = 1 (warranty is excluded), so badge shows 1
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
       console.log('✓ Badge shows 1; hidden warranty item not counted');
     });
@@ -368,7 +372,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       // Only one visible row in the minicart (warranty is hidden from cart UI)
       const cartItems = minicart.locator('.cart-item');
@@ -428,7 +432,7 @@ test.describe('Edge Checkout', () => {
       await page.waitForLoadState('networkidle');
 
       // visibleItemCount = 1+2 = 3
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '3', { timeout: 5000 });
       console.log('✓ Cart badge shows 3 after restoring from localStorage');
     });
@@ -440,7 +444,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       // Remove the item directly via the cart API to trigger cart:empty
       await page.evaluate(() => {
@@ -481,7 +485,7 @@ test.describe('Edge Checkout', () => {
 
       await page.locator('.quantity-container button').click();
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
       console.log('✓ Cart badge updates on mobile');
     });
@@ -490,7 +494,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await page.waitForLoadState('networkidle');
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
       console.log('✓ Cart icon href is /us/en_us/order/cart on mobile');
     });
@@ -523,7 +527,7 @@ test.describe('Edge Checkout', () => {
 
       await page.locator('.quantity-container button').click();
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
       console.log('✓ FR-CA cart badge shows 1 after add-to-cart');
     });
@@ -625,7 +629,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       // Close minicart
       await minicart.locator('.slide-panel-close').click();
@@ -633,10 +637,9 @@ test.describe('Edge Checkout', () => {
       await page.waitForTimeout(400);
 
       // Now click the cart icon directly — different code path from pdp:add-to-cart
-      await page.locator('header a[href*="/order/cart"]').click();
+      await page.locator(CART_LINK_SELECTOR).click();
 
-      await expect(minicart).toBeVisible({ timeout: 5000 });
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       console.log('✓ Cart icon click opens minicart independently');
     });
 
@@ -647,7 +650,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
 
       // Click remove on the only cart item
@@ -657,7 +660,7 @@ test.describe('Edge Checkout', () => {
       await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
 
       // Badge is removed
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
 
       // localStorage is empty
@@ -685,13 +688,13 @@ test.describe('Edge Checkout', () => {
 
       // Switch to desktop and open minicart via cart icon
       await page.setViewportSize({ width: 1280, height: 720 });
-      await page.locator('header a[href*="/order/cart"]').click();
+      await page.locator(CART_LINK_SELECTOR).click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart.locator('.cart-item')).toHaveCount(2, { timeout: 5000 });
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '2');
 
       // Remove the first item
@@ -714,7 +717,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
 
       // Click the + button in the minicart cart item
@@ -722,7 +725,7 @@ test.describe('Edge Checkout', () => {
       await page.waitForTimeout(600);
 
       // Badge should now show 2
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '2', { timeout: 5000 });
 
       // localStorage quantity updated
@@ -738,7 +741,7 @@ test.describe('Edge Checkout', () => {
       await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
       await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
 
       // The qty starts at 1; clicking − triggers handleQtyChange(0)
@@ -747,7 +750,7 @@ test.describe('Edge Checkout', () => {
       await minicart.locator('.cart-item-remove').first().click();
 
       await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
       console.log('✓ Removing last item via minicart closes it and clears badge');
     });
@@ -758,7 +761,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(cartPageUrl);
       await page.waitForLoadState('networkidle');
 
-      const cartLink = page.locator('header a[href*="/order/cart"]');
+      const cartLink = page.locator(CART_LINK_SELECTOR);
       if (await cartLink.count() === 0) {
         console.log('ℹ Cart icon not present on cart page — skipping');
         return;

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import {
   getCurrentBranch,
   buildProductUrl,
-  waitForElement,
+  waitForAddToCartButton,
 } from '../utils/test-helpers.js';
 
 /**
@@ -35,7 +35,7 @@ test.describe('Edge Checkout', () => {
   // Disable retries for this file — the failing tests don't recover with
   // re-runs (their issues are timing / DOM-readiness), and 2 retries per
   // failure was tripling total CI time without improving outcomes.
-  test.describe.configure({ retries: 0 });
+  test.describe.configure({ retries: 0, timeout: 90000 });
 
   let currentBranch;
 
@@ -54,9 +54,9 @@ test.describe('Edge Checkout', () => {
 
     test('add to cart opens minicart on desktop', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -66,13 +66,16 @@ test.describe('Edge Checkout', () => {
 
     test('item stored in localStorage with correct schema', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
-      await page.waitForTimeout(600); // allow debounced persist to flush
+      await page.locator('.quantity-container button').click();
+
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Cart not persisted to localStorage' },
+      ).toBe(1);
 
       const cart = await getCart(page);
-      expect(cart).not.toBeNull();
       expect(cart.version).toBe(1);
       expect(cart.items).toHaveLength(1);
 
@@ -87,21 +90,21 @@ test.describe('Edge Checkout', () => {
 
     test('cart count badge updates after add-to-cart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).not.toHaveAttribute('data-cart-items');
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
       console.log('✓ Cart badge shows 1 after add-to-cart');
     });
 
     test('minicart shows the added item', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -111,9 +114,9 @@ test.describe('Edge Checkout', () => {
 
     test('minicart closes via × button', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -125,9 +128,9 @@ test.describe('Edge Checkout', () => {
 
     test('minicart closes on backdrop click', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -140,9 +143,9 @@ test.describe('Edge Checkout', () => {
 
     test('minicart checkout button links to /order/checkout', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -171,9 +174,9 @@ test.describe('Edge Checkout', () => {
 
     test('opens minicart and stores item with correct schema', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
@@ -200,9 +203,9 @@ test.describe('Edge Checkout', () => {
 
     test('opens minicart and stores item with bundle data', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
@@ -236,7 +239,7 @@ test.describe('Edge Checkout', () => {
 
     test('can add up to the max quantity of 3', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const btn = page.locator('.quantity-container button');
       await clickAndWait(btn, page);
@@ -250,7 +253,7 @@ test.describe('Edge Checkout', () => {
 
     test('4th add-to-cart is silently blocked when already at max', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const btn = page.locator('.quantity-container button');
       await clickAndWait(btn, page);
@@ -268,7 +271,7 @@ test.describe('Edge Checkout', () => {
 
     test('button re-enables and resets text after a blocked add', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const btn = page.locator('.quantity-container button');
       await clickAndWait(btn, page);
@@ -291,21 +294,24 @@ test.describe('Edge Checkout', () => {
 
     test('no warranty item in cart when default (no-cost) tier is active', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       // Don't change the default warranty selection
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
-      await page.waitForTimeout(600);
+      await page.locator('.quantity-container button').click();
+
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Cart not persisted to localStorage' },
+      ).toBe(1);
 
       const cart = await getCart(page);
-      expect(cart.items).toHaveLength(1);
       expect(cart.items[0].custom?.linkedTo).toBeUndefined();
       console.log('✓ No linked warranty item for default (included) tier');
     });
 
     test('paid warranty tier adds a hidden linked item to the cart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const warrantyOptions = page.locator('.pdp-warranty-option');
       if (await warrantyOptions.count() < 2) {
@@ -316,7 +322,7 @@ test.describe('Edge Checkout', () => {
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -336,7 +342,7 @@ test.describe('Edge Checkout', () => {
 
     test('warranty hidden item excluded from cart badge count', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const warrantyOptions = page.locator('.pdp-warranty-option');
       if (await warrantyOptions.count() < 2) {
@@ -346,7 +352,7 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(500);
 
       // visibleItemCount = 1 (warranty is excluded), so badge shows 1
@@ -357,7 +363,7 @@ test.describe('Edge Checkout', () => {
 
     test('warranty item quantity matches parent quantity', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const warrantyOptions = page.locator('.pdp-warranty-option');
       if (await warrantyOptions.count() < 2) {
@@ -367,7 +373,7 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -382,7 +388,7 @@ test.describe('Edge Checkout', () => {
 
     test('warranty item visible on cart page inside minicart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const warrantyOptions = page.locator('.pdp-warranty-option');
       if (await warrantyOptions.count() < 2) {
@@ -392,7 +398,7 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -413,9 +419,9 @@ test.describe('Edge Checkout', () => {
 
     test('cart survives a page reload', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       // Poll until cart is actually written to localStorage before reloading
       await expect.poll(
@@ -470,9 +476,9 @@ test.describe('Edge Checkout', () => {
 
     test('minicart closes automatically when cart is emptied', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -496,9 +502,9 @@ test.describe('Edge Checkout', () => {
 
     test('minicart does NOT open after add-to-cart on mobile', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(1000);
 
       await expect(page.locator('#minicart')).not.toBeVisible();
@@ -507,12 +513,12 @@ test.describe('Edge Checkout', () => {
 
     test('cart badge updates on mobile after add-to-cart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
-      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 15000 });
       console.log('✓ Cart badge updates on mobile');
     });
 
@@ -534,15 +540,18 @@ test.describe('Edge Checkout', () => {
 
     test('cart stored under cart:ca key, not cart:us', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
-      await page.waitForTimeout(600);
+      await page.locator('.quantity-container button').click();
+
+      await expect.poll(
+        () => getCart(page, CART_KEY_CA).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'FR-CA cart not persisted to localStorage' },
+      ).toBeGreaterThan(0);
 
       const caCart = await getCart(page, CART_KEY_CA);
       const usCart = await getCart(page, CART_KEY_US);
 
-      expect(caCart).not.toBeNull();
       expect(caCart.items).toHaveLength(1);
       expect(usCart).toBeNull();
       console.log('✓ FR-CA cart stored under cart:ca, cart:us is empty');
@@ -550,9 +559,9 @@ test.describe('Edge Checkout', () => {
 
     test('cart badge updates using FR-CA cart data', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
@@ -561,9 +570,9 @@ test.describe('Edge Checkout', () => {
 
     test('FR-CA cart survives page reload', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       // Poll until cart is actually written to localStorage before reloading
       await expect.poll(
@@ -596,7 +605,7 @@ test.describe('Edge Checkout', () => {
 
     test('adding the same item twice increments quantity, not a separate entry', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       const btn = page.locator('.quantity-container button');
       await btn.click();
@@ -604,7 +613,11 @@ test.describe('Edge Checkout', () => {
       await page.waitForTimeout(300);
       await btn.click();
       await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
-      await page.waitForTimeout(600);
+
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.[0]?.quantity ?? 0),
+        { timeout: 10000, message: 'Cart quantity not updated to 2' },
+      ).toBe(2);
 
       const cart = await getCart(page);
       expect(cart.items).toHaveLength(1);
@@ -614,9 +627,9 @@ test.describe('Edge Checkout', () => {
 
     test('deeplinked variant stores variant sku and parentSku', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge', color: 'polar-white' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -638,9 +651,9 @@ test.describe('Edge Checkout', () => {
       // Simple product has no warranty options
       const simplePath = '/us/en_us/products/20-ounce-travel-cup';
       await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -658,10 +671,10 @@ test.describe('Edge Checkout', () => {
 
     test('cart icon click opens minicart independently of add-to-cart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
       // Add to cart so there is something in the cart
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -680,9 +693,9 @@ test.describe('Edge Checkout', () => {
 
     test('removing the only item closes minicart and clears badge', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -712,8 +725,8 @@ test.describe('Edge Checkout', () => {
 
       // Add Ascent X2 and confirm it's in localStorage before navigating away
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await waitForAddToCartButton(page);
+      await page.locator('.quantity-container button').click();
       await expect.poll(
         () => getCart(page).then((c) => c?.items?.length ?? 0),
         { timeout: 10000, message: 'First item (Ascent X2) not added to cart' },
@@ -722,8 +735,8 @@ test.describe('Edge Checkout', () => {
       // Add simple product to get a second item and confirm both are persisted
       const simplePath = '/us/en_us/products/20-ounce-travel-cup';
       await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await waitForAddToCartButton(page);
+      await page.locator('.quantity-container button').click();
       await expect.poll(
         () => getCart(page).then((c) => c?.items?.length ?? 0),
         { timeout: 10000, message: 'Second item (Travel Cup) not added to cart' },
@@ -755,9 +768,9 @@ test.describe('Edge Checkout', () => {
 
     test('incrementing quantity in minicart updates badge and localStorage', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
@@ -779,9 +792,9 @@ test.describe('Edge Checkout', () => {
 
     test('decrementing quantity to zero removes item and closes minicart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await waitForElement(page, '.quantity-container button');
+      await waitForAddToCartButton(page);
 
-      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await page.locator('.quantity-container button').click();
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -1,0 +1,779 @@
+/* eslint-disable no-console */
+import { test, expect } from '@playwright/test';
+import {
+  getCurrentBranch,
+  buildProductUrl,
+  waitForElement,
+} from '../utils/test-helpers.js';
+
+/**
+ * Integration tests for the edge checkout flow.
+ *
+ * Edge cart behaviour:
+ * - Cart stored in localStorage under `cart:${locale}` (e.g. cart:us, cart:ca)
+ * - Schema: { version: 1, items: [...] }
+ * - On desktop (≥900px): opens minicart popover (#minicart) after add-to-cart
+ * - On mobile (<900px): minicart does not open; cart icon href navigates to /order/cart
+ * - Default max quantity per SKU: 3; blocked adds silently re-enable the button
+ * - Paid warranty tier stored as a hidden linked item (custom.linkedTo, local.showInCart: false)
+ * - visibleItemCount excludes hidden items; cart badge tracks visibleItemCount
+ */
+
+const CART_KEY_US = 'cart:us';
+const CART_KEY_CA = 'cart:ca';
+
+async function getCart(page, key = CART_KEY_US) {
+  const raw = await page.evaluate((k) => localStorage.getItem(k), key);
+  return raw ? JSON.parse(raw) : null;
+}
+
+test.describe('Edge Checkout', () => {
+  let currentBranch;
+
+  test.beforeAll(async () => {
+    currentBranch = await getCurrentBranch();
+    console.log(`Running tests against branch: ${currentBranch}`);
+  });
+
+  // ─── Configurable product ────────────────────────────────────────────────────
+
+  test.describe('Configurable Product - Ascent X2', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test('add to cart opens minicart on desktop', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true');
+      console.log('✓ Minicart opens after add-to-cart');
+    });
+
+    test('item stored in localStorage with correct schema', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600); // allow debounced persist to flush
+
+      const cart = await getCart(page);
+      expect(cart).not.toBeNull();
+      expect(cart.version).toBe(1);
+      expect(cart.items).toHaveLength(1);
+
+      const item = cart.items[0];
+      expect(item.sku).toBeTruthy();
+      expect(item.quantity).toBe(1);
+      expect(parseFloat(item.price)).toBeGreaterThan(0);
+      expect(item.name).toBeTruthy();
+      expect(item.path).toMatch(/^\/us\/en_us\/products\//);
+      console.log(`✓ Stored: sku=${item.sku}, qty=${item.quantity}, price=${item.price}`);
+    });
+
+    test('cart count badge updates after add-to-cart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).not.toHaveAttribute('data-cart-items');
+
+      await page.locator('.quantity-container button').click();
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
+      console.log('✓ Cart badge shows 1 after add-to-cart');
+    });
+
+    test('minicart shows the added item', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+      console.log('✓ Minicart renders at least one cart item');
+    });
+
+    test('minicart closes via × button', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      await minicart.locator('.slide-panel-close').click();
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      console.log('✓ Minicart closes via × button');
+    });
+
+    test('minicart closes on backdrop click', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      // Click outside the dialog bounds (top-left corner of viewport)
+      await page.mouse.click(5, 5);
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      console.log('✓ Minicart closes on backdrop click');
+    });
+
+    test('minicart checkout button links to /order/checkout', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      const checkoutBtn = minicart.locator('a[href*="/order/checkout"]');
+      await expect(checkoutBtn.first()).toBeVisible({ timeout: 5000 });
+      await expect(checkoutBtn.first()).toHaveAttribute('href', /\/order\/checkout/);
+      console.log('✓ Checkout button links to /order/checkout');
+    });
+
+    test('cart link href points to /order/cart in edge mode', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await page.waitForLoadState('networkidle');
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
+      console.log('✓ Cart icon href is /us/en_us/order/cart in edge mode');
+    });
+  });
+
+  // ─── Simple product ──────────────────────────────────────────────────────────
+
+  test.describe('Simple Product - 20-ounce Travel Cup', () => {
+    const productPath = '/us/en_us/products/20-ounce-travel-cup';
+
+    test('opens minicart and stores item with correct schema', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      await expect(page.locator('#minicart')).toBeVisible({ timeout: 10000 });
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(1);
+      expect(cart.items[0].quantity).toBe(1);
+      // Simple products carry no Magento UIDs in selectedOptions
+      expect(cart.items[0].selectedOptions ?? []).toEqual([]);
+      console.log('✓ Simple product stored in edge cart');
+    });
+  });
+
+  // ─── Bundle product ──────────────────────────────────────────────────────────
+
+  test.describe('Bundle Product - 5200 Legacy Bundle', () => {
+    const productPath = '/us/en_us/products/5200-legacy-bundle';
+
+    test('opens minicart and stores item with bundle data', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      await expect(page.locator('#minicart')).toBeVisible({ timeout: 10000 });
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(1);
+      expect(cart.items[0].sku).toBeTruthy();
+      console.log(`✓ Bundle product stored in edge cart: sku=${cart.items[0].sku}`);
+    });
+  });
+
+  // ─── Quantity limits ─────────────────────────────────────────────────────────
+
+  // Mobile viewport prevents minicart from opening between clicks,
+  // which would otherwise block subsequent interactions.
+  test.describe('Quantity Limits', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    // Helper: click add-to-cart and wait for the async operation to finish.
+    async function clickAndWait(btn, page) {
+      await btn.click();
+      await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await page.waitForTimeout(300);
+    }
+
+    test('can add up to the max quantity of 3', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const btn = page.locator('.quantity-container button');
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+
+      const cart = await getCart(page);
+      expect(cart.items[0].quantity).toBe(3);
+      console.log('✓ Cart accepted 3 adds; quantity = 3');
+    });
+
+    test('4th add-to-cart is silently blocked when already at max', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const btn = page.locator('.quantity-container button');
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+
+      // 4th click — allowedQty = 0, should return early
+      await btn.click();
+      await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+
+      const cart = await getCart(page);
+      expect(cart.items[0].quantity).toBe(3);
+      console.log('✓ Quantity remains 3 after 4th add-to-cart attempt');
+    });
+
+    test('button re-enables and resets text after a blocked add', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const btn = page.locator('.quantity-container button');
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+      await clickAndWait(btn, page);
+
+      await btn.click();
+      await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await expect(btn).toContainText(/add to cart/i);
+      console.log('✓ Button re-enables and text resets after blocked add');
+    });
+  });
+
+  // ─── Warranty selection ──────────────────────────────────────────────────────
+
+  test.describe('Warranty Selection', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test('no warranty item in cart when default (no-cost) tier is active', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      // Don't change the default warranty selection
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(1);
+      expect(cart.items[0].custom?.linkedTo).toBeUndefined();
+      console.log('✓ No linked warranty item for default (included) tier');
+    });
+
+    test('paid warranty tier adds a hidden linked item to the cart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const warrantyOptions = page.locator('.pdp-warranty-option');
+      if (await warrantyOptions.count() < 2) {
+        console.log('ℹ No paid warranty options on this product — skipping');
+        return;
+      }
+
+      await warrantyOptions.nth(1).locator('input').click();
+      await page.waitForTimeout(500);
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(2);
+
+      const mainItem = cart.items.find((i) => !i.custom?.linkedTo);
+      const warrantyItem = cart.items.find((i) => i.custom?.linkedTo);
+
+      expect(mainItem).toBeDefined();
+      expect(warrantyItem).toBeDefined();
+      expect(warrantyItem.custom.linkedTo).toBe(mainItem.sku);
+      expect(warrantyItem.local.showInCart).toBe(false);
+      expect(warrantyItem.quantity).toBe(1);
+      expect(parseFloat(warrantyItem.price)).toBeGreaterThan(0);
+      console.log(`✓ Warranty sku=${warrantyItem.sku} linked to ${mainItem.sku}, hidden`);
+    });
+
+    test('warranty hidden item excluded from cart badge count', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const warrantyOptions = page.locator('.pdp-warranty-option');
+      if (await warrantyOptions.count() < 2) {
+        console.log('ℹ No paid warranty options on this product — skipping');
+        return;
+      }
+
+      await warrantyOptions.nth(1).locator('input').click();
+      await page.waitForTimeout(500);
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(500);
+
+      // visibleItemCount = 1 (warranty is excluded), so badge shows 1
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
+      console.log('✓ Badge shows 1; hidden warranty item not counted');
+    });
+
+    test('warranty item quantity matches parent quantity', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const warrantyOptions = page.locator('.pdp-warranty-option');
+      if (await warrantyOptions.count() < 2) {
+        console.log('ℹ No paid warranty options on this product — skipping');
+        return;
+      }
+
+      await warrantyOptions.nth(1).locator('input').click();
+      await page.waitForTimeout(500);
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      const mainItem = cart.items.find((i) => !i.custom?.linkedTo);
+      const warrantyItem = cart.items.find((i) => i.custom?.linkedTo);
+
+      if (warrantyItem) {
+        expect(warrantyItem.quantity).toBe(mainItem.quantity);
+        console.log(`✓ Warranty qty ${warrantyItem.quantity} matches product qty ${mainItem.quantity}`);
+      }
+    });
+
+    test('warranty item visible on cart page inside minicart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const warrantyOptions = page.locator('.pdp-warranty-option');
+      if (await warrantyOptions.count() < 2) {
+        console.log('ℹ No paid warranty options on this product — skipping');
+        return;
+      }
+
+      await warrantyOptions.nth(1).locator('input').click();
+      await page.waitForTimeout(500);
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      // Only one visible row in the minicart (warranty is hidden from cart UI)
+      const cartItems = minicart.locator('.cart-item');
+      await expect(cartItems).toHaveCount(1, { timeout: 5000 });
+      console.log('✓ Minicart shows 1 item; hidden warranty item not rendered');
+    });
+  });
+
+  // ─── Cart persistence ─────────────────────────────────────────────────────────
+
+  test.describe('Cart Persistence', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test('cart survives a page reload', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      if (await minicart.isVisible()) {
+        await minicart.locator('.slide-panel-close').click();
+        await page.waitForTimeout(400);
+      }
+
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      const cart = await getCart(page);
+      expect(cart).not.toBeNull();
+      expect(cart.items).toHaveLength(1);
+      expect(cart.items[0].quantity).toBe(1);
+      console.log('✓ Cart persists after page reload');
+    });
+
+    test('cart badge restored from localStorage on page load', async ({ page }) => {
+      // Seed localStorage before the page script initialises the cart
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await page.waitForLoadState('networkidle');
+
+      await page.evaluate((key) => {
+        localStorage.setItem(key, JSON.stringify({
+          version: 1,
+          items: [
+            {
+              sku: 'seed-sku-1', quantity: 1, price: '9.99', name: 'Product A', path: '/us/en_us/products/a',
+            },
+            {
+              sku: 'seed-sku-2', quantity: 2, price: '4.99', name: 'Product B', path: '/us/en_us/products/b',
+            },
+          ],
+        }));
+      }, CART_KEY_US);
+
+      // Reload so the header picks up the seeded items via cart:change restore event
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      // visibleItemCount = 1+2 = 3
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '3', { timeout: 5000 });
+      console.log('✓ Cart badge shows 3 after restoring from localStorage');
+    });
+
+    test('minicart closes automatically when cart is emptied', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      // Remove the item directly via the cart API to trigger cart:empty
+      await page.evaluate(() => {
+        // Dispatch a cart:change event with action='empty' to simulate cart being emptied
+        // (the real path is: remove last item → quantity hits 0 → empty event)
+        const cartItem = document.querySelector('#minicart .cart-item');
+        const removeBtn = cartItem?.querySelector('button[aria-label*="remove"], button[aria-label*="Remove"], .cart-item-remove');
+        if (removeBtn) removeBtn.click();
+      });
+
+      // After emptying, minicart closes
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+      console.log('✓ Minicart closes when cart becomes empty');
+    });
+  });
+
+  // ─── Mobile behaviour ─────────────────────────────────────────────────────────
+
+  test.describe('Mobile Behaviour', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('minicart does NOT open after add-to-cart on mobile', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(1000);
+
+      await expect(page.locator('#minicart')).not.toBeVisible();
+      console.log('✓ Minicart does not open on mobile');
+    });
+
+    test('cart badge updates on mobile after add-to-cart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
+      console.log('✓ Cart badge updates on mobile');
+    });
+
+    test('cart icon links to /order/cart on mobile', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await page.waitForLoadState('networkidle');
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
+      console.log('✓ Cart icon href is /us/en_us/order/cart on mobile');
+    });
+  });
+
+  // ─── FR-CA locale ─────────────────────────────────────────────────────────────
+
+  test.describe('FR-CA Locale', () => {
+    const productPath = '/ca/fr_ca/products/ascent-x2';
+
+    test('cart stored under cart:ca key, not cart:us', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const caCart = await getCart(page, CART_KEY_CA);
+      const usCart = await getCart(page, CART_KEY_US);
+
+      expect(caCart).not.toBeNull();
+      expect(caCart.items).toHaveLength(1);
+      expect(usCart).toBeNull();
+      console.log('✓ FR-CA cart stored under cart:ca, cart:us is empty');
+    });
+
+    test('cart badge updates using FR-CA cart data', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
+      console.log('✓ FR-CA cart badge shows 1 after add-to-cart');
+    });
+
+    test('FR-CA cart survives page reload', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      if (await minicart.isVisible()) {
+        await minicart.locator('.slide-panel-close').click();
+        await page.waitForTimeout(400);
+      }
+
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      const caCart = await getCart(page, CART_KEY_CA);
+      expect(caCart.items).toHaveLength(1);
+      console.log('✓ FR-CA cart persists after page reload');
+    });
+  });
+
+  // ─── Add-to-cart behaviour ────────────────────────────────────────────────────
+
+  test.describe('Add-to-cart Behaviour', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    // Mobile viewport so minicart does not open between clicks.
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('adding the same item twice increments quantity, not a separate entry', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      const btn = page.locator('.quantity-container button');
+      await btn.click();
+      await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await page.waitForTimeout(300);
+      await btn.click();
+      await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(1);
+      expect(cart.items[0].quantity).toBe(2);
+      console.log('✓ Second add-to-cart merged: quantity = 2, items.length = 1');
+    });
+
+    test('deeplinked variant stores variant sku and parentSku', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge', color: 'polar-white' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      expect(cart.items).toHaveLength(1);
+
+      const item = cart.items[0];
+      // Variant SKU differs from the parent configurable SKU
+      expect(item.sku).not.toBe('Ascent X2');
+      // Parent SKU is stored separately so the order API can resolve the variant
+      expect(item.parentSku).toBe('Ascent X2');
+      // Semantic selected options include the color selection
+      const colorOption = item.selectedOptions?.find((o) => o.id === 'color');
+      expect(colorOption).toBeDefined();
+      expect(colorOption.value).toBeTruthy();
+      console.log(`✓ Deeplinked variant stored: sku=${item.sku}, parentSku=${item.parentSku}, color=${colorOption?.value}`);
+    });
+
+    test('product without warranties stores no local.availableWarranties', async ({ page }) => {
+      // Simple product has no warranty options
+      const simplePath = '/us/en_us/products/20-ounce-travel-cup';
+      await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+      await page.waitForTimeout(600);
+
+      const cart = await getCart(page);
+      expect(cart.items[0].local?.availableWarranties).toBeUndefined();
+      console.log('✓ No availableWarranties stored for product without warranty options');
+    });
+  });
+
+  // ─── Minicart interactions ────────────────────────────────────────────────────
+
+  test.describe('Minicart Interactions', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test('cart icon click opens minicart independently of add-to-cart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      // Add to cart so there is something in the cart
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+
+      // Close minicart
+      await minicart.locator('.slide-panel-close').click();
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      await page.waitForTimeout(400);
+
+      // Now click the cart icon directly — different code path from pdp:add-to-cart
+      await page.locator('header a[href*="/order/cart"]').click();
+
+      await expect(minicart).toBeVisible({ timeout: 5000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true');
+      console.log('✓ Cart icon click opens minicart independently');
+    });
+
+    test('removing the only item closes minicart and clears badge', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+
+      // Click remove on the only cart item
+      await minicart.locator('.cart-item-remove').first().click();
+
+      // Minicart closes automatically when cart becomes empty
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+
+      // Badge is removed
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
+
+      // localStorage is empty
+      const cart = await getCart(page);
+      expect(cart?.items ?? []).toHaveLength(0);
+      console.log('✓ Removing last item closes minicart and clears badge');
+    });
+
+    test('removing one of two items decrements badge but keeps minicart open', async ({ page }) => {
+      // Use mobile so we can add two different products without the minicart blocking
+      await page.setViewportSize({ width: 390, height: 844 });
+
+      // Add Ascent X2
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+      await page.locator('.quantity-container button').click();
+      await expect(page.locator('.quantity-container button')).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+
+      // Add simple product to get a second item
+      const simplePath = '/us/en_us/products/20-ounce-travel-cup';
+      await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+      await page.locator('.quantity-container button').click();
+      await expect(page.locator('.quantity-container button')).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+
+      // Switch to desktop and open minicart via cart icon
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.locator('header a[href*="/order/cart"]').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart.locator('.cart-item')).toHaveCount(2, { timeout: 5000 });
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '2');
+
+      // Remove the first item
+      await minicart.locator('.cart-item-remove').first().click();
+      await page.waitForTimeout(500);
+
+      // Minicart stays open (still one item)
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart.locator('.cart-item')).toHaveCount(1, { timeout: 5000 });
+
+      // Badge decrements to 1
+      await expect(cartLink).toHaveAttribute('data-cart-items', '1');
+      console.log('✓ Removing one of two items decrements badge; minicart stays open');
+    });
+
+    test('incrementing quantity in minicart updates badge and localStorage', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+
+      // Click the + button in the minicart cart item
+      await minicart.locator('.qty-inc').first().click();
+      await page.waitForTimeout(600);
+
+      // Badge should now show 2
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).toHaveAttribute('data-cart-items', '2', { timeout: 5000 });
+
+      // localStorage quantity updated
+      const cart = await getCart(page);
+      expect(cart.items[0].quantity).toBe(2);
+      console.log('✓ Qty + in minicart: badge = 2, localStorage qty = 2');
+    });
+
+    test('decrementing quantity to zero removes item and closes minicart', async ({ page }) => {
+      await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
+      await waitForElement(page, '.quantity-container button');
+
+      await page.locator('.quantity-container button').click();
+
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toBeVisible({ timeout: 10000 });
+      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+
+      // The qty starts at 1; clicking − triggers handleQtyChange(0)
+      // which is clamped to min=1, so the qty-dec path is effectively
+      // handled by the remove button. Use remove instead.
+      await minicart.locator('.cart-item-remove').first().click();
+
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
+      console.log('✓ Removing last item via minicart closes it and clears badge');
+    });
+
+    test('minicart does not open when cart icon clicked on the cart page', async ({ page }) => {
+      // Navigate to the edge cart page itself
+      const cartPageUrl = buildProductUrl('/us/en_us/order/cart', currentBranch, { cart: 'edge' });
+      await page.goto(cartPageUrl);
+      await page.waitForLoadState('networkidle');
+
+      const cartLink = page.locator('header a[href*="/order/cart"]');
+      if (await cartLink.count() === 0) {
+        console.log('ℹ Cart icon not present on cart page — skipping');
+        return;
+      }
+
+      await cartLink.click();
+      await page.waitForTimeout(500);
+
+      // #minicart is created lazily; it should not exist or not be visible
+      const minicart = page.locator('#minicart');
+      const exists = await minicart.count();
+      if (exists > 0) {
+        await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      }
+      console.log('✓ Cart icon click is a no-op when already on the cart page');
+    });
+  });
+});

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -49,6 +49,9 @@ test.describe('Edge Checkout', () => {
   test.describe('Configurable Product - Ascent X2', () => {
     const productPath = '/us/en_us/products/ascent-x2';
 
+    // openOrRedirect() returns early when window.innerWidth < 900 — force desktop
+    test.use({ viewport: { width: 1280, height: 720 } });
+
     test('add to cart opens minicart on desktop', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
@@ -116,7 +119,7 @@ test.describe('Edge Checkout', () => {
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
 
       await minicart.locator('.slide-panel-close').click();
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       console.log('✓ Minicart closes via × button');
     });
 
@@ -152,10 +155,9 @@ test.describe('Edge Checkout', () => {
 
     test('cart link href points to /order/cart in edge mode', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await page.waitForLoadState('networkidle');
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
-      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
+      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/, { timeout: 15000 });
       console.log('✓ Cart icon href is /us/en_us/order/cart in edge mode');
     });
   });
@@ -164,6 +166,8 @@ test.describe('Edge Checkout', () => {
 
   test.describe('Simple Product - 20-ounce Travel Cup', () => {
     const productPath = '/us/en_us/products/20-ounce-travel-cup';
+
+    test.use({ viewport: { width: 1280, height: 720 } });
 
     test('opens minicart and stores item with correct schema', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
@@ -186,6 +190,8 @@ test.describe('Edge Checkout', () => {
 
   test.describe('Bundle Product - 5200 Legacy Bundle', () => {
     const productPath = '/us/en_us/products/5200-legacy-bundle';
+
+    test.use({ viewport: { width: 1280, height: 720 } });
 
     test('opens minicart and stores item with bundle data', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
@@ -270,6 +276,8 @@ test.describe('Edge Checkout', () => {
 
   test.describe('Warranty Selection', () => {
     const productPath = '/us/en_us/products/ascent-x2';
+
+    test.use({ viewport: { width: 1280, height: 720 } });
 
     test('no warranty item in cart when default (no-cost) tier is active', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
@@ -391,11 +399,19 @@ test.describe('Edge Checkout', () => {
   test.describe('Cart Persistence', () => {
     const productPath = '/us/en_us/products/ascent-x2';
 
+    test.use({ viewport: { width: 1280, height: 720 } });
+
     test('cart survives a page reload', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
       await page.locator('.quantity-container button').click();
+
+      // Poll until cart is actually written to localStorage before reloading
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Cart was not persisted to localStorage before reload' },
+      ).toBeGreaterThan(0);
 
       const minicart = page.locator('#minicart');
       if (await minicart.isVisible()) {
@@ -404,7 +420,7 @@ test.describe('Edge Checkout', () => {
       }
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       const cart = await getCart(page);
       expect(cart).not.toBeNull();
@@ -416,7 +432,7 @@ test.describe('Edge Checkout', () => {
     test('cart badge restored from localStorage on page load', async ({ page }) => {
       // Seed localStorage before the page script initialises the cart
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.evaluate((key) => {
         localStorage.setItem(key, JSON.stringify({
@@ -434,7 +450,7 @@ test.describe('Edge Checkout', () => {
 
       // Reload so the header picks up the seeded items via cart:change restore event
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // visibleItemCount = 1+2 = 3
       const cartLink = page.locator(CART_LINK_SELECTOR);
@@ -450,18 +466,13 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
-      // Remove the item directly via the cart API to trigger cart:empty
-      await page.evaluate(() => {
-        // Dispatch a cart:change event with action='empty' to simulate cart being emptied
-        // (the real path is: remove last item → quantity hits 0 → empty event)
-        const cartItem = document.querySelector('#minicart .cart-item');
-        const removeBtn = cartItem?.querySelector('button[aria-label*="remove"], button[aria-label*="Remove"], .cart-item-remove');
-        if (removeBtn) removeBtn.click();
-      });
+      // Click the remove button via Playwright so the handler fires correctly
+      await minicart.locator('.cart-item-remove').first().click();
 
       // After emptying, minicart closes
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       console.log('✓ Minicart closes when cart becomes empty');
     });
   });
@@ -497,10 +508,9 @@ test.describe('Edge Checkout', () => {
 
     test('cart icon links to /order/cart on mobile', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
-      await page.waitForLoadState('networkidle');
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
-      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/);
+      await expect(cartLink).toHaveAttribute('href', /\/us\/en_us\/order\/cart/, { timeout: 15000 });
       console.log('✓ Cart icon href is /us/en_us/order/cart on mobile');
     });
   });
@@ -509,6 +519,8 @@ test.describe('Edge Checkout', () => {
 
   test.describe('FR-CA Locale', () => {
     const productPath = '/ca/fr_ca/products/ascent-x2';
+
+    test.use({ viewport: { width: 1280, height: 720 } });
 
     test('cart stored under cart:ca key, not cart:us', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
@@ -543,6 +555,12 @@ test.describe('Edge Checkout', () => {
 
       await page.locator('.quantity-container button').click();
 
+      // Poll until cart is actually written to localStorage before reloading
+      await expect.poll(
+        () => getCart(page, CART_KEY_CA).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'FR-CA cart was not persisted to localStorage before reload' },
+      ).toBeGreaterThan(0);
+
       const minicart = page.locator('#minicart');
       if (await minicart.isVisible()) {
         await minicart.locator('.slide-panel-close').click();
@@ -550,7 +568,7 @@ test.describe('Edge Checkout', () => {
       }
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       const caCart = await getCart(page, CART_KEY_CA);
       expect(caCart.items).toHaveLength(1);
@@ -626,6 +644,8 @@ test.describe('Edge Checkout', () => {
   test.describe('Minicart Interactions', () => {
     const productPath = '/us/en_us/products/ascent-x2';
 
+    test.use({ viewport: { width: 1280, height: 720 } });
+
     test('cart icon click opens minicart independently of add-to-cart', async ({ page }) => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
@@ -662,15 +682,17 @@ test.describe('Edge Checkout', () => {
       await minicart.locator('.cart-item-remove').first().click();
 
       // Minicart closes automatically when cart becomes empty
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
 
       // Badge is removed
       const cartLink = page.locator(CART_LINK_SELECTOR);
-      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
+      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 5000 });
 
-      // localStorage is empty
-      const cart = await getCart(page);
-      expect(cart?.items ?? []).toHaveLength(0);
+      // localStorage is empty — poll to allow the async persist to flush
+      await expect.poll(async () => {
+        const cart = await getCart(page);
+        return cart?.items?.length ?? 0;
+      }, { timeout: 5000, message: 'Cart should be empty in localStorage after removing last item' }).toBe(0);
       console.log('✓ Removing last item closes minicart and clears badge');
     });
 
@@ -754,9 +776,9 @@ test.describe('Edge Checkout', () => {
       // handled by the remove button. Use remove instead.
       await minicart.locator('.cart-item-remove').first().click();
 
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       const cartLink = page.locator(CART_LINK_SELECTOR);
-      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 3000 });
+      await expect(cartLink).not.toHaveAttribute('data-cart-items', { timeout: 5000 });
       console.log('✓ Removing last item via minicart closes it and clears badge');
     });
 
@@ -764,7 +786,7 @@ test.describe('Edge Checkout', () => {
       // Navigate to the edge cart page itself
       const cartPageUrl = buildProductUrl('/us/en_us/order/cart', currentBranch, { cart: 'edge' });
       await page.goto(cartPageUrl);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       if (await cartLink.count() === 0) {

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -56,10 +56,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart).toHaveAttribute('aria-expanded', 'true');
       console.log('✓ Minicart opens after add-to-cart');
     });
@@ -68,7 +68,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600); // allow debounced persist to flush
 
       const cart = await getCart(page);
@@ -92,7 +92,7 @@ test.describe('Edge Checkout', () => {
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).not.toHaveAttribute('data-cart-items');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
       console.log('✓ Cart badge shows 1 after add-to-cart');
     });
@@ -101,10 +101,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
       console.log('✓ Minicart renders at least one cart item');
     });
@@ -113,10 +113,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
       await minicart.locator('.slide-panel-close').click();
       await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
@@ -127,14 +127,14 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
       // Click outside the dialog bounds (top-left corner of viewport)
       await page.mouse.click(5, 5);
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       console.log('✓ Minicart closes on backdrop click');
     });
 
@@ -142,10 +142,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
       const checkoutBtn = minicart.locator('a[href*="/order/checkout"]');
       await expect(checkoutBtn.first()).toBeVisible({ timeout: 5000 });
@@ -173,12 +173,17 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
-      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
+
+      // Poll until the debounced cart persist has flushed to localStorage
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Simple product cart not persisted to localStorage' },
+      ).toBe(1);
 
       const cart = await getCart(page);
-      expect(cart.items).toHaveLength(1);
       expect(cart.items[0].quantity).toBe(1);
       // Simple products carry no Magento UIDs in selectedOptions
       expect(cart.items[0].selectedOptions ?? []).toEqual([]);
@@ -197,12 +202,17 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
-      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(page.locator('#minicart')).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
+
+      // Poll until the debounced cart persist has flushed to localStorage
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Bundle product cart not persisted to localStorage' },
+      ).toBe(1);
 
       const cart = await getCart(page);
-      expect(cart.items).toHaveLength(1);
       expect(cart.items[0].sku).toBeTruthy();
       console.log(`✓ Bundle product stored in edge cart: sku=${cart.items[0].sku}`);
     });
@@ -284,7 +294,7 @@ test.describe('Edge Checkout', () => {
       await waitForElement(page, '.quantity-container button');
 
       // Don't change the default warranty selection
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -306,7 +316,7 @@ test.describe('Edge Checkout', () => {
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -336,7 +346,7 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(500);
 
       // visibleItemCount = 1 (warranty is excluded), so badge shows 1
@@ -357,7 +367,7 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -382,10 +392,10 @@ test.describe('Edge Checkout', () => {
 
       await warrantyOptions.nth(1).locator('input').click();
       await page.waitForTimeout(500);
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
       // Only one visible row in the minicart (warranty is hidden from cart UI)
       const cartItems = minicart.locator('.cart-item');
@@ -405,7 +415,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       // Poll until cart is actually written to localStorage before reloading
       await expect.poll(
@@ -462,10 +472,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // Click the remove button via Playwright so the handler fires correctly
@@ -488,7 +498,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(1000);
 
       await expect(page.locator('#minicart')).not.toBeVisible();
@@ -499,7 +509,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
@@ -526,7 +536,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const caCart = await getCart(page, CART_KEY_CA);
@@ -542,7 +552,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '1', { timeout: 5000 });
@@ -553,7 +563,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       // Poll until cart is actually written to localStorage before reloading
       await expect.poll(
@@ -606,7 +616,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge', color: 'polar-white' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -630,7 +640,7 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
       await page.waitForTimeout(600);
 
       const cart = await getCart(page);
@@ -651,14 +661,14 @@ test.describe('Edge Checkout', () => {
       await waitForElement(page, '.quantity-container button');
 
       // Add to cart so there is something in the cart
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
 
       // Close minicart
       await minicart.locator('.slide-panel-close').click();
-      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
       await page.waitForTimeout(400);
 
       // Now click the cart icon directly — different code path from pdp:add-to-cart
@@ -672,10 +682,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // Click remove on the only cart item
@@ -700,25 +710,31 @@ test.describe('Edge Checkout', () => {
       // Use mobile so we can add two different products without the minicart blocking
       await page.setViewportSize({ width: 390, height: 844 });
 
-      // Add Ascent X2
+      // Add Ascent X2 and confirm it's in localStorage before navigating away
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
-      await page.locator('.quantity-container button').click();
-      await expect(page.locator('.quantity-container button')).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'First item (Ascent X2) not added to cart' },
+      ).toBe(1);
 
-      // Add simple product to get a second item
+      // Add simple product to get a second item and confirm both are persisted
       const simplePath = '/us/en_us/products/20-ounce-travel-cup';
       await page.goto(buildProductUrl(simplePath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
-      await page.locator('.quantity-container button').click();
-      await expect(page.locator('.quantity-container button')).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
+      await expect.poll(
+        () => getCart(page).then((c) => c?.items?.length ?? 0),
+        { timeout: 10000, message: 'Second item (Travel Cup) not added to cart' },
+      ).toBe(2);
 
       // Switch to desktop and open minicart via cart icon
       await page.setViewportSize({ width: 1280, height: 720 });
       await page.locator(CART_LINK_SELECTOR).click();
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item')).toHaveCount(2, { timeout: 20000 });
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
@@ -729,7 +745,7 @@ test.describe('Edge Checkout', () => {
       await page.waitForTimeout(500);
 
       // Minicart stays open (still one item)
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true');
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 5000 });
       await expect(minicart.locator('.cart-item')).toHaveCount(1, { timeout: 20000 });
 
       // Badge decrements to 1
@@ -741,10 +757,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // Click the + button in the minicart cart item
@@ -765,10 +781,10 @@ test.describe('Edge Checkout', () => {
       await page.goto(buildProductUrl(productPath, currentBranch, { cart: 'edge' }));
       await waitForElement(page, '.quantity-container button');
 
-      await page.locator('.quantity-container button').click();
+      await page.locator('.quantity-container button').evaluate((el) => el.click());
 
       const minicart = page.locator('#minicart');
-      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 30000 });
       await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // The qty starts at 1; clicking − triggers handleQtyChange(0)

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -32,6 +32,11 @@ async function getCart(page, key = CART_KEY_US) {
 const CART_LINK_SELECTOR = 'header a:has(.icon-cart)';
 
 test.describe('Edge Checkout', () => {
+  // Disable retries for this file — the failing tests don't recover with
+  // re-runs (their issues are timing / DOM-readiness), and 2 retries per
+  // failure was tripling total CI time without improving outcomes.
+  test.describe.configure({ retries: 0 });
+
   let currentBranch;
 
   test.beforeAll(async () => {
@@ -97,7 +102,7 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
-      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+      await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
       console.log('✓ Minicart renders at least one cart item');
     });
 
@@ -651,7 +656,7 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
-      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+      await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // Click remove on the only cart item
       await minicart.locator('.cart-item-remove').first().click();
@@ -692,7 +697,7 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
-      await expect(minicart.locator('.cart-item')).toHaveCount(2, { timeout: 5000 });
+      await expect(minicart.locator('.cart-item')).toHaveCount(2, { timeout: 20000 });
 
       const cartLink = page.locator(CART_LINK_SELECTOR);
       await expect(cartLink).toHaveAttribute('data-cart-items', '2');
@@ -703,7 +708,7 @@ test.describe('Edge Checkout', () => {
 
       // Minicart stays open (still one item)
       await expect(minicart).toHaveAttribute('aria-expanded', 'true');
-      await expect(minicart.locator('.cart-item')).toHaveCount(1, { timeout: 5000 });
+      await expect(minicart.locator('.cart-item')).toHaveCount(1, { timeout: 20000 });
 
       // Badge decrements to 1
       await expect(cartLink).toHaveAttribute('data-cart-items', '1');
@@ -718,7 +723,7 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
-      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+      await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // Click the + button in the minicart cart item
       await minicart.locator('.qty-inc').first().click();
@@ -742,7 +747,7 @@ test.describe('Edge Checkout', () => {
 
       const minicart = page.locator('#minicart');
       await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 15000 });
-      await expect(minicart.locator('.cart-item').first()).toBeVisible({ timeout: 5000 });
+      await expect(minicart.locator('.cart-item').first()).toBeAttached({ timeout: 20000 });
 
       // The qty starts at 1; clicking − triggers handleQtyChange(0)
       // which is clamped to min=1, so the qty-dec path is effectively

--- a/tests/cart/stale-session.spec.js
+++ b/tests/cart/stale-session.spec.js
@@ -76,7 +76,7 @@ test.describe('Stale Session Cart ID', () => {
     });
 
     // Load the product page
-    const productUrl = buildProductUrl(productPath, currentBranch);
+    const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
     await page.goto(productUrl);
     await page.waitForLoadState('networkidle');
 

--- a/tests/cart/storage.spec.js
+++ b/tests/cart/storage.spec.js
@@ -28,7 +28,7 @@ test.describe('Cart Storage Tests', () => {
     const storePath = '/us/en_us';
 
     test('should use original mage-cache-storage key', async ({ page }) => {
-      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       // Trigger a cart interaction to populate localStorage
@@ -96,7 +96,7 @@ test.describe('Cart Storage Tests', () => {
         });
       });
 
-      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       // Wait for add to cart button
@@ -119,7 +119,7 @@ test.describe('Cart Storage Tests', () => {
         expect(cartData['side-by-side'].cart_id).toBe('us-cart-abc123');
         console.log('✓ US cart stored in mage-cache-storage with correct cart_id');
       } else {
-        expect.fail('US cart not stored in mage-cache-storage');
+        throw new Error('US cart not stored in mage-cache-storage');
       }
     });
   });
@@ -162,7 +162,7 @@ test.describe('Cart Storage Tests', () => {
         });
       });
 
-      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       // Wait for add to cart button
@@ -215,7 +215,7 @@ test.describe('Cart Storage Tests', () => {
         });
       });
 
-      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}${storePath}/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       const addToCartButton = page.locator('.quantity-container button');
@@ -234,7 +234,7 @@ test.describe('Cart Storage Tests', () => {
         expect(cartData['side-by-side'].cart_id).toBe('fr-cart-isolated');
         console.log('✓ FR-CA cart stored in mage-cache-storage-ca-fr_ca with correct cart_id');
       } else {
-        expect.fail('FR-CA cart not stored in mage-cache-storage-ca-fr_ca');
+        throw new Error('FR-CA cart not stored in mage-cache-storage-ca-fr_ca');
       }
     });
   });
@@ -276,7 +276,7 @@ test.describe('Cart Storage Tests', () => {
       });
 
       // Step 1: Add to cart on US store
-      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       let addToCartButton = page.locator('.quantity-container button');
@@ -294,7 +294,7 @@ test.describe('Cart Storage Tests', () => {
       console.log('✓ US cart stored correctly');
 
       // Step 2: Navigate to FR-CA store and add to cart
-      await page.goto(`${baseUrl}/ca/fr_ca/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}/ca/fr_ca/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       addToCartButton = page.locator('.quantity-container button');
@@ -321,7 +321,7 @@ test.describe('Cart Storage Tests', () => {
       console.log('✓ US cart still intact after FR-CA interaction');
 
       // Step 4: Navigate back to US and verify cart is preserved
-      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       const usCartFinal = await page.evaluate(() => {
@@ -368,7 +368,7 @@ test.describe('Cart Storage Tests', () => {
         });
       });
 
-      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}/us/en_us/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       const addToCartButton = page.locator('.quantity-container button');
@@ -412,7 +412,7 @@ test.describe('Cart Storage Tests', () => {
         });
       });
 
-      await page.goto(`${baseUrl}/ca/fr_ca/products/ascent-x2?martech=off`);
+      await page.goto(`${baseUrl}/ca/fr_ca/products/ascent-x2?martech=off&cart=magento`);
       await page.waitForLoadState('networkidle');
 
       const addToCartButton = page.locator('.quantity-container button');

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -193,6 +193,10 @@ test.describe('Edge Checkout Page', () => {
   let currentBranch;
   let baseUrl;
 
+  // The checkout flow involves multiple async operations (shipping rates,
+  // preview, order create, payment); allow extra time over the default 30s.
+  test.describe.configure({ timeout: 60000 });
+
   test.beforeAll(async () => {
     currentBranch = await getCurrentBranch();
     baseUrl = getBaseUrl(currentBranch);

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -25,19 +25,6 @@ import {
 
 const TEST_EMAIL = 'qa-test@example.com';
 
-const TEST_ITEM = {
-  sku: 'test-ascent-x2-black',
-  parentSku: 'Ascent X2',
-  quantity: 1,
-  price: '549.99',
-  name: 'Ascent X2 Blender',
-  url: 'https://www.vitamix.com/us/en_us/products/ascent-x2',
-  path: '/us/en_us/products/ascent-x2',
-  image: 'https://www.vitamix.com/dummy.jpg',
-  variant: 'Black',
-  selectedOptions: [{ id: 'color', value: 'black' }],
-};
-
 const VALID_ADDRESS = {
   firstName: 'Test',
   lastName: 'User',
@@ -72,10 +59,29 @@ const MOCK_ORDER_ID = 'mock-order-12345';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-async function seedCart(page, items = [TEST_ITEM]) {
-  await page.addInitScript((cart) => {
-    localStorage.setItem('cart:us', JSON.stringify(cart));
-  }, { version: 1, items });
+/**
+ * Seed the edge cart with a real product by visiting a PDP and clicking
+ * "Add to Cart". The cart persists to localStorage and survives the
+ * subsequent navigation to /us/en_us/order/checkout, so the checkout
+ * block renders the form instead of the empty state.
+ *
+ * Using addInitScript to seed cart:us directly did not work — the cart
+ * module on the checkout page does not pick up pre-seeded localStorage
+ * the same way it picks up cart items added through the real ATC flow.
+ *
+ * @param {string} productPath Defaults to Ascent X2 PDP.
+ */
+async function seedCart(page, baseUrl, productPath = '/us/en_us/products/ascent-x2') {
+  await page.goto(`${baseUrl}${productPath}?cart=edge&martech=off`);
+  const atc = page.locator('.quantity-container button');
+  await atc.waitFor({ state: 'visible', timeout: 15000 });
+  await atc.click();
+  // Cart writes are debounced 300ms; wait long enough for persist to flush.
+  await page.waitForTimeout(1000);
+  const cart = await page.evaluate(() => JSON.parse(localStorage.getItem('cart:us') || 'null'));
+  if (!cart || !cart.items?.length) {
+    throw new Error('Failed to seed cart via PDP add-to-cart');
+  }
 }
 
 /**
@@ -190,12 +196,12 @@ async function fillShipping(page, address = VALID_ADDRESS) {
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 test.describe('Edge Checkout Page', () => {
+  // No retries on these tests; failures need to be investigated, not retried.
+  // Allow extra time over the default 30s — the cart seed visits a PDP first.
+  test.describe.configure({ retries: 0, timeout: 90000 });
+
   let currentBranch;
   let baseUrl;
-
-  // The checkout flow involves multiple async operations (shipping rates,
-  // preview, order create, payment); allow extra time over the default 30s.
-  test.describe.configure({ timeout: 60000 });
 
   test.beforeAll(async () => {
     currentBranch = await getCurrentBranch();
@@ -222,7 +228,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Form rendering', () => {
     test('renders contact section fields', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -233,7 +239,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('renders all required shipping address fields', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -254,7 +260,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('billing defaults to "same as shipping"', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -268,7 +274,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('renders payment method radios', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -279,7 +285,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('renders the submit / continue button', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -288,7 +294,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('order-summary block is auto-injected and shows line items', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -303,7 +309,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Billing address toggle', () => {
     test('shows billing fields when "different" is selected', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -318,7 +324,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('hides billing fields again when "same" is re-selected', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -337,7 +343,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Shipping rates', () => {
     test('fetches and displays rates after address state is selected', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -367,7 +373,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('auto-selects the first shipping rate', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -381,7 +387,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('shows an error / empty state when no rates are available', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         shipping: async (route) => {
           await route.fulfill({
@@ -404,19 +410,21 @@ test.describe('Edge Checkout Page', () => {
   // ─── Order totals ─────────────────────────────────────────────────────────
 
   test.describe('Order totals', () => {
-    test('order summary reflects subtotal from cart', async ({ page }) => {
-      await seedCart(page);
+    test('order summary shows a non-zero subtotal from cart', async ({ page }) => {
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
       const subtotalEl = page.locator('.order-summary-subtotal');
       await expect(subtotalEl).toBeVisible({ timeout: 15000 });
-      await expect(subtotalEl).toContainText(/549\.99/);
-      console.log('✓ Order summary subtotal matches cart');
+      // Cart subtotal depends on the real PDP price; just assert it's a
+      // currency-formatted value > 0, not a literal amount.
+      await expect(subtotalEl).toContainText(/\$\d+(?:,\d{3})*\.\d{2}/);
+      console.log('✓ Order summary subtotal rendered as currency');
     });
 
     test('total updates after a preview response is received', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -430,8 +438,9 @@ test.describe('Edge Checkout Page', () => {
       );
 
       const total = page.locator('.order-summary-grand-total');
-      await expect(total).toContainText(/604\.10/, { timeout: 10000 });
-      console.log('✓ Order summary total reflects preview response');
+      // MOCK_PREVIEW.total = 604.10 — formatted as $604.10
+      await expect(total).toContainText('604.10', { timeout: 10000 });
+      console.log('✓ Order summary total reflects mocked preview response');
     });
   });
 
@@ -439,7 +448,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Coupon code', () => {
     test('applying a valid coupon shows a discount line', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         estimatePrice: async (route) => {
           await route.fulfill({
@@ -464,7 +473,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('shows error for invalid coupon', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         estimatePrice: async (route) => {
           await route.fulfill({
@@ -490,7 +499,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Place order - Chase credit card', () => {
     test('happy path: validates, previews, creates order, initiates payment, redirects to /order/complete', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
 
       const requestLog = [];
       await setupCheckoutMocks(page, {
@@ -561,7 +570,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('saves checkout session to sessionStorage after order creation', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -585,12 +594,14 @@ test.describe('Edge Checkout Page', () => {
       expect(session.email).toBe(TEST_EMAIL);
       expect(session.order).toContain(MOCK_ORDER_ID);
       expect(session.preview).toContain(MOCK_PREVIEW.estimateToken);
-      expect(session.cartItems).toContain(TEST_ITEM.sku);
+      // cartItems is the serialised cart from the time of order creation;
+      // assert it has at least one item entry (sku depends on the real PDP)
+      expect(JSON.parse(session.cartItems).length).toBeGreaterThan(0);
       console.log('✓ Checkout session saved to sessionStorage');
     });
 
     test('clears the cart after successful order completion', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 
@@ -615,7 +626,7 @@ test.describe('Edge Checkout Page', () => {
 
     test('redirects to external payment URL when payment requires redirect', async ({ page }) => {
       const redirectUrl = 'https://payments.example.com/secure-form/xyz';
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         payment: async (route) => {
           await route.fulfill({
@@ -652,7 +663,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('does not submit when required fields are empty', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
 
       let orderCreateCalled = false;
       await setupCheckoutMocks(page, {
@@ -680,7 +691,7 @@ test.describe('Edge Checkout Page', () => {
 
   test.describe('Error handling', () => {
     test('shows an error if order creation fails', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         createOrder: async (route) => {
           if (route.request().method() !== 'POST') { await route.continue(); return; }
@@ -712,7 +723,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('shows reCAPTCHA error when api returns x-error: recaptcha', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {
         createOrder: async (route) => {
           if (route.request().method() !== 'POST') { await route.continue(); return; }
@@ -744,7 +755,7 @@ test.describe('Edge Checkout Page', () => {
     });
 
     test('reloads page when cart is cleared mid-checkout', async ({ page }) => {
-      await seedCart(page);
+      await seedCart(page, baseUrl);
       await setupCheckoutMocks(page);
       await gotoCheckout(page, baseUrl);
 

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -75,13 +75,24 @@ async function seedCart(page, baseUrl, productPath = '/us/en_us/products/ascent-
   await page.goto(`${baseUrl}${productPath}?cart=edge&martech=off`);
   const atc = page.locator('.quantity-container button');
   await atc.waitFor({ state: 'visible', timeout: 15000 });
-  await atc.click();
-  // Cart writes are debounced 300ms; wait long enough for persist to flush.
-  await page.waitForTimeout(1000);
-  const cart = await page.evaluate(() => JSON.parse(localStorage.getItem('cart:us') || 'null'));
-  if (!cart || !cart.items?.length) {
-    throw new Error('Failed to seed cart via PDP add-to-cart');
-  }
+  // Cart module is dynamically imported inside the click handler — give
+  // the click handler a moment to actually be attached.
+  await page.waitForTimeout(500);
+  // Invoke the DOM `click()` method directly. On Mobile Chrome (Pixel 5
+  // emulation with hasTouch:true), Playwright's `.click()` dispatches a
+  // touchstart→touchend→click sequence; the ATC handler doesn't reliably
+  // fire from that path here. `el.click()` fires the click event
+  // synchronously and works in both desktop and mobile contexts.
+  await atc.evaluate((el) => el.click());
+  // Cart writes are debounced 300ms; poll until the cart appears in
+  // localStorage rather than waiting a fixed amount of time.
+  await expect.poll(
+    async () => {
+      const cart = await page.evaluate(() => JSON.parse(localStorage.getItem('cart:us') || 'null'));
+      return cart?.items?.length || 0;
+    },
+    { timeout: 15000, message: 'Cart did not populate in localStorage after ATC click' },
+  ).toBeGreaterThan(0);
 }
 
 /**
@@ -90,9 +101,13 @@ async function seedCart(page, baseUrl, productPath = '/us/en_us/products/ascent-
  * preview values). Each handler key receives `(route, request)`.
  */
 async function setupCheckoutMocks(page, overrides = {}) {
-  // Block reCAPTCHA scripts/iframes — they don't affect tests since mocks
-  // accept any (or no) x-recaptcha-token header.
-  await page.route(/recaptcha|gstatic\.com|googletagmanager/, (route) => route.abort());
+  // Block only the external Google reCAPTCHA SDK and Tag Manager — keep
+  // the local `/scripts/recaptcha.js` wrapper alive (the checkout block
+  // imports it; aborting it makes decorate() throw and render nothing).
+  await page.route(
+    /https:\/\/(?:www\.google\.com\/recaptcha|www\.gstatic\.com\/recaptcha|www\.recaptcha\.net|www\.googletagmanager\.com)/,
+    (route) => route.abort(),
+  );
 
   // Block Google Places address autocomplete to keep the address fields static
   await page.route('**/places/autocomplete*', (route) => route.fulfill({
@@ -171,26 +186,64 @@ async function setupCheckoutMocks(page, overrides = {}) {
       }),
     });
   }));
+
+  // Stub the order-complete page. The real one loads slowly and triggers
+  // `networkidle` issues. We only care that the redirect happens — the
+  // destination's actual content is not part of the test.
+  await page.route('**/us/en_us/order/complete*', (route) => route.fulfill({
+    status: 200,
+    contentType: 'text/html',
+    body: '<!doctype html><html><body><h1>Order complete (stub)</h1></body></html>',
+  }));
 }
 
 async function gotoCheckout(page, baseUrl) {
+  // Do NOT wait for `networkidle` — the checkout page loads analytics /
+  // RUM / Forter beacons that keep firing indefinitely. The subsequent
+  // `expect(...).toBeVisible({ timeout })` calls do the waiting we need.
   await page.goto(`${baseUrl}/us/en_us/order/checkout?cart=edge&martech=off`);
-  await page.waitForLoadState('networkidle');
 }
 
+/**
+ * On mobile viewports the order-summary block starts collapsed
+ * (.order-summary.is-collapsed, content height: 0, overflow: hidden).
+ * Locators inside the collapsed content still resolve as "visible" to
+ * Playwright but clicks don't reach handlers because the rendered
+ * height is zero. Expand it before interacting.
+ */
+async function expandOrderSummary(page) {
+  // Two elements have `.order-summary`: the outer AEM block wrapper
+  // (`<div class="order-summary block">`) and the inner template div
+  // (`<div class="order-summary is-collapsed">`). The collapse class is
+  // applied to the inner one, so exclude the outer block wrapper.
+  const summary = page.locator('.order-summary:not(.block)');
+  await summary.waitFor({ state: 'attached', timeout: 15000 });
+  const collapsed = await summary.evaluate((el) => el.classList.contains('is-collapsed'));
+  if (collapsed) {
+    await page.locator('.order-summary-toggle').click();
+    // height transition is 0.35s; wait for it to settle.
+    await page.waitForTimeout(500);
+  }
+}
+
+// Field selectors must be scoped to the checkout form — the footer also
+// renders a newsletter form with [name="email"] etc., which would match
+// otherwise (strict-mode locator violation).
+const field = (page, name) => page.locator(`.checkout-form [name="${name}"]`);
+
 async function fillContact(page, email = TEST_EMAIL) {
-  await page.locator('[name="email"]').fill(email);
+  await field(page, 'email').fill(email);
 }
 
 async function fillShipping(page, address = VALID_ADDRESS) {
-  await page.locator('[name="shipping-firstname"]').fill(address.firstName);
-  await page.locator('[name="shipping-lastname"]').fill(address.lastName);
-  await page.locator('[name="shipping-street-0"]').fill(address.street);
-  await page.locator('[name="shipping-city"]').fill(address.city);
+  await field(page, 'shipping-firstname').fill(address.firstName);
+  await field(page, 'shipping-lastname').fill(address.lastName);
+  await field(page, 'shipping-street-0').fill(address.street);
+  await field(page, 'shipping-city').fill(address.city);
   // State must change last so it triggers the shipping rates fetch
-  await page.locator('[name="shipping-zip"]').fill(address.zip);
-  await page.locator('[name="shipping-telephone"]').fill(address.phone);
-  await page.locator('[name="shipping-state"]').selectOption(address.state);
+  await field(page, 'shipping-zip').fill(address.zip);
+  await field(page, 'shipping-telephone').fill(address.phone);
+  await field(page, 'shipping-state').selectOption(address.state);
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -233,8 +286,8 @@ test.describe('Edge Checkout Page', () => {
       await gotoCheckout(page, baseUrl);
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
-      await expect(page.locator('[name="email"]')).toBeVisible();
-      await expect(page.locator('[name="email"]')).toHaveAttribute('type', 'email');
+      await expect(field(page, 'email')).toBeVisible();
+      await expect(field(page, 'email')).toHaveAttribute('type', 'email');
       console.log('✓ Contact section renders email field');
     });
 
@@ -254,7 +307,7 @@ test.describe('Edge Checkout Page', () => {
         'shipping-telephone',
       ];
       await Promise.all(fields.map((name) => expect(
-        page.locator(`[name="${name}"]`),
+        field(page, name),
       ).toBeVisible({ timeout: 10000 })));
       console.log('✓ All shipping address fields rendered');
     });
@@ -266,10 +319,10 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
 
-      const sameRadio = page.locator('[name="billing-choice"][value="same"]');
+      const sameRadio = page.locator('.checkout-form [name="billing-choice"][value="same"]');
       await expect(sameRadio).toBeChecked();
       // Billing fields should NOT be visible when "same" is selected
-      await expect(page.locator('[name="billing-firstname"]')).not.toBeVisible();
+      await expect(field(page, 'billing-firstname')).not.toBeVisible();
       console.log('✓ Billing defaults to "same as shipping"; fields hidden');
     });
 
@@ -280,7 +333,7 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       // At minimum the Chase (credit card) option must be present
-      await expect(page.locator('[name="paymentMethod"][value="chase"]')).toBeAttached();
+      await expect(page.locator('.checkout-form [name="paymentMethod"][value="chase"]')).toBeAttached();
       console.log('✓ Credit-card payment method is present');
     });
 
@@ -315,11 +368,11 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
 
-      await page.locator('[name="billing-choice"][value="different"]').check();
+      await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
 
-      await expect(page.locator('[name="billing-firstname"]')).toBeVisible({ timeout: 3000 });
-      await expect(page.locator('[name="billing-street-0"]')).toBeVisible();
-      await expect(page.locator('[name="billing-zip"]')).toBeVisible();
+      await expect(field(page, 'billing-firstname')).toBeVisible({ timeout: 3000 });
+      await expect(field(page, 'billing-street-0')).toBeVisible();
+      await expect(field(page, 'billing-zip')).toBeVisible();
       console.log('✓ Billing fields appear when "different" selected');
     });
 
@@ -330,11 +383,11 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
 
-      await page.locator('[name="billing-choice"][value="different"]').check();
-      await expect(page.locator('[name="billing-firstname"]')).toBeVisible({ timeout: 3000 });
+      await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
+      await expect(field(page, 'billing-firstname')).toBeVisible({ timeout: 3000 });
 
-      await page.locator('[name="billing-choice"][value="same"]').check();
-      await expect(page.locator('[name="billing-firstname"]')).not.toBeVisible({ timeout: 3000 });
+      await page.locator('.checkout-form [name="billing-choice"][value="same"]').check();
+      await expect(field(page, 'billing-firstname')).not.toBeVisible({ timeout: 3000 });
       console.log('✓ Billing fields hide again when "same" re-selected');
     });
   });
@@ -366,7 +419,7 @@ test.describe('Edge Checkout Page', () => {
       expect(shippingRequestBody.items.length).toBeGreaterThan(0);
 
       // Rates render in the DOM
-      const rateOptions = page.locator('[name="shippingMethod"]');
+      const rateOptions = page.locator('.checkout-form [name="shippingMethod"]');
       await expect(rateOptions.first()).toBeAttached({ timeout: 5000 });
       await expect(page.locator('.shipping-method-label').first()).toContainText(/standard/i);
       console.log('✓ Shipping rates fetched and rendered after state selection');
@@ -380,7 +433,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillShipping(page);
 
-      const firstRate = page.locator('[name="shippingMethod"]').first();
+      const firstRate = page.locator('.checkout-form [name="shippingMethod"]').first();
       await expect(firstRate).toBeChecked({ timeout: 10000 });
       await expect(firstRate).toHaveValue('standard');
       console.log('✓ First shipping rate is auto-selected');
@@ -464,11 +517,13 @@ test.describe('Edge Checkout Page', () => {
       });
       await gotoCheckout(page, baseUrl);
 
-      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('.order-summary-wrapper')).toBeVisible({ timeout: 15000 });
+      await expandOrderSummary(page);
+      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 5000 });
       await page.locator('.discount-input').fill('SAVE10');
       await page.locator('.discount-apply').click();
 
-      await expect(page.locator('.order-summary-discounts')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.order-summary-discounts')).toBeVisible({ timeout: 10000 });
       console.log('✓ Coupon discount row appears after valid coupon applied');
     });
 
@@ -486,11 +541,13 @@ test.describe('Edge Checkout Page', () => {
       });
       await gotoCheckout(page, baseUrl);
 
-      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('.order-summary-wrapper')).toBeVisible({ timeout: 15000 });
+      await expandOrderSummary(page);
+      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 5000 });
       await page.locator('.discount-input').fill('NOPE');
       await page.locator('.discount-apply').click();
 
-      await expect(page.locator('.order-summary-coupon-error')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('.order-summary-coupon-error')).toBeVisible({ timeout: 10000 });
       console.log('✓ Coupon error message shown for invalid coupon');
     });
   });
@@ -555,7 +612,14 @@ test.describe('Edge Checkout Page', () => {
       await page.locator('.checkout-submit-btn').click();
 
       // After payment completes, page redirects to /order/complete?orderId=...
-      await page.waitForURL(/\/order\/complete\?orderId=/, { timeout: 15000 });
+      // `cart.clear()` in `onComplete` triggers a checkout-block reload
+      // that races with the `location.href` redirect, so Playwright's
+      // navigation tracking sees a detached frame. `expect.poll` on
+      // `page.url()` reads the URL string directly and ignores nav events.
+      await expect.poll(
+        () => page.url(),
+        { timeout: 15000, message: 'Page did not navigate to /order/complete' },
+      ).toMatch(/\/order\/complete\?orderId=/);
       expect(page.url()).toContain(`orderId=${MOCK_ORDER_ID}`);
 
       // The order creation request had the correct payload
@@ -583,7 +647,10 @@ test.describe('Edge Checkout Page', () => {
       );
 
       await page.locator('.checkout-submit-btn').click();
-      await page.waitForURL(/\/order\/complete/, { timeout: 15000 });
+      await expect.poll(
+        () => page.url(),
+        { timeout: 15000, message: 'Page did not navigate to /order/complete' },
+      ).toMatch(/\/order\/complete/);
 
       const session = await page.evaluate(() => ({
         email: sessionStorage.getItem('checkout_email'),
@@ -614,7 +681,10 @@ test.describe('Edge Checkout Page', () => {
       );
 
       await page.locator('.checkout-submit-btn').click();
-      await page.waitForURL(/\/order\/complete/, { timeout: 15000 });
+      await expect.poll(
+        () => page.url(),
+        { timeout: 15000, message: 'Page did not navigate to /order/complete' },
+      ).toMatch(/\/order\/complete/);
 
       const cart = await page.evaluate(() => {
         const raw = localStorage.getItem('cart:us');
@@ -761,12 +831,11 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
 
-      // Clear cart via the cart API; checkout listens to cart:change
+      // Clear the actual cart singleton — checkout's `cart:change` listener
+      // reads `cart.itemCount` from the imported singleton, so dispatching
+      // a fake event with a synthetic cart object would not trigger reload.
       await page.evaluate(() => {
-        localStorage.removeItem('cart:us');
-        document.dispatchEvent(new CustomEvent('cart:change', {
-          detail: { cart: { itemCount: 0, items: [], visibleItemCount: 0 }, action: 'empty' },
-        }));
+        window.cart.clear();
       });
 
       // After cart empty event, checkout reloads → empty state should render

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -1,0 +1,762 @@
+/* eslint-disable no-console */
+import { test, expect } from '@playwright/test';
+import {
+  getCurrentBranch,
+  getBaseUrl,
+} from '../utils/test-helpers.js';
+
+/**
+ * Integration tests for the edge checkout page at /us/en_us/order/checkout.
+ *
+ * Setup pattern for each test:
+ *   1. Use page.addInitScript to seed the edge cart in localStorage so the
+ *      checkout page renders the form instead of the empty state.
+ *   2. Mock all commerce API endpoints (shipping, preview, order, payment).
+ *   3. Block third-party SDKs (reCAPTCHA, PayPal, Apple Pay, Places) that
+ *      add noise and instability.
+ *   4. Navigate to /us/en_us/order/checkout?cart=edge.
+ *   5. Fill the form, submit, and verify request bodies + side effects.
+ *
+ * Checkout flow under test:
+ *   submit → validate → updatePreview (POST /orders/preview)
+ *          → createOrder (POST /orders) → initiatePayment (POST /orders/:id/payments)
+ *          → either redirect to payment URL or /order/complete?orderId=...
+ */
+
+const TEST_EMAIL = 'qa-test@example.com';
+
+const TEST_ITEM = {
+  sku: 'test-ascent-x2-black',
+  parentSku: 'Ascent X2',
+  quantity: 1,
+  price: '549.99',
+  name: 'Ascent X2 Blender',
+  url: 'https://www.vitamix.com/us/en_us/products/ascent-x2',
+  path: '/us/en_us/products/ascent-x2',
+  image: 'https://www.vitamix.com/dummy.jpg',
+  variant: 'Black',
+  selectedOptions: [{ id: 'color', value: 'black' }],
+};
+
+const VALID_ADDRESS = {
+  firstName: 'Test',
+  lastName: 'User',
+  street: '123 Main St',
+  city: 'San Francisco',
+  state: 'CA',
+  zip: '94102',
+  phone: '5551234567',
+};
+
+const MOCK_RATES = [
+  {
+    id: 'standard', label: 'Standard Shipping', rate: 5.99, eta: '3-5 business days',
+  },
+  {
+    id: 'express', label: 'Express Shipping', rate: 19.99, eta: '1-2 business days',
+  },
+];
+
+const MOCK_PREVIEW = {
+  subtotal: 549.99,
+  taxAmount: 48.12,
+  taxRate: 0.0875,
+  shippingMethod: { id: 'standard', rate: 5.99 },
+  shippingRate: 5.99,
+  discounts: [],
+  total: 604.10,
+  estimateToken: 'mock-estimate-token-abc',
+};
+
+const MOCK_ORDER_ID = 'mock-order-12345';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function seedCart(page, items = [TEST_ITEM]) {
+  await page.addInitScript((cart) => {
+    localStorage.setItem('cart:us', JSON.stringify(cart));
+  }, { version: 1, items });
+}
+
+/**
+ * Register default mocks for all commerce API endpoints used by checkout.
+ * Pass overrides to swap specific behaviour (e.g. failing endpoints, custom
+ * preview values). Each handler key receives `(route, request)`.
+ */
+async function setupCheckoutMocks(page, overrides = {}) {
+  // Block reCAPTCHA scripts/iframes — they don't affect tests since mocks
+  // accept any (or no) x-recaptcha-token header.
+  await page.route(/recaptcha|gstatic\.com|googletagmanager/, (route) => route.abort());
+
+  // Block Google Places address autocomplete to keep the address fields static
+  await page.route('**/places/autocomplete*', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ predictions: [] }),
+  }));
+  await page.route('**/places/details*', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ result: null }),
+  }));
+
+  // Shipping rates
+  await page.route('**/estimate/shipping', overrides.shipping || (async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rates: MOCK_RATES }),
+    });
+  }));
+
+  // Coupon validation / discount estimate
+  await page.route('**/estimate/price', overrides.estimatePrice || (async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        subtotal: 549.99,
+        discounts: [],
+        orderDiscountTotal: 0,
+      }),
+    });
+  }));
+
+  // Order preview — locks totals and returns estimateToken
+  await page.route('**/orders/preview', overrides.preview || (async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_PREVIEW),
+    });
+  }));
+
+  // Order creation
+  await page.route(/\/orders$/, overrides.createOrder || (async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        order: {
+          id: MOCK_ORDER_ID,
+          customer: {
+            firstName: VALID_ADDRESS.firstName,
+            lastName: VALID_ADDRESS.lastName,
+            email: TEST_EMAIL,
+          },
+        },
+      }),
+    });
+  }));
+
+  // Payment initiation — defaults to synchronous success
+  await page.route(/\/orders\/[^/]+\/payments$/, overrides.payment || (async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        orderId: MOCK_ORDER_ID,
+        paymentAttemptId: 'pay-abc-123',
+        status: 'completed',
+      }),
+    });
+  }));
+}
+
+async function gotoCheckout(page, baseUrl) {
+  await page.goto(`${baseUrl}/us/en_us/order/checkout?cart=edge&martech=off`);
+  await page.waitForLoadState('networkidle');
+}
+
+async function fillContact(page, email = TEST_EMAIL) {
+  await page.locator('[name="email"]').fill(email);
+}
+
+async function fillShipping(page, address = VALID_ADDRESS) {
+  await page.locator('[name="shipping-firstname"]').fill(address.firstName);
+  await page.locator('[name="shipping-lastname"]').fill(address.lastName);
+  await page.locator('[name="shipping-street-0"]').fill(address.street);
+  await page.locator('[name="shipping-city"]').fill(address.city);
+  // State must change last so it triggers the shipping rates fetch
+  await page.locator('[name="shipping-zip"]').fill(address.zip);
+  await page.locator('[name="shipping-telephone"]').fill(address.phone);
+  await page.locator('[name="shipping-state"]').selectOption(address.state);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+test.describe('Edge Checkout Page', () => {
+  let currentBranch;
+  let baseUrl;
+
+  test.beforeAll(async () => {
+    currentBranch = await getCurrentBranch();
+    baseUrl = getBaseUrl(currentBranch);
+    console.log(`Running tests against branch: ${currentBranch}`);
+    console.log(`Base URL: ${baseUrl}`);
+  });
+
+  // ─── Empty cart ────────────────────────────────────────────────────────────
+
+  test.describe('Empty cart', () => {
+    test('renders the empty state when cart is empty', async ({ page }) => {
+      // Do NOT seed the cart
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-empty')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('.checkout-form')).not.toBeVisible();
+      console.log('✓ Empty state renders when cart is empty');
+    });
+  });
+
+  // ─── Form rendering ───────────────────────────────────────────────────────
+
+  test.describe('Form rendering', () => {
+    test('renders contact section fields', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('[name="email"]')).toBeVisible();
+      await expect(page.locator('[name="email"]')).toHaveAttribute('type', 'email');
+      console.log('✓ Contact section renders email field');
+    });
+
+    test('renders all required shipping address fields', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      const fields = [
+        'shipping-firstname',
+        'shipping-lastname',
+        'shipping-street-0',
+        'shipping-street-1',
+        'shipping-city',
+        'shipping-state',
+        'shipping-zip',
+        'shipping-telephone',
+      ];
+      await Promise.all(fields.map((name) => expect(
+        page.locator(`[name="${name}"]`),
+      ).toBeVisible({ timeout: 10000 })));
+      console.log('✓ All shipping address fields rendered');
+    });
+
+    test('billing defaults to "same as shipping"', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+
+      const sameRadio = page.locator('[name="billing-choice"][value="same"]');
+      await expect(sameRadio).toBeChecked();
+      // Billing fields should NOT be visible when "same" is selected
+      await expect(page.locator('[name="billing-firstname"]')).not.toBeVisible();
+      console.log('✓ Billing defaults to "same as shipping"; fields hidden');
+    });
+
+    test('renders payment method radios', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      // At minimum the Chase (credit card) option must be present
+      await expect(page.locator('[name="paymentMethod"][value="chase"]')).toBeAttached();
+      console.log('✓ Credit-card payment method is present');
+    });
+
+    test('renders the submit / continue button', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-submit-btn')).toBeVisible({ timeout: 15000 });
+      console.log('✓ Submit button rendered');
+    });
+
+    test('order-summary block is auto-injected and shows line items', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.order-summary-wrapper')).toBeVisible({ timeout: 15000 });
+      const items = page.locator('.order-summary-items .cart-item');
+      await expect(items.first()).toBeVisible({ timeout: 5000 });
+      console.log('✓ Order summary block rendered with line items');
+    });
+  });
+
+  // ─── Billing toggle ───────────────────────────────────────────────────────
+
+  test.describe('Billing address toggle', () => {
+    test('shows billing fields when "different" is selected', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+
+      await page.locator('[name="billing-choice"][value="different"]').check();
+
+      await expect(page.locator('[name="billing-firstname"]')).toBeVisible({ timeout: 3000 });
+      await expect(page.locator('[name="billing-street-0"]')).toBeVisible();
+      await expect(page.locator('[name="billing-zip"]')).toBeVisible();
+      console.log('✓ Billing fields appear when "different" selected');
+    });
+
+    test('hides billing fields again when "same" is re-selected', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+
+      await page.locator('[name="billing-choice"][value="different"]').check();
+      await expect(page.locator('[name="billing-firstname"]')).toBeVisible({ timeout: 3000 });
+
+      await page.locator('[name="billing-choice"][value="same"]').check();
+      await expect(page.locator('[name="billing-firstname"]')).not.toBeVisible({ timeout: 3000 });
+      console.log('✓ Billing fields hide again when "same" re-selected');
+    });
+  });
+
+  // ─── Shipping rates ───────────────────────────────────────────────────────
+
+  test.describe('Shipping rates', () => {
+    test('fetches and displays rates after address state is selected', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+
+      // Capture the shipping API request body
+      let shippingRequestBody = null;
+      const shippingReqPromise = page.waitForRequest(
+        (req) => req.url().includes('/estimate/shipping') && req.method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await fillShipping(page);
+
+      const shippingReq = await shippingReqPromise;
+      shippingRequestBody = shippingReq.postDataJSON();
+      expect(shippingRequestBody.country).toBe('us');
+      expect(shippingRequestBody.shipping?.state).toBe('CA');
+      expect(Array.isArray(shippingRequestBody.items)).toBe(true);
+      expect(shippingRequestBody.items.length).toBeGreaterThan(0);
+
+      // Rates render in the DOM
+      const rateOptions = page.locator('[name="shippingMethod"]');
+      await expect(rateOptions.first()).toBeAttached({ timeout: 5000 });
+      await expect(page.locator('.shipping-method-label').first()).toContainText(/standard/i);
+      console.log('✓ Shipping rates fetched and rendered after state selection');
+    });
+
+    test('auto-selects the first shipping rate', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillShipping(page);
+
+      const firstRate = page.locator('[name="shippingMethod"]').first();
+      await expect(firstRate).toBeChecked({ timeout: 10000 });
+      await expect(firstRate).toHaveValue('standard');
+      console.log('✓ First shipping rate is auto-selected');
+    });
+
+    test('shows an error / empty state when no rates are available', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        shipping: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ rates: [] }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillShipping(page);
+
+      await expect(page.locator('.shipping-methods-empty')).toBeVisible({ timeout: 10000 });
+      console.log('✓ Empty shipping methods state shown when no rates returned');
+    });
+  });
+
+  // ─── Order totals ─────────────────────────────────────────────────────────
+
+  test.describe('Order totals', () => {
+    test('order summary reflects subtotal from cart', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      const subtotalEl = page.locator('.order-summary-subtotal');
+      await expect(subtotalEl).toBeVisible({ timeout: 15000 });
+      await expect(subtotalEl).toContainText(/549\.99/);
+      console.log('✓ Order summary subtotal matches cart');
+    });
+
+    test('total updates after a preview response is received', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillShipping(page);
+
+      // Wait for the preview call triggered by state-change → shipping-selected
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      const total = page.locator('.order-summary-grand-total');
+      await expect(total).toContainText(/604\.10/, { timeout: 10000 });
+      console.log('✓ Order summary total reflects preview response');
+    });
+  });
+
+  // ─── Coupon code ──────────────────────────────────────────────────────────
+
+  test.describe('Coupon code', () => {
+    test('applying a valid coupon shows a discount line', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        estimatePrice: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              subtotal: 549.99,
+              discounts: [{ source: 'coupon', name: 'SAVE10', amount: 54.99 }],
+              orderDiscountTotal: 54.99,
+            }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 15000 });
+      await page.locator('.discount-input').fill('SAVE10');
+      await page.locator('.discount-apply').click();
+
+      await expect(page.locator('.order-summary-discounts')).toBeVisible({ timeout: 5000 });
+      console.log('✓ Coupon discount row appears after valid coupon applied');
+    });
+
+    test('shows error for invalid coupon', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        estimatePrice: async (route) => {
+          await route.fulfill({
+            status: 400,
+            contentType: 'application/json',
+            headers: { 'x-error': 'coupon_not_found' },
+            body: JSON.stringify({ message: 'Coupon not found' }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.discount-input')).toBeVisible({ timeout: 15000 });
+      await page.locator('.discount-input').fill('NOPE');
+      await page.locator('.discount-apply').click();
+
+      await expect(page.locator('.order-summary-coupon-error')).toBeVisible({ timeout: 5000 });
+      console.log('✓ Coupon error message shown for invalid coupon');
+    });
+  });
+
+  // ─── Place order (Chase credit card) ───────────────────────────────────────
+
+  test.describe('Place order - Chase credit card', () => {
+    test('happy path: validates, previews, creates order, initiates payment, redirects to /order/complete', async ({ page }) => {
+      await seedCart(page);
+
+      const requestLog = [];
+      await setupCheckoutMocks(page, {
+        preview: async (route) => {
+          requestLog.push({ url: '/orders/preview', body: route.request().postDataJSON() });
+          await route.fulfill({
+            status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_PREVIEW),
+          });
+        },
+        createOrder: async (route) => {
+          if (route.request().method() !== 'POST') { await route.continue(); return; }
+          requestLog.push({ url: '/orders', body: route.request().postDataJSON() });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              order: {
+                id: MOCK_ORDER_ID,
+                customer: {
+                  firstName: VALID_ADDRESS.firstName,
+                  lastName: VALID_ADDRESS.lastName,
+                  email: TEST_EMAIL,
+                },
+              },
+            }),
+          });
+        },
+        payment: async (route) => {
+          requestLog.push({ url: 'payments', body: route.request().postDataJSON() });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              orderId: MOCK_ORDER_ID, paymentAttemptId: 'pay-abc-123', status: 'completed',
+            }),
+          });
+        },
+      });
+
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+
+      // Wait for shipping rates + first preview to land
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      // Submit
+      await page.locator('.checkout-submit-btn').click();
+
+      // After payment completes, page redirects to /order/complete?orderId=...
+      await page.waitForURL(/\/order\/complete\?orderId=/, { timeout: 15000 });
+      expect(page.url()).toContain(`orderId=${MOCK_ORDER_ID}`);
+
+      // The order creation request had the correct payload
+      const orderRequest = requestLog.find((r) => r.url === '/orders');
+      expect(orderRequest).toBeDefined();
+      expect(orderRequest.body.customer.email).toBe(TEST_EMAIL);
+      expect(orderRequest.body.shipping.city).toBe(VALID_ADDRESS.city);
+      expect(orderRequest.body.shipping.state).toBe(VALID_ADDRESS.state);
+      expect(orderRequest.body.estimateToken).toBe(MOCK_PREVIEW.estimateToken);
+      expect(orderRequest.body.items).toHaveLength(1);
+      console.log('✓ Place order happy path: preview → order → payment → /order/complete');
+    });
+
+    test('saves checkout session to sessionStorage after order creation', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+      await page.waitForURL(/\/order\/complete/, { timeout: 15000 });
+
+      const session = await page.evaluate(() => ({
+        email: sessionStorage.getItem('checkout_email'),
+        order: sessionStorage.getItem('checkout_order'),
+        preview: sessionStorage.getItem('checkout_preview'),
+        cartItems: sessionStorage.getItem('checkout_cart_items'),
+      }));
+      expect(session.email).toBe(TEST_EMAIL);
+      expect(session.order).toContain(MOCK_ORDER_ID);
+      expect(session.preview).toContain(MOCK_PREVIEW.estimateToken);
+      expect(session.cartItems).toContain(TEST_ITEM.sku);
+      console.log('✓ Checkout session saved to sessionStorage');
+    });
+
+    test('clears the cart after successful order completion', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+      await page.waitForURL(/\/order\/complete/, { timeout: 15000 });
+
+      const cart = await page.evaluate(() => {
+        const raw = localStorage.getItem('cart:us');
+        return raw ? JSON.parse(raw) : null;
+      });
+      expect(cart?.items ?? []).toHaveLength(0);
+      console.log('✓ Cart cleared after successful order');
+    });
+
+    test('redirects to external payment URL when payment requires redirect', async ({ page }) => {
+      const redirectUrl = 'https://payments.example.com/secure-form/xyz';
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        payment: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              orderId: MOCK_ORDER_ID,
+              paymentAttemptId: 'pay-redirect-1',
+              status: 'redirect',
+              action: 'redirect',
+              redirectUrl,
+            }),
+          });
+        },
+      });
+      // Stop the test before the external navigation actually completes
+      await page.route(redirectUrl, (route) => route.fulfill({
+        status: 200, contentType: 'text/html', body: '<html><body>Payment page mock</body></html>',
+      }));
+
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+      await page.waitForURL(redirectUrl, { timeout: 15000 });
+      console.log('✓ Page navigates to external payment URL on redirect action');
+    });
+
+    test('does not submit when required fields are empty', async ({ page }) => {
+      await seedCart(page);
+
+      let orderCreateCalled = false;
+      await setupCheckoutMocks(page, {
+        createOrder: async (route) => {
+          orderCreateCalled = true;
+          await route.continue();
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      // Leave the form empty and click submit
+      await page.locator('.checkout-submit-btn').click();
+      await page.waitForTimeout(1000);
+
+      // Inline validation errors should appear; order endpoint must not be called
+      const hasError = await page.locator('.form-field.has-error, .field-error').first().isVisible();
+      expect(hasError).toBe(true);
+      expect(orderCreateCalled).toBe(false);
+      console.log('✓ Submit with empty form shows validation errors and does not create order');
+    });
+  });
+
+  // ─── Error handling ───────────────────────────────────────────────────────
+
+  test.describe('Error handling', () => {
+    test('shows an error if order creation fails', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        createOrder: async (route) => {
+          if (route.request().method() !== 'POST') { await route.continue(); return; }
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'Internal server error' }),
+          });
+        },
+      });
+
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+
+      await expect(page.locator('.checkout-error')).toBeVisible({ timeout: 10000 });
+      // Should not redirect on failure
+      await page.waitForTimeout(1000);
+      expect(page.url()).toContain('/order/checkout');
+      console.log('✓ Checkout error shown when order creation fails');
+    });
+
+    test('shows reCAPTCHA error when api returns x-error: recaptcha', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page, {
+        createOrder: async (route) => {
+          if (route.request().method() !== 'POST') { await route.continue(); return; }
+          await route.fulfill({
+            status: 403,
+            contentType: 'application/json',
+            headers: { 'x-error': 'recaptcha' },
+            body: JSON.stringify({ message: 'reCAPTCHA validation failed' }),
+          });
+        },
+      });
+
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+
+      // Page should still be on checkout (no redirect) and an error shown
+      await expect(page.locator('.checkout-error')).toBeVisible({ timeout: 10000 });
+      expect(page.url()).toContain('/order/checkout');
+      console.log('✓ reCAPTCHA error path handled');
+    });
+
+    test('reloads page when cart is cleared mid-checkout', async ({ page }) => {
+      await seedCart(page);
+      await setupCheckoutMocks(page);
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+
+      // Clear cart via the cart API; checkout listens to cart:change
+      await page.evaluate(() => {
+        localStorage.removeItem('cart:us');
+        document.dispatchEvent(new CustomEvent('cart:change', {
+          detail: { cart: { itemCount: 0, items: [], visibleItemCount: 0 }, action: 'empty' },
+        }));
+      });
+
+      // After cart empty event, checkout reloads → empty state should render
+      await expect(page.locator('.checkout-empty')).toBeVisible({ timeout: 15000 });
+      console.log('✓ Checkout shows empty state after cart cleared mid-checkout');
+    });
+  });
+});

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -63,9 +63,22 @@ test.describe('PDP Integration Tests', () => {
     });
 
     test('add to cart button should work', async ({ page }) => {
+      await page.route('**/customer/section/load/**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            cart: { items: [], summary_count: 0, data_id: 12345 },
+            customer: { data_id: 12345 },
+            'side-by-side': { cart_id: 'test-cart-id', data_id: 12345 },
+          }),
+        });
+      });
+
       await page.route('**/graphql', async (route) => {
         const requestBody = route.request().postDataJSON();
         expect(requestBody.variables).toEqual({
+          cartId: 'test-cart-id',
           cartItems: [
             {
               sku: 'Ascent X2',
@@ -99,7 +112,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
       // Wait for add to cart button
@@ -121,9 +134,22 @@ test.describe('PDP Integration Tests', () => {
     });
 
     test('dialog should be shown if add to cart fails', async ({ page }) => {
+      await page.route('**/customer/section/load/**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            cart: { items: [], summary_count: 0, data_id: 12345 },
+            customer: { data_id: 12345 },
+            'side-by-side': { cart_id: 'test-cart-id', data_id: 12345 },
+          }),
+        });
+      });
+
       await page.route('**/graphql', async (route) => {
         const requestBody = route.request().postDataJSON();
         expect(requestBody.variables).toEqual({
+          cartId: 'test-cart-id',
           cartItems: [
             {
               sku: 'Ascent X2',
@@ -166,7 +192,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
       // Wait for add to cart button
@@ -225,7 +251,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch, { COUPON: 'test' });
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento', COUPON: 'test' });
       console.log('productUrl: ', productUrl);
       await page.goto(productUrl);
 
@@ -309,9 +335,22 @@ test.describe('PDP Integration Tests', () => {
     });
 
     test('add to cart button should work', async ({ page }) => {
+      await page.route('**/customer/section/load/**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            cart: { items: [], summary_count: 0, data_id: 12345 },
+            customer: { data_id: 12345 },
+            'side-by-side': { cart_id: 'test-cart-id', data_id: 12345 },
+          }),
+        });
+      });
+
       await page.route('**/graphql', async (route) => {
         const requestBody = route.request().postDataJSON();
         expect(requestBody.variables).toEqual({
+          cartId: 'test-cart-id',
           cartItems: [
             {
               sku: 'VBND5200LB',
@@ -348,7 +387,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
       // Wait for add to cart button
@@ -410,7 +449,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
       // Wait for add to cart button
@@ -488,7 +527,7 @@ test.describe('PDP Integration Tests', () => {
         await route.fulfill({ status: 200 });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
       await waitForElement(page, '.quantity-container button');
 
@@ -534,9 +573,22 @@ test.describe('PDP Integration Tests', () => {
     });
 
     test('add to cart button should work', async ({ page }) => {
+      await page.route('**/customer/section/load/**', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            cart: { items: [], summary_count: 0, data_id: 12345 },
+            customer: { data_id: 12345 },
+            'side-by-side': { cart_id: 'test-cart-id', data_id: 12345 },
+          }),
+        });
+      });
+
       await page.route('**/graphql', async (route) => {
         const requestBody = route.request().postDataJSON();
         expect(requestBody.variables).toEqual({
+          cartId: 'test-cart-id',
           cartItems: [
             {
               sku: '056264',
@@ -568,7 +620,7 @@ test.describe('PDP Integration Tests', () => {
         });
       });
 
-      const productUrl = buildProductUrl(productPath, currentBranch);
+      const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
       // Wait for add to cart button

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -106,8 +106,16 @@ async function handleApprove(callbacks, deps) {
         email: session.payer.email,
         phone: '',
       },
-      shipping: session.shippingAddress,
-      billing: session.shippingAddress,
+      shipping: {
+        name: `${session.payer.firstName} ${session.payer.lastName}`.trim(),
+        ...session.shippingAddress,
+        email: session.payer.email,
+      },
+      billing: {
+        name: `${session.payer.firstName} ${session.payer.lastName}`.trim(),
+        ...session.shippingAddress,
+        email: session.payer.email,
+      },
       items: cart.getItemsForAPI(),
       shippingMethod: { id: session.selectedOptionId },
       estimateToken: state.currentEstimateToken,

--- a/tests/utils/test-helpers.js
+++ b/tests/utils/test-helpers.js
@@ -151,3 +151,19 @@ export async function waitForElement(page, selector, timeout = 10000) {
   await page.waitForSelector(selector, { timeout });
   console.log(`✓ Element found: ${selector}`);
 }
+
+/**
+ * Wait for the add-to-cart button AND for the header to finish async decoration
+ * (nav-fragment fetch). Uses Promise.all so both waits run concurrently — no
+ * extra delay when the CDN is warm. Without this, clicking ATC before the
+ * header finishes decorating means pdp:add-to-cart and cart:change events fire
+ * before their listeners are registered.
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ */
+export async function waitForAddToCartButton(page) {
+  await Promise.all([
+    page.waitForSelector('.quantity-container button', { timeout: 30000 }),
+    page.waitForSelector('header a[href*="/order/cart"]', { timeout: 30000 }),
+  ]);
+  console.log('✓ Add-to-cart button ready');
+}


### PR DESCRIPTION
All sites now default to the edge checkout flow, so Playwright tests for the Magento cart path were silently running against the wrong flow.

- Add `?cart=magento` URL param support to `scripts.js` — overrides `window.useEdgeCheckout` at page init, highest priority above localStorage and host detection
- Set `?cart=magento` on all Magento cart test URLs in `integration.spec.js`, `stale-session.spec.js`, and `storage.spec.js`

`cartApi.addToCart` now always calls `updateMagentoCacheSections(['side-by-side'])` before add-to-cart (commit `de6c828`), so `store.getCartId()` always returns a value. Updated GraphQL add-to-cart tests to mock `/customer/section/load/` and assert `cartId` in the request variables.

`addItem` in `scripts/cart.js` was changed to silently create separate entries for same-SKU items with differing `custom` payloads (commit `123a937`). Restored the default throw; added `{ allowSeparateEntry: true }` opt-in used by warranty selector code where two different parent products can legitimately share a warranty SKU.

Fixed `handleApprove` in `paypal-express.spec.js` to match the updated shipping/billing shape in `scripts/payments/paypal.js` (commit `90c416e`).

Fixed invalid `expect.fail()` calls in `storage.spec.js` (Chai API, not available in Playwright) — replaced with `throw new Error(...)`.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://test-fixes--vitamix--aemsites.aem.network/
