### PR TITLE
fix(checkout): restore keyboard focus on radio buttons in Chrome

### DIFF
--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -51,7 +51,7 @@ export function renderShippingMethods(container, rates, strings, currencyCode = 
       body.appendChild(eta);
     }
 
-    label.append(body, radio);
+    label.append(radio, body);
 
     container.appendChild(label);
   });

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -536,6 +536,14 @@ main > .section:has(.checkout-wrapper) {
   accent-color: var(--commerce-color-text);
 }
 
+/* Restore focus ring on radio buttons — global outline:0 on input:focus suppresses it */
+.shipping-method-option input[type="radio"]:focus-visible,
+.billing-option-card input[type="radio"]:focus-visible,
+.payment-option-card input[type="radio"]:focus-visible {
+  outline: 2px solid var(--commerce-color-text);
+  outline-offset: 2px;
+}
+
 .payment-option-icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
The global `input:focus { outline: 0 }` rule in `styles.css` removes the native focus ring from all inputs, including radio buttons. The box-shadow replacement is designed for text inputs and is invisible on circular radio controls, so keyboard users saw no focus indicator when Tab landed on a radio button — making it appear as if Tab was skipping them entirely. This was reported as a Chrome-specific issue because Chrome's focus handling makes the gap more apparent.

Two fixes: added `:focus-visible` outline (2px, matching the dark text color) for radio buttons in all three checkout card variants (shipping, billing, payment); and corrected the DOM order in `checkout-shipping.js` so the radio element comes before the body text, matching the payment option layout and resolving Chrome's tab routing issue with flex-display labels.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-radio-keyboard-nav--vitamix--aemsites.aem.network/