### PR TITLE
feat: render gift with purchase

### DIFF
--- a/blocks/cart/cart.css
+++ b/blocks/cart/cart.css
@@ -102,3 +102,33 @@ div.section.cart-section .cart-wrapper {
   flex-shrink: 0;
   border-radius: 6px;
 }
+
+/* Gift-with-purchase line — no qty/remove controls, distinct badge. */
+.cart-item.cart-item-gift {
+  background: var(--commerce-color-surface, #f9fafb);
+}
+
+.cart-item-gift-badge {
+  display: inline-block;
+  font-size: var(--commerce-font-size-xs, 12px);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--commerce-color-accent, #0a7d2e);
+  background: var(--commerce-color-accent-bg, #e6f6ec);
+  border-radius: var(--commerce-radius-badge, 8px);
+  padding: 2px 8px;
+  margin-bottom: 4px;
+}
+
+.cart-item-gift .cart-item-price-original {
+  text-decoration: line-through;
+  color: var(--commerce-color-text-muted, #6b7280);
+  font-weight: 400;
+  margin-right: 6px;
+}
+
+.cart-item-gift .cart-item-price-free {
+  color: var(--commerce-color-accent, #0a7d2e);
+  font-weight: 700;
+}

--- a/blocks/cart/cart.css
+++ b/blocks/cart/cart.css
@@ -114,6 +114,7 @@ div.section.cart-section .cart-wrapper {
   border-radius: var(--commerce-radius-badge, 8px);
   padding: 2px 8px;
   margin-bottom: 4px;
+  width: fit-content;
 }
 
 .cart-item-gift .cart-item-price-original {

--- a/blocks/cart/cart.css
+++ b/blocks/cart/cart.css
@@ -103,11 +103,6 @@ div.section.cart-section .cart-wrapper {
   border-radius: 6px;
 }
 
-/* Gift-with-purchase line — no qty/remove controls, distinct badge. */
-.cart-item.cart-item-gift {
-  background: var(--commerce-color-surface, #f9fafb);
-}
-
 .cart-item-gift-badge {
   display: inline-block;
   font-size: var(--commerce-font-size-xs, 12px);

--- a/blocks/cart/cart.js
+++ b/blocks/cart/cart.js
@@ -139,6 +139,9 @@ export default async function decorate(block) {
 
     cart.items
       .filter((item) => item.local?.showInCart !== false)
+      // Free gifts always render last, regardless of insertion order.
+      .slice()
+      .sort((a, b) => (a.custom?.giftWithPurchase ? 1 : 0) - (b.custom?.giftWithPurchase ? 1 : 0))
       .forEach((item) => {
         if (item.custom?.giftWithPurchase) {
           itemList.appendChild(buildGiftItem(item, s, currencyCode));

--- a/blocks/cart/cart.js
+++ b/blocks/cart/cart.js
@@ -1,21 +1,70 @@
-import { loadCSS } from '../../scripts/aem.js';
+import { loadCSS, createOptimizedPicture } from '../../scripts/aem.js';
 import cart from '../../scripts/cart.js';
-import { getConfig } from '../../scripts/commerce-config.js';
+import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
 import buildCartItem from '../../scripts/commerce/cart-item.js';
 import buildWarrantySelector from './warranty-selector.js';
+import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
 
 const LOCAL_STRINGS = {
   'en-us': {
     cartEmpty: 'Your cart is empty.',
     viewCart: 'View cart',
     checkout: 'Checkout',
+    freeGift: 'Free gift',
+    free: 'Free',
   },
   'fr-ca': {
     cartEmpty: 'Votre panier est vide.',
     viewCart: 'Voir le panier',
     checkout: 'Passer à la caisse',
+    freeGift: 'Cadeau gratuit',
+    free: 'Gratuit',
   },
 };
+
+function buildGiftItem(item, s, currencyCode) {
+  const el = document.createElement('div');
+  el.className = `cart-item cart-item-gift cart-item-${item.sku}`;
+  el.innerHTML = /* html */`
+    <div class="cart-item-image"></div>
+    <div class="cart-item-details">
+      <span class="cart-item-gift-badge">${s.freeGift}</span>
+      <p class="cart-item-name"></p>
+    </div>
+    <div class="cart-item-right">
+      <div class="cart-item-price"></div>
+    </div>`;
+  el.querySelector('.cart-item-image').appendChild(
+    createOptimizedPicture(item.image, item.name || '', true),
+  );
+  const nameEl = el.querySelector('.cart-item-name');
+  if (item.url) {
+    const a = document.createElement('a');
+    a.textContent = item.name;
+    try {
+      a.href = new URL(item.url, window.location.origin).pathname;
+    } catch {
+      a.href = item.url;
+    }
+    nameEl.appendChild(a);
+  } else {
+    nameEl.textContent = item.name;
+  }
+  const priceEl = el.querySelector('.cart-item-price');
+  const regularPrice = item.custom?.regularPrice;
+  if (regularPrice) {
+    const original = document.createElement('span');
+    original.className = 'cart-item-price-original';
+    original.textContent = formatPrice(parseFloat(regularPrice), currencyCode);
+    const free = document.createElement('span');
+    free.className = 'cart-item-price-free';
+    free.textContent = s.free;
+    priceEl.append(original, free);
+  } else {
+    priceEl.textContent = s.free;
+  }
+  return el;
+}
 
 function getStrings(config) {
   const lang = config.getLanguage().toLowerCase().replace('_', '-');
@@ -77,7 +126,10 @@ export default async function decorate(block) {
   }
 
   const updateEmptyState = () => {
-    const visible = cart.items.filter((i) => i.local?.showInCart !== false);
+    // Empty state ignores GWP lines — a cart with nothing but free gifts is
+    // still empty from the customer's perspective.
+    const visible = cart.items.filter((i) => i.local?.showInCart !== false
+      && !i.custom?.giftWithPurchase);
     cartEl.classList.toggle('cart-is-empty', visible.length === 0);
   };
 
@@ -88,6 +140,11 @@ export default async function decorate(block) {
     cart.items
       .filter((item) => item.local?.showInCart !== false)
       .forEach((item) => {
+        if (item.custom?.giftWithPurchase) {
+          itemList.appendChild(buildGiftItem(item, s, currencyCode));
+          return;
+        }
+
         const linkedWarranty = cart.items
           .find((i) => i.custom?.linkedTo === item.sku) || null;
 
@@ -143,4 +200,8 @@ export default async function decorate(block) {
 
   populatelist();
   document.addEventListener('cart:change', populatelist);
+
+  // Visiting cart/minicart is always a GWP trigger — populate/refresh rules
+  // and reconcile. populatelist re-renders on the resulting cart:change.
+  ensurePriceRulesLoaded({ reason: 'cart-block-init' }).then(() => evaluateGWP());
 }

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -11,6 +11,7 @@ import { initShipping, updatePreview } from './checkout-shipping.js';
 import { initOrder } from './checkout-order.js';
 import { initPayment } from './checkout-payment.js';
 import { parsePreview } from '../../scripts/commerce-api.js';
+import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -160,6 +161,12 @@ export default async function decorate(block) {
   await loadCSS('/styles/commerce-tokens.css');
   const config = getConfig();
   const strings = getStrings(config);
+
+  // Reconcile gift-with-purchase before the empty-cart guard — a returning
+  // visitor whose cart no longer qualifies needs the stale gift removed,
+  // and a visitor who newly qualifies needs the gift added so totals reflect
+  // it. Fire-and-forget; the cart:change re-render path picks up the result.
+  ensurePriceRulesLoaded({ reason: 'checkout-block-init' }).then(() => evaluateGWP());
 
   // Empty cart guard
   if (cart.itemCount === 0) {

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -94,16 +94,18 @@ export class Cart {
   }
 
   /**
-   * Quantity sum excluding entries flagged invisible via `local.showInCart`.
-   * Display surfaces (header badge, cart-page empty state, etc.) should prefer
-   * this over `itemCount` so hidden line items (e.g. linked add-ons) don't
+   * Quantity sum excluding entries flagged invisible via `local.showInCart`
+   * and free gift-with-purchase lines. Display surfaces (header badge,
+   * cart-page empty state, etc.) should prefer this over `itemCount` so
+   * hidden line items (e.g. linked add-ons) and promotional gifts don't
    * inflate the user-facing count.
    */
   get visibleItemCount() {
-    return this.#items.reduce(
-      (acc, item) => (item.local?.showInCart === false ? acc : acc + item.quantity),
-      0,
-    );
+    return this.#items.reduce((acc, item) => {
+      if (item.local?.showInCart === false) return acc;
+      if (item.custom?.giftWithPurchase) return acc;
+      return acc + item.quantity;
+    }, 0);
   }
 
   get subtotal() {
@@ -192,13 +194,17 @@ export class Cart {
 
   /**
    * @param {string} sku
-   * @param {string} [linkedTo] When provided, removes only the entry whose
-   *   `custom.linkedTo` matches — needed when the same warranty SKU appears
-   *   multiple times linked to different parent products.
+   * @param {string|((item: CartItem) => boolean)} [matcher] Disambiguator when
+   *   the same SKU has multiple entries. A string matches `custom.linkedTo`
+   *   (back-compat with the warranty flow); a function is a custom predicate
+   *   evaluated against each candidate item.
    */
-  removeItem(sku, linkedTo = undefined) {
+  removeItem(sku, matcher = undefined) {
+    const predicate = typeof matcher === 'function'
+      ? matcher
+      : (item) => matcher === undefined || item.custom?.linkedTo === matcher;
     const index = this.#items.findIndex(
-      (i) => i.sku === sku && (linkedTo === undefined || i.custom?.linkedTo === linkedTo),
+      (i) => i.sku === sku && predicate(i),
     );
     const item = index === -1 ? undefined : this.#items[index];
     if (index !== -1) {

--- a/scripts/gift-with-purchase.js
+++ b/scripts/gift-with-purchase.js
@@ -1,0 +1,356 @@
+/**
+ * Gift-with-purchase (GWP) reconciliation.
+ *
+ * Keeps free-gift cart lines in sync with the active catalog promotions whose
+ * `conditions.minimumSubtotal` is satisfied by the current cart. Lines are
+ * marked with `custom.giftWithPurchase: true` and `custom.promotionId`, which
+ * also disambiguates removal so a paid copy of the same SKU is never touched.
+ *
+ * Triggers (wired by `initGWP` and by the cart/checkout blocks):
+ *   - `loadLazy` if the cart already has items (restored from localStorage)
+ *   - Every `cart:change` event (refetches only on `add`)
+ *   - Decoration of the cart and checkout blocks
+ *
+ * Non-prod overrides (ignored on prod hosts):
+ *   - `localStorage['vitamix.priceRulesUrl']` — override endpoint
+ *   - `localStorage['vitamix.priceRules.stub']` — JSON payload, bypasses fetch
+ *   - `localStorage['vitamix.now']`            — ISO datetime for time-travel
+ */
+
+import cart from './cart.js';
+import { getConfig } from './commerce-config.js';
+
+// Inlined to avoid an import cycle (auth-api -> recaptcha -> scripts -> here).
+const AUTH_TOKEN_SESSION_KEY = 'auth_token';
+
+const CACHE_KEY = 'vitamix.priceRules.v1';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const STUB_KEY = 'vitamix.priceRules.stub';
+const NOW_KEY = 'vitamix.now';
+const ENDPOINT_OVERRIDE_KEY = 'vitamix.priceRulesUrl';
+
+/** Mirrors the prod-host check in commerce-config.js. */
+function isNonProdHost() {
+  const { hostname } = window.location;
+  return hostname.endsWith('.aem.page')
+    || hostname.endsWith('.aem.live')
+    || hostname.endsWith('.aem.network')
+    || hostname === 'localhost'
+    || hostname.startsWith('127.')
+    || hostname.startsWith('integration.')
+    || hostname.startsWith('uat.');
+}
+
+function readLocalStorage(key) {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+
+/** Effective "now" — honours the non-prod time-travel override. */
+function getNow() {
+  if (isNonProdHost()) {
+    const raw = readLocalStorage(NOW_KEY);
+    if (raw) {
+      const d = new Date(raw);
+      if (!Number.isNaN(d.getTime())) return d;
+    }
+  }
+  return new Date();
+}
+
+function getEndpoint() {
+  if (isNonProdHost()) {
+    const override = readLocalStorage(ENDPOINT_OVERRIDE_KEY);
+    if (override) return override;
+  }
+  return `${getConfig().apiOrigin}/price-rules/catalog?active=true`;
+}
+
+function getStub() {
+  if (!isNonProdHost()) return null;
+  const raw = readLocalStorage(STUB_KEY);
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+function readSessionCache() {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed.fetchedAt !== 'number' || !parsed.payload) return null;
+    if (Date.now() - parsed.fetchedAt > CACHE_TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionCache(entry) {
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // sessionStorage may be unavailable in private modes — caching is best-effort.
+  }
+}
+
+let inMemoryCache = null;
+let inflight = null;
+
+/**
+ * Load the catalog-rules payload, memoised in-memory and persisted to
+ * sessionStorage for up to 24h. Returns `null` on failure — callers must
+ * tolerate a missing payload (no GWP, cart remains usable).
+ *
+ * @returns {Promise<{ payload: object, productsByPath: object } | null>}
+ */
+export async function ensurePriceRulesLoaded() {
+  const stub = getStub();
+  if (stub) {
+    inMemoryCache = {
+      payload: stub,
+      productsByPath: inMemoryCache?.productsByPath || {},
+    };
+    return inMemoryCache;
+  }
+  if (inMemoryCache) return inMemoryCache;
+
+  const cached = readSessionCache();
+  if (cached) {
+    inMemoryCache = { payload: cached.payload, productsByPath: cached.productsByPath || {} };
+    return inMemoryCache;
+  }
+
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const headers = { Accept: 'application/json' };
+      let token = null;
+      try { token = sessionStorage.getItem(AUTH_TOKEN_SESSION_KEY); } catch { /* noop */ }
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const res = await fetch(getEndpoint(), { method: 'GET', headers });
+      if (!res.ok) throw new Error(`price-rules ${res.status}`);
+      const payload = await res.json();
+      const entry = { fetchedAt: Date.now(), payload, productsByPath: {} };
+      writeSessionCache(entry);
+      inMemoryCache = { payload, productsByPath: entry.productsByPath };
+      return inMemoryCache;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('[GWP] price-rules load failed', e);
+      return null;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+function promotionAppliesToLocale(promotion, locale) {
+  if (Array.isArray(promotion.countries)) {
+    return promotion.countries.map((c) => String(c).toLowerCase()).includes(locale);
+  }
+  if (typeof promotion.country === 'string') {
+    return promotion.country.toLowerCase() === locale;
+  }
+  return false;
+}
+
+function ruleIsActive(rule, now) {
+  const t = now.getTime();
+  const startOk = !rule.start || new Date(rule.start).getTime() <= t;
+  const endOk = !rule.end || new Date(rule.end).getTime() > t;
+  return startOk && endOk;
+}
+
+/**
+ * Returns the set of GWP rules that should currently be applied, keyed by
+ * `${promotionId}::${rule.path}`. Each value is `{ promotion, rule }`.
+ */
+function computeApplicableRules(payload, currentCart) {
+  const locale = getConfig().getLocale();
+  const now = getNow();
+
+  // Subtract any existing GWP value from the comparison subtotal. Defensive —
+  // GWP prices are usually "0" so this is normally a no-op, but the rule
+  // contract doesn't strictly require it.
+  const subtotalSansGifts = currentCart.items.reduce((acc, item) => {
+    if (item.custom?.giftWithPurchase) return acc;
+    return acc + (item.quantity * parseFloat(item.price || 0));
+  }, 0);
+
+  const applicable = new Map();
+  const promotions = Array.isArray(payload?.promotions) ? payload.promotions : [];
+  promotions.forEach((promotion) => {
+    if (!promotion.conditions || promotion.conditions.minimumSubtotal == null) return;
+    if (!promotionAppliesToLocale(promotion, locale)) return;
+    if (subtotalSansGifts < parseFloat(promotion.conditions.minimumSubtotal)) return;
+    const rules = Array.isArray(promotion.rules) ? promotion.rules : [];
+    rules.forEach((rule) => {
+      if (!ruleIsActive(rule, now)) return;
+      if (!rule.path) return;
+      applicable.set(`${promotion.id}::${rule.path}`, { promotion, rule });
+    });
+  });
+  return applicable;
+}
+
+function extractProductFromJsonLd(html) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const ldScripts = Array.from(doc.querySelectorAll('script[type="application/ld+json"]'));
+  let product = null;
+  ldScripts.some((s) => {
+    let parsed;
+    try { parsed = JSON.parse(s.textContent); } catch { return false; }
+    const candidates = Array.isArray(parsed) ? parsed : [parsed];
+    const flattened = candidates.flatMap(
+      (c) => (Array.isArray(c?.['@graph']) ? c['@graph'] : [c]),
+    );
+    product = flattened.find((n) => n && (n['@type'] === 'Product'
+      || (Array.isArray(n['@type']) && n['@type'].includes('Product'))));
+    return !!product;
+  });
+  return product;
+}
+
+/**
+ * Fetches a product page and extracts the fields we need from its JSON-LD
+ * Product node. Memoised inside `inMemoryCache.productsByPath` and persisted
+ * to sessionStorage alongside the rules payload.
+ *
+ * @param {string} path
+ * @returns {Promise<{ sku, name, image, url } | null>}
+ */
+async function resolveProductByPath(path) {
+  if (!inMemoryCache) return null;
+  if (inMemoryCache.productsByPath[path]) return inMemoryCache.productsByPath[path];
+  try {
+    const res = await fetch(path, { credentials: 'omit' });
+    if (!res.ok) throw new Error(`product page ${res.status}`);
+    const html = await res.text();
+    const product = extractProductFromJsonLd(html);
+    if (!product || !product.sku) throw new Error('no Product JSON-LD');
+    const image = Array.isArray(product.image) ? product.image[0] : product.image;
+    const resolved = {
+      sku: String(product.sku),
+      name: product.name || '',
+      image: image || '',
+      url: path,
+    };
+    inMemoryCache.productsByPath[path] = resolved;
+    // Persist the enriched map so revisits don't re-fetch.
+    const sessionEntry = readSessionCache();
+    if (sessionEntry) {
+      sessionEntry.productsByPath = inMemoryCache.productsByPath;
+      writeSessionCache(sessionEntry);
+    }
+    return resolved;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`[GWP] resolveProductByPath(${path}) failed`, e);
+    return null;
+  }
+}
+
+let isApplyingGWP = false;
+
+function removeStaleGifts(applicable) {
+  const stale = cart.items.filter((item) => {
+    if (!item.custom?.giftWithPurchase) return false;
+    const key = `${item.custom?.promotionId}::${item.path}`;
+    return !applicable.has(key);
+  });
+  stale.forEach((item) => {
+    const { promotionId } = item.custom;
+    cart.removeItem(
+      item.sku,
+      (candidate) => candidate.custom?.giftWithPurchase
+        && candidate.custom?.promotionId === promotionId
+        && candidate.path === item.path,
+    );
+  });
+}
+
+async function addOneGift(promotion, rule) {
+  const product = await resolveProductByPath(rule.path);
+  if (!product) return;
+  cart.addItem(
+    {
+      sku: product.sku,
+      name: product.name,
+      image: product.image,
+      url: product.url,
+      path: rule.path,
+      price: String(rule.price ?? '0'),
+      quantity: 1,
+      custom: {
+        giftWithPurchase: true,
+        promotionId: promotion.id,
+        ...(rule.custom?.regularPrice ? { regularPrice: rule.custom.regularPrice } : {}),
+      },
+    },
+    { allowSeparateEntry: true },
+  );
+}
+
+function addMissingGifts(applicable) {
+  // Sequential chain — addItem is sync but resolveProductByPath is async; a
+  // parallel Promise.all would race on inMemoryCache.productsByPath.
+  return Array.from(applicable.entries()).reduce(
+    (prev, [key, { promotion, rule }]) => prev.then(() => {
+      const alreadyPresent = cart.items.some((item) => item.custom?.giftWithPurchase
+        && `${item.custom?.promotionId}::${item.path}` === key);
+      if (alreadyPresent) return undefined;
+      return addOneGift(promotion, rule);
+    }),
+    Promise.resolve(),
+  );
+}
+
+/**
+ * Reconcile the cart against the currently-cached rules. Adds gift lines that
+ * should be present and removes ones that no longer qualify. Safe to call
+ * without rules loaded — does nothing in that case.
+ *
+ * @returns {Promise<void>}
+ */
+export async function evaluateGWP() {
+  if (isApplyingGWP) return;
+  if (!inMemoryCache?.payload) return;
+  const applicable = computeApplicableRules(inMemoryCache.payload, cart);
+
+  isApplyingGWP = true;
+  try {
+    removeStaleGifts(applicable);
+    await addMissingGifts(applicable);
+  } finally {
+    isApplyingGWP = false;
+  }
+}
+
+let initialised = false;
+
+/**
+ * Wire GWP triggers. Idempotent — safe to call from multiple entry points.
+ */
+export function initGWP() {
+  if (initialised) return;
+  initialised = true;
+
+  // Trigger on every cart mutation. Only `add` and `restore` refresh the
+  // rules cache (the rule set itself doesn't change as items get edited);
+  // every action re-evaluates so qty changes can apply/unapply gifts.
+  document.addEventListener('cart:change', async (event) => {
+    if (isApplyingGWP) return;
+    const action = event.detail?.action;
+    if (action === 'add' || action === 'restore') {
+      await ensurePriceRulesLoaded();
+    }
+    if (!inMemoryCache?.payload) return;
+    evaluateGWP();
+  });
+
+  // Initial pass if the cart was restored with items already in it.
+  if (cart.itemCount > 0) {
+    ensurePriceRulesLoaded().then(() => evaluateGWP());
+  }
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1440,6 +1440,11 @@ async function loadLazy(doc) {
   loadHeader(doc.querySelector('header'));
   await loadSections(main);
 
+  // Gift-with-purchase: kick off once the cart (initialised in eager phase)
+  // is known. The module wires its own cart:change listener and handles
+  // the pageload-cart-has-items case internally.
+  import('./gift-with-purchase.js').then(({ initGWP }) => initGWP());
+
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();


### PR DESCRIPTION
- renders in cart/checkout with a badge, not able to remove manually
- add/remove gift item automatically on reaching/dropping below threshold

localStorage properties for testing (only works on non-prod hosts):
`vitamix.priceRulesUrl` - endpoint override
`vitamix.priceRules.stub` - JSON payload, bypasses fetch
`vitamix.now` - ISO datetime, used in start/end checks  

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/order/cart
- After: https://gwp--vitamix--aemsites.aem.network/us/en_us/order/cart
