### PR TITLE
feat(cart): forward selectedOptions to the API and fall back to parent image

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -291,7 +291,10 @@ export default function renderAddToCart(ph, block, parent) {
           name,
           url: selectedVariant.url,
           path: new URL(selectedVariant.url).pathname,
-          image: selectedVariant.image[0],
+          // Variant may not declare its own image (e.g. a bundle's first color
+          // variant whose source `images` array is empty); fall back to the
+          // parent product's first image.
+          image: selectedVariant.image?.[0] ?? parent.image?.[0],
           variant: window.selectedVariant?.options?.color || '',
           selectedOptions: semanticOptions,
           ...(parent.bundleItems ? { bundleItems: parent.bundleItems } : {}),

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -227,8 +227,15 @@ export class Cart {
    *
    * Fields kept cart-local and not forwarded:
    *   - `local` — site-defined data used by the cart UI only
-   *   - `selectedOptions` — cart-UI data today; gains a passthrough
-   *     alongside the bundle work's Commerce API change
+   *   - `bundleItems` — reference data; the Commerce API re-reads the
+   *     authoritative bundle composition from Product Bus at preview time
+   *     so cart staleness can never affect billing or fulfillment.
+   *
+   * Fields forwarded that drive server-side bundle resolution:
+   *   - `selectedOptions` — `{id, value}` pairs; the Commerce API uses
+   *     them to pick which configurable bundle item variant ships.
+   *     Omitted when absent or empty so the server-side estimate-token
+   *     hash sees the same shape across calls.
    *
    * @returns {Array<object>}
    */
@@ -246,6 +253,7 @@ export class Cart {
       },
       ...(item.image ? { imageUrl: item.image } : {}),
       ...(item.url ? { productUrl: item.url } : {}),
+      ...(item.selectedOptions?.length ? { selectedOptions: item.selectedOptions } : {}),
       ...(item.custom ? { custom: item.custom } : {}),
     }));
   }

--- a/tests/unit/cart.test.js
+++ b/tests/unit/cart.test.js
@@ -432,8 +432,9 @@ test('addItem throws when nested custom payloads differ', () => {
 
 // --- getItemsForAPI: passthrough --------------------------------------------
 
-test('getItemsForAPI does not forward selectedOptions', () => {
-  // selectedOptions is cart-local; the Commerce API does not accept it.
+test('getItemsForAPI forwards non-empty selectedOptions verbatim', () => {
+  // The Commerce API uses selectedOptions to resolve which configurable
+  // bundle item variant ships. Forwarded as `{id, value}` pairs.
   const cart = new Cart();
   cart.addItem({
     sku: 'foo',
@@ -444,7 +445,47 @@ test('getItemsForAPI does not forward selectedOptions', () => {
     selectedOptions: [{ id: 'color', value: 'Red' }],
   });
   const [api] = cart.getItemsForAPI();
-  assert.equal('selectedOptions' in api, false);
+  assert.deepEqual(api.selectedOptions, [{ id: 'color', value: 'Red' }]);
+});
+
+test('getItemsForAPI omits selectedOptions when empty or absent', () => {
+  // Empty and absent must hash identically server-side (estimate-token
+  // hash treats `selectedOptions?.length` as the gate). Match here.
+  const cart = new Cart();
+  cart.addItem({
+    sku: 'with-empty',
+    quantity: 1,
+    price: '10.00',
+    name: 'With empty',
+    path: '/a',
+    selectedOptions: [],
+  });
+  cart.addItem({
+    sku: 'with-absent',
+    quantity: 1,
+    price: '10.00',
+    name: 'With absent',
+    path: '/b',
+  });
+  const [a, b] = cart.getItemsForAPI();
+  assert.equal('selectedOptions' in a, false);
+  assert.equal('selectedOptions' in b, false);
+});
+
+test('getItemsForAPI does not forward bundleItems', () => {
+  // bundleItems on the cart entry is reference data only; the Commerce
+  // API re-reads the authoritative composition from Product Bus.
+  const cart = new Cart();
+  cart.addItem({
+    sku: 'bundle-parent',
+    quantity: 1,
+    price: '100.00',
+    name: 'Bundle Parent',
+    path: '/bundle',
+    bundleItems: [{ sku: 'comp-a', name: 'Component A', price: { final: '40.00' } }],
+  });
+  const [api] = cart.getItemsForAPI();
+  assert.equal('bundleItems' in api, false);
 });
 
 test('getItemsForAPI forwards custom verbatim', () => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Forward selectedOptions from cart entries through getItemsForAPI so the Commerce API can resolve which configurable bundle item variant ships. Gated on length so absent and [] hash identically against the estimate-token. bundleItems stays cart-local (the API re-reads composition from Product Bus). Also defensive image lookup in add-to-cart: fall back to the parent product's first image when the selected variant has none, fixing a crash on variants whose JSON-LD image is absent.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://bundle-cart-fixes--vitamix--aemsites.aem.network/