### PR TITLE
fix: raise z-index above paypal sdk iframe and smart-menu

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -5,7 +5,7 @@ header {
   background-color: var(--layer-base);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 301;
 }
 
 header a:any-link {


### PR DESCRIPTION
PayPal's JS SDK (via [zoid](https://github.com/krakenjs/zoid)) injects inline `z-index: 100` on the button iframe and `z-index: 300` on the funding source menu at runtime. Obviously, we can't override these values via CSS. The sticky header's current `z-index: 10` is insufficient to remain above these layers on scroll. Raising to `301` ensures the header always paints above both PayPal layers. At least for now.

<img width="1164" height="610" alt="image" src="https://github.com/user-attachments/assets/c7d96ed2-a8f8-4aaf-aaf0-ba0bd2ee1909" />

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://header-vs-paypal--vitamix--aemsites.aem.network/
