### PR TITLE
feat: apply coupon free-shipping to `estimate/shipping` rates

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -236,7 +236,7 @@ function showAddressError(section, message) {
   const error = document.createElement('p');
   error.className = 'address-validation-error checkout-error';
   error.textContent = message;
-  const formGrid = section.querySelector('.form-grid');
+  const formGrid = section.querySelector('.form-fields');
   if (formGrid) {
     formGrid.insertAdjacentElement('afterend', error);
   } else {
@@ -802,9 +802,13 @@ export function initAddress(form, state, config, strings) {
     : null;
   if (billingSection) initPlacesAutocomplete(billingSection, config);
 
-  // Clear the section-level address-validation error as soon as the user edits any field.
+  // Clear the section-level address-validation error when the user edits any field.
+  // Only fires for trusted (user-initiated) events — programmatic input dispatches
+  // (e.g. the unit-number write in CONFIRM_ADD_SUBPREMISES) must not clear it.
   if (shippingSection) {
-    shippingSection.addEventListener('input', () => clearAddressError(shippingSection));
+    shippingSection.addEventListener('input', (e) => {
+      if (e.isTrusted) clearAddressError(shippingSection);
+    });
   }
 
   // Invalidate estimate token when estimate-affecting fields change

--- a/blocks/checkout/checkout-session-state.js
+++ b/blocks/checkout/checkout-session-state.js
@@ -13,6 +13,10 @@ export function saveFormState(form, locale) {
         data[el.name] = el.value;
       }
     });
+    const shippingSection = form.querySelector('.shipping-address-section');
+    if (shippingSection) {
+      data.shippingCollapsed = shippingSection.classList.contains('is-collapsed');
+    }
     sessionStorage.setItem(formStateKey(locale), JSON.stringify(data));
   } catch { /* ignore quota / private-mode errors */ }
 }

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -38,7 +38,7 @@ export function renderShippingMethods(container, rates, strings, currencyCode = 
     labelText.className = 'shipping-method-label';
     labelText.textContent = rate.label;
 
-    const isFree = rate.rate === 0;
+    const isFree = parseFloat(rate.rate) === 0;
     const price = document.createElement('span');
     price.className = isFree ? 'shipping-method-price shipping-method-price-free' : 'shipping-method-price';
     price.textContent = isFree ? strings.free : formatPrice(parseFloat(rate.rate), currencyCode);
@@ -146,13 +146,19 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
   const locale = config.getLocale();
   const country = locale === 'ca' ? 'ca' : 'us';
 
+  const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
+
   try {
-    const result = await estimateShipping(country, stateCode, cart.getItemsForAPI());
+    const result = await estimateShipping(country, stateCode, cart.getItemsForAPI(), couponCode);
     renderShippingMethods(shippingContainer, result.rates || [], strings, currencyCode);
 
-    const firstRadio = shippingContainer.querySelector('input[type="radio"]');
-    if (firstRadio) {
-      state.selectedShippingMethodId = firstRadio.value;
+    // Preserve the user's previous selection; fall back to the first method.
+    const previousId = state.selectedShippingMethodId;
+    const targetRadio = (previousId && shippingContainer.querySelector(`input[value="${previousId}"]`))
+      || shippingContainer.querySelector('input[type="radio"]');
+    if (targetRadio) {
+      targetRadio.checked = true;
+      state.selectedShippingMethodId = targetRadio.value;
       shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', { bubbles: true }));
       await updatePreview(form, cart, state, config);
     }
@@ -197,4 +203,6 @@ export function initShipping(form, shippingContainer, cart, state, config, strin
       updatePreview(form, cart, state, config);
     }
   });
+
+  return () => fetchAndPreview(form, shippingContainer, cart, state, config, strings, currencyCode);
 }

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -308,6 +308,17 @@ export default async function decorate(block) {
     }
   });
 
+  // Re-apply shipping section collapse state from session storage. When the user
+  // returns to checkout after navigating away, the address fields are restored by
+  // restoreFormState but the section UI starts expanded. If the address was already
+  // validated and collapsed when they left, collapse it again so the summary shows.
+  (() => {
+    try {
+      const saved = JSON.parse(sessionStorage.getItem(formStateKey(locale)));
+      if (saved?.shippingCollapsed) collapseShipping();
+    } catch { /* ignore */ }
+  })();
+
   // Wire shipping rate fetching and preview
   const shippingContainer = form.querySelector('.shipping-methods');
   initShipping(form, shippingContainer, cart, state, config, strings);

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -321,7 +321,7 @@ export default async function decorate(block) {
 
   // Wire shipping rate fetching and preview
   const shippingContainer = form.querySelector('.shipping-methods');
-  initShipping(form, shippingContainer, cart, state, config, strings);
+  const refreshShipping = initShipping(form, shippingContainer, cart, state, config, strings);
 
   // When the cart changes mid-checkout, invalidate the stale estimate and
   // re-run the preview so totals stay accurate. The empty-cart listener above
@@ -349,9 +349,11 @@ export default async function decorate(block) {
     });
   });
 
