### PR TITLE
fix(cart): prevent remove-last-item failures in Firefox and on checkout

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -718,6 +718,7 @@ export default async function decorate(block) {
       headerRow.append(cartTitle);
 
       const cartClose = document.createElement('button');
+      cartClose.type = 'button';
       cartClose.className = 'slide-panel-close';
       cartClose.textContent = '\u00D7';
       cartClose.setAttribute('aria-label', 'Close');

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -204,6 +204,12 @@ export class Cart {
     if (index !== -1) {
       this.#items.splice(index, 1);
     }
+    // Persist synchronously when the cart becomes empty so that any immediate
+    // page reload (e.g. from the checkout empty-cart listener) sees the correct
+    // state rather than restoring the stale pre-removal localStorage snapshot.
+    if (this.#items.length === 0) {
+      this.#persistNow();
+    }
     document.dispatchEvent(
       new CustomEvent('cart:change', {
         detail: {

--- a/scripts/commerce/cart-item.js
+++ b/scripts/commerce/cart-item.js
@@ -47,16 +47,16 @@ export default function buildCartItem(item, {
       <p class="cart-item-name"></p>
       <div class="cart-item-actions">
         <div class="cart-item-qty-control">
-          <button class="qty-dec" aria-label="Decrease quantity">&ndash;</button>
+          <button type="button" class="qty-dec" aria-label="Decrease quantity">&ndash;</button>
           <input class="qty-input" type="number" value="1" min="1"${Number.isFinite(maxQty) ? ` max="${maxQty}"` : ''}>
-          <button class="qty-inc" aria-label="Increase quantity">+</button>
+          <button type="button" class="qty-inc" aria-label="Increase quantity">+</button>
         </div>
       </div>
     </div>
     <div class="cart-item-right">
       <div class="cart-item-price"></div>
       <div class="cart-item-per-unit"></div>
-      <button class="cart-item-remove" aria-label="${removeItem}">
+      <button type="button" class="cart-item-remove" aria-label="${removeItem}">
         ${TRASH_ICON}<span>${remove}</span>
       </button>
     </div>`;


### PR DESCRIPTION
Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://merge-main--vitamix--aemsites.aem.network/

Buttons without `type="button"` default to `type="submit"`, which causes Firefox 150 to apply dialog-submission semantics when clicked inside a `showModal()` dialog — breaking the qty-decrement-to-zero and remove flows for the last cart item. Added explicit `type="button"` to all three custom buttons in `cart-item.js` and to the minicart close button in `header.js`.

Separately, `cart.removeItem` debounces localStorage persistence by 300ms, but the checkout page reloads immediately when the cart empties. This caused the pre-removal snapshot to be restored on reload, making the item reappear. Fixed by calling `#persistNow()` synchronously in `removeItem` whenever the cart becomes empty, before the `cart:change` event fires.