### PR TITLE
fix: pass `shippingDimensions` to shipping estimate API

### DIFF
--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -323,6 +323,15 @@ export default async function decorate(block) {
   const shippingContainer = form.querySelector('.shipping-methods');
   const refreshShipping = initShipping(form, shippingContainer, cart, state, config, strings);
 
+  // If the address was restored from sessionStorage on this page load, the
+  // state select has a value but no `change` event ever fired — so the
+  // estimate/preview chain never ran. Trigger it once now. fetchAndPreview
+  // self-guards on missing state or empty cart, so calling it
+  // unconditionally is safe.
+  if (form.elements['shipping-state']?.value) {
+    refreshShipping();
+  }
+
   // When the cart changes mid-checkout, invalidate the stale estimate and
   // re-run the preview so totals stay accurate. The empty-cart listener above
   // handles the zero-items case via reload; this handles qty changes and
@@ -402,6 +411,11 @@ export default async function decorate(block) {
       }
       // decorate() doesn't re-run for bfcache hits — restore form data here
       restoreFormState(form, locale);
+      // ...and re-trigger the estimate/preview chain for the restored address,
+      // matching the initial-load path above.
+      if (form.elements['shipping-state']?.value) {
+        refreshShipping();
+      }
     }
   });
 }

--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -102,6 +102,24 @@ export function normalizeCartPrice(value) {
 }
 
 /**
+ * Extract shippingDimensions from a JSON-LD Offer's `shippingDetails`, converting
+ * each schema.org `QuantitativeValue` back to the Product Bus `{ value, unit }` shape
+ * the Commerce API expects on cart items. Returns `undefined` when the offer has no
+ * shipping data, so callers can spread it conditionally onto the cart item.
+ *
+ * The pipeline preserves the original unit on `unitText` (e.g. `"lb"`) for this
+ * round-trip, distinct from the UN/CEFACT `unitCode` (e.g. `"LBR"`).
+ *
+ * @param {Object} offer - A schema.org Offer object from the page JSON-LD
+ * @returns {{weight: {value: number, unit: string}} | undefined}
+ */
+export function shippingDimensionsFromOffer(offer) {
+  const w = offer?.shippingDetails?.weight;
+  if (!w || typeof w.value !== 'number' || !w.unitText) return undefined;
+  return { weight: { value: w.value, unit: w.unitText } };
+}
+
+/**
  * Checks if a variant is available for sale.
  * @param {Object} variant - The variant object
  * @returns {boolean} True if the variant is available for sale, false otherwise
@@ -283,6 +301,13 @@ export default function renderAddToCart(ph, block, parent) {
         }));
         const availableWarranties = warrantyOptions.length > 0 ? warrantyOptions : null;
 
+        // For simple products, `selectedVariant === parent` and shippingDetails
+        // lives on the auto-generated single Offer; for variants it lives on
+        // the variant offer itself. Read from the variant first, fall back to
+        // the parent's first Offer for the simple-product case.
+        const shippingDimensions = shippingDimensionsFromOffer(selectedVariant)
+          ?? shippingDimensionsFromOffer(parent.offers?.[0]);
+
         const item = {
           sku: targetSku,
           parentSku: variantSku ? sku : undefined,
@@ -299,6 +324,7 @@ export default function renderAddToCart(ph, block, parent) {
           selectedOptions: semanticOptions,
           ...(parent.bundleItems ? { bundleItems: parent.bundleItems } : {}),
           ...(availableWarranties ? { local: { availableWarranties } } : {}),
+          ...(shippingDimensions ? { shippingDimensions } : {}),
         };
         await cartApi.addItem(item);
 

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -267,6 +267,7 @@ export class Cart {
       ...(item.url ? { productUrl: item.url } : {}),
       ...(item.selectedOptions?.length ? { selectedOptions: item.selectedOptions } : {}),
       ...(item.custom ? { custom: item.custom } : {}),
+      ...(item.shippingDimensions ? { shippingDimensions: item.shippingDimensions } : {}),
     }));
   }
 

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -6,7 +6,12 @@
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeCartPrice, isVariantAvailableForSale, computeAllowedQty } from '../../blocks/pdp/add-to-cart.js';
+import {
+  normalizeCartPrice,
+  isVariantAvailableForSale,
+  computeAllowedQty,
+  shippingDimensionsFromOffer,
+} from '../../blocks/pdp/add-to-cart.js';
 import { __setMetadata, __resetMetadata } from './mocks/aem.mjs';
 import { __setOutOfStockSkus, __resetScripts } from './mocks/scripts.mjs';
 
@@ -125,4 +130,56 @@ test('computeAllowedQty: normal single-unit add', () => {
 
 test('computeAllowedQty: clamps to zero, not negative, when existing exceeds max', () => {
   assert.equal(computeAllowedQty(1, 4, 3), 0);
+});
+
+// --- shippingDimensionsFromOffer -------------------------------------------
+
+test('shippingDimensionsFromOffer: extracts weight from JSON-LD QuantitativeValue', () => {
+  const offer = {
+    '@type': 'Offer',
+    shippingDetails: {
+      '@type': 'OfferShippingDetails',
+      weight: {
+        '@type': 'QuantitativeValue', value: 14.25, unitCode: 'LBR', unitText: 'lb',
+      },
+    },
+  };
+  assert.deepEqual(
+    shippingDimensionsFromOffer(offer),
+    { weight: { value: 14.25, unit: 'lb' } },
+  );
+});
+
+test('shippingDimensionsFromOffer: returns undefined when offer has no shippingDetails', () => {
+  assert.equal(shippingDimensionsFromOffer({ '@type': 'Offer', sku: 'foo' }), undefined);
+});
+
+test('shippingDimensionsFromOffer: returns undefined when shippingDetails has no weight', () => {
+  assert.equal(
+    shippingDimensionsFromOffer({ shippingDetails: { '@type': 'OfferShippingDetails' } }),
+    undefined,
+  );
+});
+
+test('shippingDimensionsFromOffer: returns undefined when weight has no unitText', () => {
+  const offer = {
+    shippingDetails: {
+      weight: { '@type': 'QuantitativeValue', value: 14.25, unitCode: 'LBR' },
+    },
+  };
+  assert.equal(shippingDimensionsFromOffer(offer), undefined);
+});
+
+test('shippingDimensionsFromOffer: returns undefined when value is not numeric', () => {
+  const offer = {
+    shippingDetails: {
+      weight: { '@type': 'QuantitativeValue', value: '14.25', unitText: 'lb' },
+    },
+  };
+  assert.equal(shippingDimensionsFromOffer(offer), undefined);
+});
+
+test('shippingDimensionsFromOffer: returns undefined for null/undefined input', () => {
+  assert.equal(shippingDimensionsFromOffer(null), undefined);
+  assert.equal(shippingDimensionsFromOffer(undefined), undefined);
 });

--- a/tests/unit/cart.test.js
+++ b/tests/unit/cart.test.js
@@ -283,6 +283,33 @@ test('getItemsForAPI omits imageUrl/productUrl when not present', () => {
   assert.equal('productUrl' in api[0], false);
 });
 
+test('getItemsForAPI forwards shippingDimensions when present', () => {
+  const cart = new Cart();
+  cart.addItem({
+    sku: 'foo',
+    quantity: 1,
+    price: '10.00',
+    name: 'Foo',
+    path: '/products/foo',
+    shippingDimensions: { weight: { value: 14.25, unit: 'lb' } },
+  });
+  const api = cart.getItemsForAPI();
+  assert.deepEqual(api[0].shippingDimensions, { weight: { value: 14.25, unit: 'lb' } });
+});
+
+test('getItemsForAPI omits shippingDimensions when not present', () => {
+  const cart = new Cart();
+  cart.addItem({
+    sku: 'foo',
+    quantity: 1,
+    price: '10.00',
+    name: 'Foo',
+    path: '/products/foo',
+  });
+  const api = cart.getItemsForAPI();
+  assert.equal('shippingDimensions' in api[0], false);
+});
+
 // --- cart:change events -----------------------------------------------------
 
 const eventsByAction = (action) => globalThis.__events.filter((e) => e.detail.action === action);


### PR DESCRIPTION
Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://shipping-weight--vitamix--aemsites.aem.network/
