### PR TITLE
fix: checkout fixes

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -266,6 +266,19 @@ function formatEnteredAddressLines(formData) {
 }
 
 /**
+ * Splits a formattedAddress string into two display lines: street on line 1,
+ * city/state/zip/country on line 2.
+ * @param {string} formattedAddress
+ * @returns {string[]}
+ */
+export function splitFormattedAddress(formattedAddress) {
+  const commaIdx = formattedAddress.indexOf(',');
+  return commaIdx >= 0
+    ? [formattedAddress.slice(0, commaIdx).trim(), formattedAddress.slice(commaIdx + 1).trim()]
+    : [formattedAddress];
+}
+
+/**
  * Formats Google's addressComponents array into display lines.
  * @param {Array<{ longText: string, shortText: string, types: string[] }>} components
  * @returns {string[]}
@@ -382,7 +395,9 @@ function buildAddressCard({
  * @param {Object} opts
  * @returns {Promise<{ choice: 'accept'|'keep' }>}
  */
-function showConfirmModal({ addressComponents, formData, strings }) {
+function showConfirmModal({
+  addressComponents, formattedAddress, formData, strings,
+}) {
   return new Promise((resolve) => {
     let chosen = null;
 
@@ -395,9 +410,12 @@ function showConfirmModal({ addressComponents, formData, strings }) {
     });
 
     const enteredLines = formatEnteredAddressLines(formData);
-    const suggestedLines = addressComponents
-      ? formatSuggestedAddressLines(addressComponents)
-      : [];
+    let suggestedLines;
+    if (formattedAddress) {
+      suggestedLines = splitFormattedAddress(formattedAddress);
+    } else {
+      suggestedLines = addressComponents ? formatSuggestedAddressLines(addressComponents) : [];
+    }
 
     const comparison = document.createElement('div');
     comparison.className = 'address-validation-comparison';
@@ -458,7 +476,9 @@ function showConfirmModal({ addressComponents, formData, strings }) {
  * @param {Object} opts
  * @returns {Promise<{ choice: 'add-unit', unit: string } | { choice: 'keep' }>}
  */
-function showAddUnitModal({ addressComponents, formData, strings }) {
+function showAddUnitModal({
+  addressComponents, formattedAddress, formData, strings,
+}) {
   return new Promise((resolve) => {
     let chosen = null;
 
@@ -471,9 +491,14 @@ function showAddUnitModal({ addressComponents, formData, strings }) {
       onClose: () => { chosen = { choice: 'keep' }; dialog.close(); },
     });
 
-    const displayLines = addressComponents
-      ? formatSuggestedAddressLines(addressComponents).filter((line) => !line.startsWith('Apt '))
-      : formatEnteredAddressLines(formData);
+    let displayLines;
+    if (formattedAddress) {
+      displayLines = splitFormattedAddress(formattedAddress);
+    } else if (addressComponents) {
+      displayLines = formatSuggestedAddressLines(addressComponents).filter((line) => !line.startsWith('Apt '));
+    } else {
+      displayLines = formatEnteredAddressLines(formData);
+    }
 
     const addressCard = document.createElement('div');
     addressCard.className = 'address-card address-card-display';
@@ -608,7 +633,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
       return;
     }
 
-    const { action, addressComponents } = result;
+    const { action, addressComponents, formattedAddress } = result;
 
     if (!action || action === 'ACCEPT') {
       collapse();
@@ -625,7 +650,9 @@ export async function validateAndCollapseShipping(section, collapse, config, str
 
     if (action === 'CONFIRM') {
       // eslint-disable-next-line no-await-in-loop
-      const { choice } = await showConfirmModal({ addressComponents, formData, strings });
+      const { choice } = await showConfirmModal({
+        addressComponents, formattedAddress, formData, strings,
+      });
       if (choice === 'accept' && addressComponents) {
         // Use [name$="street-0"] — the autocomplete attr is rewritten to "off"
         // by initPlacesAutocomplete to suppress Chrome's autofill dropdown.
@@ -638,7 +665,9 @@ export async function validateAndCollapseShipping(section, collapse, config, str
 
     if (action === 'CONFIRM_ADD_SUBPREMISES') {
       // eslint-disable-next-line no-await-in-loop
-      const result2 = await showAddUnitModal({ addressComponents, formData, strings });
+      const result2 = await showAddUnitModal({
+        addressComponents, formattedAddress, formData, strings,
+      });
       if (result2.choice !== 'add-unit' || !result2.unit) {
         // User declined — accept the address as-is.
         collapse();

--- a/blocks/checkout/checkout-form.js
+++ b/blocks/checkout/checkout-form.js
@@ -258,6 +258,7 @@ export default function buildForm(container, config, strings) {
   sameRadio.name = 'billing-choice';
   sameRadio.value = 'same';
   sameRadio.checked = true;
+  sameRadio.tabIndex = 0;
   const sameContent = document.createElement('div');
   sameContent.className = 'billing-option-content';
   const sameLabelSpan = document.createElement('span');
@@ -274,6 +275,7 @@ export default function buildForm(container, config, strings) {
   differentRadio.type = 'radio';
   differentRadio.name = 'billing-choice';
   differentRadio.value = 'different';
+  differentRadio.tabIndex = 0;
   const differentContent = document.createElement('div');
   differentContent.className = 'billing-option-content';
   const differentLabelSpan = document.createElement('span');

--- a/blocks/checkout/checkout-payment.js
+++ b/blocks/checkout/checkout-payment.js
@@ -102,6 +102,7 @@ export function renderPaymentSection(container, activeProviders, callbacks, stri
     cardRadio.value = cardProviderId;
     cardRadio.checked = true;
     cardRadio.id = 'payment-credit-card';
+    cardRadio.tabIndex = 0;
 
     const cardIcon = document.createElement('span');
     cardIcon.className = 'payment-option-icon';
@@ -145,6 +146,7 @@ export function renderPaymentSection(container, activeProviders, callbacks, stri
     radio.name = 'paymentMethod';
     radio.value = provider.id;
     radio.id = `payment-${provider.id}`;
+    radio.tabIndex = 0;
 
     const optIcon = document.createElement('span');
     optIcon.className = 'payment-option-icon';

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -28,6 +28,7 @@ export function renderShippingMethods(container, rates, strings, currencyCode = 
     radio.type = 'radio';
     radio.name = 'shippingMethod';
     radio.value = rate.id;
+    radio.tabIndex = 0;
     if (i === 0) radio.checked = true;
 
     const body = document.createElement('div');

--- a/blocks/checkout/checkout-validation.js
+++ b/blocks/checkout/checkout-validation.js
@@ -161,8 +161,12 @@ export function validateForm(form) {
   });
 
   if (firstInvalid) {
+    const section = firstInvalid.closest('.form-section');
+    if (section?.classList.contains('is-collapsed')) {
+      section.querySelector('.section-edit-btn')?.click();
+    }
     firstInvalid.focus();
-    firstInvalid.closest('.form-section')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    section?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 
   return !firstInvalid;

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -12,6 +12,7 @@ import { initOrder } from './checkout-order.js';
 import { initPayment } from './checkout-payment.js';
 import { parsePreview } from '../../scripts/commerce-api.js';
 import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
+import { validateField } from './checkout-validation.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -272,7 +273,7 @@ export default async function decorate(block) {
   const shippingAddrSection = form.querySelector('.shipping-address-section');
   const { collapse: collapseShipping } = initCollapse(shippingAddrSection, {
     getIsValid: () => [...shippingAddrSection.querySelectorAll('[required]')].every(
-      (el) => el.checkValidity(),
+      (el) => el.checkValidity() && !validateField(el),
     ),
     getSummary: () => {
       const data = new FormData(form);

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -210,6 +210,12 @@ export class Cart {
     if (index !== -1) {
       this.#items.splice(index, 1);
     }
+    // Persist synchronously when the cart becomes empty so that any immediate
+    // page reload (e.g. from the checkout empty-cart listener) sees the correct
+    // state rather than restoring the stale pre-removal localStorage snapshot.
+    if (this.#items.length === 0) {
+      this.#persistNow();
+    }
     document.dispatchEvent(
       new CustomEvent('cart:change', {
         detail: {

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -413,4 +413,48 @@ test.describe('formatSuggestedAddressLines', () => {
   test('returns empty array when components list is empty', () => {
     expect(formatSuggestedAddressLines([])).toEqual([]);
   });
+
+  test('uses locality over sublocality_level_1 when both are present', () => {
+    // sublocality_level_1 is not the same key as sublocality — locality wins.
+    // The CONFIRM modal uses formattedAddress directly to avoid this ambiguity.
+    const addr = [
+      { longText: '50', shortText: '50', types: ['street_number'] },
+      { longText: 'Queen Elizabeth Boulevard', shortText: 'Queen Elizabeth Blvd', types: ['route'] },
+      { longText: 'Toronto', shortText: 'Toronto', types: ['locality'] },
+      { longText: 'ON', shortText: 'ON', types: ['administrative_area_level_1'] },
+      { longText: 'M8Z 1M1', shortText: 'M8Z 1M1', types: ['postal_code'] },
+      { longText: 'Etobicoke', shortText: 'Etobicoke', types: ['sublocality_level_1'] },
+    ];
+    expect(formatSuggestedAddressLines(addr)).toEqual([
+      '50 Queen Elizabeth Boulevard',
+      'Toronto, ON M8Z 1M1',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitFormattedAddress
+// ---------------------------------------------------------------------------
+
+function splitFormattedAddress(formattedAddress) {
+  const commaIdx = formattedAddress.indexOf(',');
+  return commaIdx >= 0
+    ? [formattedAddress.slice(0, commaIdx).trim(), formattedAddress.slice(commaIdx + 1).trim()]
+    : [formattedAddress];
+}
+
+test.describe('splitFormattedAddress', () => {
+  test('splits at first comma into street and rest', () => {
+    expect(splitFormattedAddress('50 Queen Elizabeth Boulevard, Etobicoke, ON M8Z 1M1, Canada'))
+      .toEqual(['50 Queen Elizabeth Boulevard', 'Etobicoke, ON M8Z 1M1, Canada']);
+  });
+
+  test('returns single-element array when no comma present', () => {
+    expect(splitFormattedAddress('123 Main St')).toEqual(['123 Main St']);
+  });
+
+  test('trims whitespace around the split', () => {
+    expect(splitFormattedAddress('123 Main St , Springfield, IL'))
+      .toEqual(['123 Main St', 'Springfield, IL']);
+  });
 });

--- a/tests/unit/checkout-validation.test.js
+++ b/tests/unit/checkout-validation.test.js
@@ -1,0 +1,193 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateField, validateForm } from '../../blocks/checkout/checkout-validation.js';
+
+// ---------------------------------------------------------------------------
+// validateField — zip code
+// ---------------------------------------------------------------------------
+
+function makeInput(name, value, { required = false, locale = null } = {}) {
+  return {
+    name,
+    value,
+    required,
+    form: locale ? { dataset: { lang: 'en', locale } } : { dataset: { lang: 'en' } },
+  };
+}
+
+test('validateField: 3-digit US ZIP is invalid', () => {
+  const input = makeInput('shipping-zip', '941', { required: true });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: 5-digit US ZIP is valid', () => {
+  const input = makeInput('shipping-zip', '94102', { required: true });
+  assert.equal(validateField(input), null);
+});
+
+test('validateField: 9-digit US ZIP with hyphen is valid', () => {
+  const input = makeInput('zip', '94102-1234', { required: true });
+  assert.equal(validateField(input), null);
+});
+
+test('validateField: all-zeros US ZIP is invalid', () => {
+  const input = makeInput('zip', '00000', { required: true });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: 4-digit US ZIP is invalid', () => {
+  const input = makeInput('zip', '9410', { required: true });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: 6-digit US ZIP is invalid', () => {
+  const input = makeInput('zip', '941021', { required: true });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: valid CA postal code (with space) is valid', () => {
+  const input = makeInput('shipping-zip', 'K1A 0A9', { required: true, locale: 'ca' });
+  assert.equal(validateField(input), null);
+});
+
+test('validateField: invalid CA postal code is invalid', () => {
+  const input = makeInput('shipping-zip', '94102', { required: true, locale: 'ca' });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: empty required zip returns required error', () => {
+  const input = makeInput('zip', '', { required: true });
+  assert.notEqual(validateField(input), null);
+});
+
+test('validateField: empty non-required zip returns null', () => {
+  const input = makeInput('zip', '', { required: false });
+  assert.equal(validateField(input), null);
+});
+
+// ---------------------------------------------------------------------------
+// validateForm — collapsed section expansion
+// ---------------------------------------------------------------------------
+
+function makeFormWithCollapsedInvalidZip() {
+  let clicked = false;
+  let focused = false;
+
+  const editBtn = { click() { clicked = true; } };
+
+  const section = {
+    classList: { contains: (cls) => cls === 'is-collapsed' },
+    querySelector: (sel) => (sel === '.section-edit-btn' ? editBtn : null),
+    scrollIntoView() {},
+  };
+
+  // Return a pre-existing error span so showFieldError never calls document.createElement.
+  const errorSpan = { textContent: '', id: '' };
+  const wrapper = {
+    classList: {
+      contains: () => false,
+      add() {},
+      remove() {},
+    },
+    querySelector: (sel) => (sel === '.field-error' ? errorSpan : null),
+    appendChild() {},
+  };
+
+  const zipInput = {
+    name: 'shipping-zip',
+    value: '941',
+    required: true,
+    disabled: false,
+    type: 'text',
+    id: 'shipping-zip',
+    form: { dataset: { lang: 'en' } },
+    closest(sel) {
+      if (sel === '.form-field') return wrapper;
+      if (sel === '.form-section') return section;
+      return null;
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    focus() { focused = true; },
+  };
+
+  const form = {
+    querySelectorAll: () => ({ forEach: (fn) => fn(zipInput) }),
+    dataset: { lang: 'en' },
+  };
+
+  return {
+    form,
+    getClicked: () => clicked,
+    getFocused: () => focused,
+  };
+}
+
+test('validateForm: returns false for invalid zip in collapsed section', () => {
+  const { form } = makeFormWithCollapsedInvalidZip();
+  assert.equal(validateForm(form), false);
+});
+
+test('validateForm: clicks edit button to expand collapsed section with invalid field', () => {
+  const { form, getClicked } = makeFormWithCollapsedInvalidZip();
+  validateForm(form);
+  assert.equal(getClicked(), true);
+});
+
+test('validateForm: focuses the invalid field after expanding', () => {
+  const { form, getFocused } = makeFormWithCollapsedInvalidZip();
+  validateForm(form);
+  assert.equal(getFocused(), true);
+});
+
+test('validateForm: does not click edit button when section is not collapsed', () => {
+  let clicked = false;
+  const editBtn = { click() { clicked = true; } };
+
+  const section = {
+    classList: { contains: () => false },
+    querySelector: (sel) => (sel === '.section-edit-btn' ? editBtn : null),
+    scrollIntoView() {},
+  };
+
+  const errorSpan2 = { textContent: '', id: '' };
+  const wrapper = {
+    classList: { contains: () => false, add() {}, remove() {} },
+    querySelector: (sel) => (sel === '.field-error' ? errorSpan2 : null),
+    appendChild() {},
+  };
+
+  const zipInput = {
+    name: 'shipping-zip',
+    value: '941',
+    required: true,
+    disabled: false,
+    type: 'text',
+    id: 'shipping-zip',
+    form: { dataset: { lang: 'en' } },
+    closest(sel) {
+      if (sel === '.form-field') return wrapper;
+      if (sel === '.form-section') return section;
+      return null;
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    focus() {},
+  };
+
+  const form = {
+    querySelectorAll: () => ({ forEach: (fn) => fn(zipInput) }),
+    dataset: { lang: 'en' },
+  };
+
+  validateForm(form);
+  assert.equal(clicked, false);
+});
+
+test('validateForm: returns true when all fields are valid', () => {
+  const form = {
+    querySelectorAll: () => ({ forEach: () => {} }),
+    dataset: { lang: 'en' },
+  };
+  assert.equal(validateForm(form), true);
+});

--- a/widgets/WIDGETS-ENGLISH-LITERALS.md
+++ b/widgets/WIDGETS-ENGLISH-LITERALS.md
@@ -137,17 +137,17 @@ These literals appear in more than one widget (good candidates for shared i18n).
 | **Address Line 2** | product-registration, manage-address |
 | **Additional comments** | wellness-program, media-contact |
 | **City** | product-registration, manage-address |
-| **Do you own a Vitamix?** | edit-account, create-account, made-in-giveaway |
+| **Do you own a Vitamix?** | edit-account, create-account, giveaway |
 | **Email Address** | product-registration, media-contact, login, edit-account, create-account, contact-us |
-| **Enter your Email** | made-in-giveaway |
+| **Enter your Email** | giveaway, pb |
 | **First Name** | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | **Last Name** | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | **Phone Number** | product-registration, wellness-program, media-contact, manage-address |
 | **Postal code** | product-registration, manage-address, edit-account, create-account |
-| **Sign up** | made-in-giveaway |
+| **Sign up** | giveaway, pb |
 | **Submit** | wellness-program, media-contact, login, contact-us |
-| **Yes** | edit-account, create-account, made-in-giveaway |
-| **No** | edit-account, create-account, made-in-giveaway |
+| **Yes** | edit-account, create-account, giveaway, pb |
+| **No** | edit-account, create-account, giveaway, pb |
 
 ---
 
@@ -205,10 +205,12 @@ Forms use `labels` and `inputPlaceholders` from locale JSON; the following are t
 | Contact Information | manage-address |
 | Create account | create-account |
 | Default | article-center (sort) |
+| Did you attend a Vitamix Series Dining Event during the festival? | pb |
+| Did you learn anything new about Vitamix Blenders? | pb |
 | Domestic | contact-us |
-| Do you own a Vitamix? | edit-account, create-account, made-in-giveaway |
+| Do you own a Vitamix? | edit-account, create-account, giveaway |
 | Email Address | product-registration, media-contact, login, edit-account, create-account, contact-us |
-| Enter your Email | made-in-giveaway |
+| Enter your Email | giveaway, pb |
 | Find your serial number | product-registration |
 | First Name | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | For commercial products | create-account |
@@ -238,13 +240,14 @@ Forms use `labels` and `inputPlaceholders` from locale JSON; the following are t
 | Select / Select an option | contact-us, product-registration |
 | Serial number / (18 digits) | product-registration |
 | Sending... / Searching... | multiple forms |
-| Sign up | made-in-giveaway |
+| Sign up | giveaway, pb |
 | Submit | wellness-program, media-contact, login, contact-us |
-| Thank you for entering. | made-in-giveaway |
+| Thank you for entering. | giveaway, pb |
 | Type of request | contact-us |
 | Use as default billing/shipping address | manage-address |
 | Verify Your Email / Enter verification code... | login |
-| Yes / No | edit-account, create-account, made-in-giveaway |
+| Which one? | pb |
+| Yes / No | edit-account, create-account, giveaway, pb |
 | * Required fields | create-account |
 
 *(Form input-hint values are in each form’s `.json` under `inputPlaceholders`; the table above reflects the English defaults used in JS when the key is missing.)*

--- a/widgets/forms/pb.css
+++ b/widgets/forms/pb.css
@@ -1,0 +1,25 @@
+.forms-pb form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-200);
+}
+
+.forms-pb [data-required]::after {
+  content: '*';
+  margin-left: 0.5ch;
+  color: var(--color-red);
+}
+
+.forms-pb .radio-group legend,
+.forms-pb .checkbox-group legend {
+  margin-bottom: 0.5em;
+}
+
+.forms-pb .radio-option,
+.forms-pb .checkbox-option {
+  cursor: pointer;
+}
+
+.forms-pb .pb-thank-you {
+  color: var(--color-asparagus);
+}

--- a/widgets/forms/pb.html
+++ b/widgets/forms/pb.html
@@ -1,0 +1,30 @@
+<form method="post" action="" aria-label="Pebble Beach Giveaway">
+  <fieldset class="field radio-group">
+    <legend data-required></legend>
+    <div class="radio-options">
+      <label class="radio-option">
+        <input type="radio" name="vitamixfoodandwine" value="True" required aria-required="true">
+        <span class="radio-label"></span>
+      </label>
+      <label class="radio-option">
+        <input type="radio" name="vitamixfoodandwine" value="False">
+        <span class="radio-label"></span>
+      </label>
+    </div>
+  </fieldset>
+  <fieldset class="field checkbox-group">
+    <legend></legend>
+    <div class="checkbox-options"></div>
+  </fieldset>
+  <div class="field">
+    <label for="pb-open-text"></label>
+    <input id="pb-open-text" type="text" name="open-text-question-fw" autocomplete="off">
+  </div>
+  <div class="field">
+    <label for="pb-email" data-required></label>
+    <input id="pb-email" type="email" name="pebblebeach-email" required aria-required="true" placeholder="" autocomplete="email">
+  </div>
+  <p class="button-wrapper">
+    <button type="submit" class="button emphasis"></button>
+  </p>
+</form>

--- a/widgets/forms/pb.js
+++ b/widgets/forms/pb.js
@@ -1,0 +1,101 @@
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
+
+/**
+ * Fetches form copy from the co-located JSON file.
+ * @returns {Promise<Object>} Parsed JSON with labels, dinners, and terms.
+ */
+async function loadFormCopy() {
+  const scriptPath = new URL(import.meta.url).pathname;
+  const jsonPath = scriptPath.replace(/\.js$/, '.json');
+  const url = `${(window.hlx && window.hlx.codeBasePath) || ''}${jsonPath}`;
+  const resp = await fetch(url);
+  return resp.json();
+}
+
+/**
+ * Decorates the Pebble Beach giveaway form widget with copy and submission handling.
+ * @param {HTMLElement} widget - Widget container element
+ */
+export default async function decorate(widget) {
+  const form = widget.querySelector('form');
+  if (!form) return;
+
+  const { locale, language } = getLocaleAndLanguage();
+  const copy = await loadFormCopy();
+  const labels = copy.labels || {};
+
+  const attendLegend = form.querySelector('.radio-group legend');
+  if (attendLegend) attendLegend.textContent = labels.attendance ?? 'Did you attend a Vitamix Series Dining Event during the festival?';
+
+  const [yesLabel, noLabel] = form.querySelectorAll('.radio-label');
+  if (yesLabel) yesLabel.textContent = labels.yes ?? 'Yes';
+  if (noLabel) noLabel.textContent = labels.no ?? 'No';
+
+  const checkboxLegend = form.querySelector('.checkbox-group legend');
+  if (checkboxLegend) checkboxLegend.textContent = labels.whichDinner ?? 'Which one?';
+
+  const checkboxOptions = form.querySelector('.checkbox-options');
+  if (checkboxOptions && Array.isArray(copy.dinners)) {
+    copy.dinners.forEach((dinnerName) => {
+      const label = document.createElement('label');
+      label.className = 'checkbox-option';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.name = 'name_of_dinner';
+      input.value = dinnerName;
+      const span = document.createElement('span');
+      span.className = 'checkbox-label';
+      span.textContent = dinnerName;
+      label.append(input, span);
+      checkboxOptions.append(label);
+    });
+  }
+
+  const openTextLabel = form.querySelector('[for="pb-open-text"]');
+  if (openTextLabel) openTextLabel.textContent = labels.openText ?? 'Did you learn anything new about Vitamix Blenders?';
+
+  const emailLabel = form.querySelector('[for="pb-email"]');
+  if (emailLabel) emailLabel.textContent = labels.email ?? 'Enter your Email';
+
+  const emailInput = form.querySelector('#pb-email');
+  if (emailInput && copy.inputPlaceholders) emailInput.placeholder = copy.inputPlaceholders.email || '';
+
+  const submitBtn = form.querySelector('button[type="submit"]');
+  if (submitBtn) submitBtn.textContent = labels.submit ?? 'Sign up';
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const params = new URLSearchParams();
+
+    [...data.entries()].forEach(([key, val]) => {
+      if (key !== 'name_of_dinner') params.append(key, val);
+    });
+    data.getAll('name_of_dinner').forEach((val) => params.append('name_of_dinner', val));
+    params.set('pageUrl', window.location.href);
+    params.set('lead_source', 'PebbleBeach');
+    params.set('actionUrl', `/${locale}/${language}/rest/V1/partners`);
+
+    [...form.elements].forEach((el) => { el.disabled = true; });
+    if (submitBtn) {
+      submitBtn.dataset.originalLabel = submitBtn.textContent;
+      submitBtn.textContent = labels.sending ?? 'Sending...';
+    }
+
+    try {
+      const resp = await fetch(`https://www.vitamix.com/bin/vitamix/partnerform?${params.toString()}`);
+      if (!resp.ok) throw new Error(`Form submission failed with ${resp.status}`);
+      const thankYou = document.createElement('p');
+      thankYou.className = 'pb-thank-you';
+      thankYou.textContent = labels.thankYou ?? 'Thank you for entering.';
+      form.replaceWith(thankYou);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Pebble Beach form submission failed', err);
+      [...form.elements].forEach((el) => { el.disabled = false; });
+      if (submitBtn) {
+        submitBtn.textContent = submitBtn.dataset.originalLabel || (labels.submit ?? 'Sign up');
+      }
+    }
+  });
+}

--- a/widgets/forms/pb.json
+++ b/widgets/forms/pb.json
@@ -1,0 +1,29 @@
+{
+  "labels": {
+    "attendance": "Did you attend a Vitamix Series Dining Event during the festival?",
+    "yes": "Yes",
+    "no": "No",
+    "whichDinner": "Which one?",
+    "openText": "Did you learn anything new about Vitamix Blenders?",
+    "email": "Enter your Email",
+    "submit": "Sign up",
+    "sending": "Sending...",
+    "thankYou": "Thank you for entering."
+  },
+  "inputPlaceholders": {
+    "email": ""
+  },
+  "dinners": [
+    "Flavors of the Mediterranean: Lunch hosted by Marc Murphy, Ayesha Nurdjaja, and Zac Young part of the Vitamix® Series",
+    "A Journey through Mexico: Lunch hosted by Val M. Cantú, Ana Castro, and Michael Diaz de Leon part of the Vitamix® Series",
+    "The Foundation Table: Dinner hosted by Antonia Lofaso and Geoffrey Zakarian part of the Vitamix® Series",
+    "A Taste of La Mar: Dinner hosted by Gastón Acurio, Kaoru Chang, Jesús Delgado, Victoriano Lopez, and Diego Oka part of the Vitamix® Series",
+    "The French Table: Dinner hosted by Markus Glocker, Lenny Messina, and Camari Mick part of the Vitamix® Series",
+    "Celebrating 75 years of Jonathan Waxman: Dinner hosted by Jimmy Bradley, Joey Campanaro, Paul Kahan, and Michael Symon part of the Vitamix® Series",
+    "Modern American: Lunch hosted by Esther Choi, Claudette Zepeda, and Francis Ang part of the Vitamix® Series",
+    "Feast of the Garden presented by GreenLeaf: Lunch hosted by Nyesha Arrington, Maneet Chauhan, and Rob Rubba part of the Vitamix® Series",
+    "Flavors of Italy: Dinner hosted by Karen Akunowicz, Amy Brandwein, and David Nayfeld part of the Vitamix® Series",
+    "The 50 Year Judgment of Paris: Dinner hosted by Elizabeth Falkner, Philip Tessier, and Duskie Estes part of the Vitamix® Series",
+    "Sunday Brunch hosted by Caroline Schiff, Alex Seidel, and Michael Schwartz part of the Vitamix® Series"
+  ]
+}


### PR DESCRIPTION
Fixes four independent checkout bugs found during QA:

**Radio keyboard navigation (Chrome)** — Chrome treats a radio group as a single tab stop, so users couldn't Tab through individual shipping, payment, and billing options. Setting `tabIndex = 0` explicitly on each radio overrides this and makes every option independently reachable by keyboard.

**Empty-cart localStorage race** — When the last cart item was removed, the `cart:change` event fired before the removal was persisted to localStorage. If the checkout page reloaded immediately on receiving that event (empty-cart redirect), it would read the stale snapshot and restore the removed item. Now the cart is flushed synchronously to localStorage before dispatching the event when it becomes empty.

**Address confirmation display (Canadian addresses)** — The confirm and add-unit modals reconstructed display lines from `addressComponents`, which could pick up `sublocality_level_1` (e.g. "Etobicoke") instead of `locality` (e.g. "Toronto"). Modals now use Google's pre-formatted `formattedAddress` string directly when available, splitting at the first comma for a clean two-line display.

**Validation: auto-expand collapsed sections** — When `validateForm` caught an invalid field inside a collapsed section, it would focus the field but the section remained collapsed, hiding the error from the user. The validator now clicks the section's Edit button to expand it before focusing. The shipping section's `getIsValid` check also now runs `validateField` alongside `checkValidity()` for consistency.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://cart-remove-firefox-checkout-race--vitamix--aemsites.aem.network/