-  // Re-run preview when a coupon code is applied from the order summary sidebar.
+  // Re-fetch shipping rates when a coupon is applied or removed so the method
+  // list reflects any free-shipping discount. updatePreview is called inside
+  // refreshShipping after the rates are rendered.
   document.addEventListener('checkout:coupon-apply', () => {
-    if (state.selectedShippingMethodId) updatePreview(form, cart, state, config);
+    refreshShipping();
   });
 
   // Wire Chase submit and get shared callbacks for providers

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -62,14 +62,16 @@ async function post(path, body, recaptchaAction) {
  * @param {string} state - State or province code (e.g. 'QC', 'CA')
  * @param {Array<{sku: string, path: string, quantity: number, price: Object}>} items
  *   Cart items in API format
- * @returns {Promise<{ rates: Array<{ id: string, label: string, rate: number }> }>}
+ * @param {string} [couponCode] - coupon code; free-shipping discounts apply when provided
+ * @returns {Promise<{ rates: Array<{ id: string, label: string, rate: string }> }>}
  * @throws {CommerceApiError}
  */
-export async function estimateShipping(country, state, items) {
+export async function estimateShipping(country, state, items, couponCode) {
   return post('/estimate/shipping', {
     country,
     shipping: { country, state },
     items,
+    ...(couponCode ? { couponCode } : {}),
   });
 }
 

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -1,12 +1,12 @@
 /**
- * Unit tests for scripts/commerce-api.js — getOrder function.
+ * Unit tests for scripts/commerce-api.js — getOrder and estimateShipping functions.
  *
  * Run with `npm run test:unit`. The setup file installs the fetch mock and
  * browser globals (sessionStorage) that commerce-api.js depends on.
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getOrder } from '../../scripts/commerce-api.js';
+import { getOrder, estimateShipping } from '../../scripts/commerce-api.js';
 
 const API_ORIGIN = 'https://api.test.com/test-org/sites/test-site';
 
@@ -122,4 +122,40 @@ test('getOrder: throws with status 500 on server error', async () => {
       return true;
     },
   );
+});
+
+// --- estimateShipping -------------------------------------------------------
+
+test('estimateShipping: omits couponCode when not provided', async () => {
+  mockFetch(200, { rates: [] });
+  await estimateShipping('us', 'CA', []);
+  const body = JSON.parse(lastInit.body);
+  assert.ok(!Object.prototype.hasOwnProperty.call(body, 'couponCode'), 'couponCode should be absent');
+});
+
+test('estimateShipping: includes couponCode in request body when provided', async () => {
+  mockFetch(200, { rates: [] });
+  await estimateShipping('us', 'CA', [], 'FREESHIP');
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.couponCode, 'FREESHIP');
+});
+
+test('estimateShipping: sends correct country, shipping, and items', async () => {
+  const items = [{ sku: 'abc', quantity: 1, price: { final: '50.00' } }];
+  mockFetch(200, { rates: [] });
+  await estimateShipping('ca', 'ON', items);
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.country, 'ca');
+  assert.deepEqual(body.shipping, { country: 'ca', state: 'ON' });
+  assert.deepEqual(body.items, items);
+});
+
+test('estimateShipping: returns rates array from response', async () => {
+  const rates = [
+    { id: '1', type: 'standard', rate: '0.00', label: 'Standard' },
+    { id: '2', type: 'priority', rate: '25.00', label: 'Priority' },
+  ];
+  mockFetch(200, { rates });
+  const result = await estimateShipping('us', 'NY', []);
+  assert.deepEqual(result.rates, rates);
 });


### PR DESCRIPTION
`estimate/shipping` was returning raw rates without evaluating coupons or cart rules, so a coupon with `freeShipping: true` had no effect on the displayed shipping methods.

API (`estimate/shipping`):
- Load cart rules and validate coupon in parallel with the sheet fetch
- Zero the rate for any method whose type matches the coupon or auto-rule `includedShippingTypes` scope
- Normalize `id` to string and `rate` to a two-decimal string on all returned methods, consistent with `estimate/order`

Vitamix:
- Pass active coupon code from sessionStorage to `estimateShipping`
- Re-fetch shipping rates on `checkout:coupon-apply` / remove so the method list reflects free-shipping discounts immediately
- Restore the user's previously selected method after re-render
- Fix `isFree` check in `renderShippingMethods` to use `parseFloat()` now that `rate` is a string

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://shipping-panel--vitamix--aemsites.aem.network/
