### PR TITLE
fix(apple-pay): remove `async` from express checkout click handler so Safari's gesture-origin tracking reaches `session.begin()`

### DIFF
--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -23,7 +23,7 @@ function createApplePayButton(locale) {
 }
 
 function startExpressSession(btn, config, callbacks) {
-  btn.addEventListener('click', async () => {
+  btn.addEventListener('click', () => {
     const cart = callbacks.getCart();
     const locale = config.getLocale();
     const language = config.getLanguage();


### PR DESCRIPTION
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-applepay-express-gesture--vitamix--aemsites.aem.network/