### PR TITLE
fix(cart): use fixed 64px height for minicart item image

### DIFF
--- a/blocks/cart/cart.css
+++ b/blocks/cart/cart.css
@@ -89,8 +89,7 @@ div.section.cart-section .cart-wrapper {
 
 .minicart .cart-item-image {
   width: 64px;
-  height: 100%;
-  align-self: stretch;
+  height: 64px;
 }
 
 /* stylelint-disable-next-line no-descending-specificity */


### PR DESCRIPTION
Replaced `height: 100%; align-self: stretch` with a fixed `height: 64px` on `.minicart .cart-item-image`. The previous values caused the image container to stretch to the full grid row height (driven by adjacent content columns), rendering a tall thin box instead of a square thumbnail.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-safari-cart-image--vitamix--aemsites.aem.network/