### PR TITLE
fix: log fetch response errors on non-prod hosts

### DIFF
--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -1,7 +1,7 @@
 import { getConfig } from './commerce-config.js';
 import { AUTH_TOKEN_KEY } from './auth-api.js';
 import { mintRecaptchaToken, RECAPTCHA_ACTIONS, RECAPTCHA_HEADER } from './recaptcha.js';
-import { getLocaleAndLanguage } from './scripts.js';
+import { getLocaleAndLanguage, loggedFetch } from './scripts.js';
 
 /**
  * Error thrown when the Commerce API returns a non-2xx response.
@@ -41,7 +41,7 @@ async function post(path, body, recaptchaAction) {
     if (recaptchaToken) headers[RECAPTCHA_HEADER] = recaptchaToken;
   }
 
-  const resp = await fetch(`${getConfig().apiOrigin}${path}`, {
+  const resp = await loggedFetch(`${getConfig().apiOrigin}${path}`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1079,29 +1079,36 @@ export async function loggedFetch(input, init) {
   if (hostname.includes('www.vitamix.com')) return fetch(input, init);
   const response = await fetch(input, init);
   if (!response.ok) {
+    const xError = response.headers.get('x-error');
+    const xErrorCode = response.headers.get('x-error-code');
     try {
-      const xError = response.headers.get('x-error');
-      const xErrorCode = response.headers.get('x-error-code');
       response.clone().text().then((text) => {
         let data = text;
         try {
           data = JSON.parse(text);
-        } catch {
-          // noop
-        }
+        } catch { /* noop */ }
+        let requestBody = init?.body;
+        try {
+          requestBody = JSON.parse(requestBody);
+        } catch { /* noop */ }
+
+        /* eslint-disable no-console */
         console.group(`Error response from: ${input.toString()}`);
-        console.error('status: ', response.status);
-        console.error('method: ', init?.method ?? 'GET');
-        console.error('request headers: ', init?.headers);
-        console.error('request body: ', init?.body);
-        console.error('response body: ', data);
-        console.error('x-error: ', xError);
-        console.error('x-error-code: ', xErrorCode);
+        console.error(JSON.stringify({
+          status: response.status,
+          method: init?.method ?? 'GET',
+          requestHeaders: init?.headers,
+          requestBody,
+          responseBody: data,
+          xError,
+          xErrorCode,
+        }, null, 2));
         console.groupEnd();
       });
     } catch (e) {
-      console.error('Error logging response', e);
+      console.error('Error logging response for:', input.toString(), e, xError, xErrorCode);
       console.warn(response);
+      /* eslint-enable no-console */
     }
   }
   return response;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1080,6 +1080,8 @@ export async function loggedFetch(input, init) {
   const response = await fetch(input, init);
   if (!response.ok) {
     try {
+      const xError = response.headers.get('x-error');
+      const xErrorCode = response.headers.get('x-error-code');
       response.clone().text().then((text) => {
         let data = text;
         try {
@@ -1093,8 +1095,8 @@ export async function loggedFetch(input, init) {
         console.error('request headers: ', init?.headers);
         console.error('request body: ', init?.body);
         console.error('response body: ', data);
-        console.error('x-error: ', response.headers.get('x-error'));
-        console.error('x-error-code: ', response.headers.get('x-error-code'));
+        console.error('x-error: ', xError);
+        console.error('x-error-code: ', xErrorCode);
         console.groupEnd();
       });
     } catch (e) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1090,7 +1090,7 @@ export async function loggedFetch(input, init) {
         console.group(`Error response from: ${input.toString()}`);
         console.error('status: ', response.status);
         console.error('method: ', init?.method ?? 'GET');
-        console.error('request headers: ', Object.fromEntries(init?.headers?.entries() ?? []));
+        console.error('request headers: ', init?.headers);
         console.error('request body: ', init?.body);
         console.error('response body: ', data);
         console.error('x-error: ', response.headers.get('x-error'));

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1070,6 +1070,42 @@ export function applyImgColor(block) {
 }
 
 /**
+ * Logs error to the console
+ * @param {RequestInfo|URL} input
+ * @param {RequestInit} [init]
+ * @returns {Promise<Response>}
+ */
+export async function loggedFetch(input, init) {
+  if (hostname.includes('www.vitamix.com')) return fetch(input, init);
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    try {
+      response.clone().text().then((text) => {
+        let data = text;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          // noop
+        }
+        console.group(`Error response from: ${input.toString()}`);
+        console.error('status: ', response.status);
+        console.error('method: ', init?.method ?? 'GET');
+        console.error('request headers: ', Object.fromEntries(init?.headers?.entries() ?? []));
+        console.error('request body: ', init?.body);
+        console.error('response body: ', data);
+        console.error('x-error: ', response.headers.get('x-error'));
+        console.error('x-error-code: ', response.headers.get('x-error-code'));
+        console.groupEnd();
+      });
+    } catch (e) {
+      console.error('Error logging response', e);
+      console.warn(response);
+    }
+  }
+  return response;
+}
+
+/**
  * Determines if a given date falls within US Eastern Daylight Saving Time.
  * DST starts: 2nd Sunday of March at 2:00 AM
  * DST ends: 1st Sunday of November at 2:00 AM


### PR DESCRIPTION
logs errors from fetches to commerce api on non-prod hosts

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/order/checkout
- After: https://logged-fetch--vitamix--aemsites.aem.network/us/en_us/order/checkout
