### PR TITLE
fix: credentials same-origin for fetching gwp resource

### DIFF
--- a/scripts/gift-with-purchase.js
+++ b/scripts/gift-with-purchase.js
@@ -224,7 +224,7 @@ async function resolveProductByPath(path) {
   if (!inMemoryCache) return null;
   if (inMemoryCache.productsByPath[path]) return inMemoryCache.productsByPath[path];
   try {
-    const res = await fetch(path, { credentials: 'omit' });
+    const res = await fetch(path, { credentials: 'same-origin' });
     if (!res.ok) throw new Error(`product page ${res.status}`);
     const html = await res.text();
     const product = extractProductFromJsonLd(html);


### PR DESCRIPTION
use `credentials: same-origin` for fetch to the gwp gift product

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://401-gwp--vitamix--aemsites.aem.network/
