### PR TITLE
fix: use custom.originalPrice when present

### DIFF
--- a/blocks/pdp/pricing.js
+++ b/blocks/pdp/pricing.js
@@ -14,7 +14,7 @@ export default function renderPricing(ph, block, variant) {
     return pricingContainer;
   }
 
-  const pricing = variant
+  let pricing = variant
     ? variant.price
     : getOfferPricing(window.jsonLdData?.offers?.[0]);
   if (!pricing) {
@@ -32,6 +32,20 @@ export default function renderPricing(ph, block, variant) {
   // If the variant is null, check if the location href includes 'reconditioned'
   // If both are false, item is not reconditioned
   const isReconditioned = variant && variant.itemCondition ? variant.itemCondition.includes('RefurbishedCondition') : window.location.href.includes('reconditioned') || false;
+
+  // Reconditioned products carry the original (pre-reconditioned) price in
+  // custom.originalPrice. Use it as the regular/"New" price so the savings row
+  // renders against the original price instead of the reconditioned price.
+  // Variant selection has custom on the variant; the initial (no-variant) render
+  // reads it from the parent product's custom in window.jsonLdData.
+  if (isReconditioned) {
+    const originalPrice = variant
+      ? variant.custom?.originalPrice
+      : window.jsonLdData?.custom?.originalPrice;
+    if (originalPrice) {
+      pricing = { ...pricing, regular: parseFloat(originalPrice) };
+    }
+  }
 
   if (pricing.regular && pricing.regular > pricing.final) {
     const nowLabel = document.createElement('div');

--- a/blocks/plp/plp.js
+++ b/blocks/plp/plp.js
@@ -39,6 +39,7 @@ function parseData(data, locale, language) {
         break;
       case 'price':
       case 'regularPrice':
+      case 'originalPrice':
         // convert price strings to numeric values
         parsed[key] = parseFloat(value, 10);
         break;
@@ -286,12 +287,16 @@ function createProductPrice(product, ph) {
   const price = document.createElement('p');
   price.className = 'plp-price';
   price.textContent = product.price ? formatPrice(product.price, ph) : '';
-  if (product.regularPrice && product.regularPrice > product.price) {
-    const savings = (product.regularPrice - product.price).toFixed(2);
+  // Reconditioned products carry the original (pre-reconditioned) price in
+  // originalPrice; use it as the regular/"was" price when present, otherwise
+  // fall back to the regular price.
+  const regular = product.originalPrice || product.regularPrice;
+  if (regular && regular > product.price) {
+    const savings = (regular - product.price).toFixed(2);
     const saleInfo = document.createElement('span');
     saleInfo.textContent = `| ${ph.save || 'Save'} ${formatPrice(savings, ph)}`;
     const regularPrice = document.createElement('del');
-    regularPrice.textContent = formatPrice(product.regularPrice, ph);
+    regularPrice.textContent = formatPrice(regular, ph);
     saleInfo.prepend(regularPrice);
     price.append(' ', saleInfo);
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,12 +44,7 @@ export function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    // Reconditioned products carry the original (pre-reconditioned) price in
-    // custom.originalPrice and use it as the regular/was price. Fall back to the
-    // offer's list price when originalPrice is not present.
-    regular: offer.custom?.originalPrice
-      ? parseFloat(offer.custom.originalPrice)
-      : (offer.priceSpecification?.price || null),
+    regular: offer.priceSpecification?.price || null,
   };
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,7 +44,12 @@ export function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.priceSpecification?.price || null,
+    // Reconditioned products carry the original (pre-reconditioned) price in
+    // custom.originalPrice and use it as the regular/was price. Fall back to the
+    // offer's list price when originalPrice is not present.
+    regular: offer.custom?.originalPrice
+      ? parseFloat(offer.custom.originalPrice)
+      : (offer.priceSpecification?.price || null),
   };
 }
 

--- a/tests/scripts/pricing.spec.js
+++ b/tests/scripts/pricing.spec.js
@@ -19,7 +19,9 @@ function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.priceSpecification?.price || null,
+    regular: offer.custom?.originalPrice
+      ? parseFloat(offer.custom.originalPrice)
+      : (offer.priceSpecification?.price || null),
   };
 }
 
@@ -92,6 +94,37 @@ test.describe('getOfferPricing', () => {
     const result = getOfferPricing(offer);
     expect(result.final).toBe(349.95);
     expect(result.regular).toBeNull();
+  });
+
+  test('uses custom.originalPrice as the regular price when present', () => {
+    const offer = {
+      price: '499.95',
+      priceCurrency: 'USD',
+      custom: { originalPrice: '549.95' },
+    };
+    const result = getOfferPricing(offer);
+    expect(result.final).toBe(499.95);
+    expect(result.regular).toBe(549.95);
+  });
+
+  test('prefers custom.originalPrice over priceSpecification', () => {
+    const offer = {
+      price: '499.95',
+      priceSpecification: { price: 519.95 },
+      custom: { originalPrice: '549.95' },
+    };
+    const result = getOfferPricing(offer);
+    expect(result.regular).toBe(549.95);
+  });
+
+  test('falls back to priceSpecification when custom.originalPrice is absent', () => {
+    const offer = {
+      price: '349.95',
+      priceSpecification: { price: 399.95 },
+      custom: {},
+    };
+    const result = getOfferPricing(offer);
+    expect(result.regular).toBe(399.95);
   });
 
   test('returns null for null offer', () => {

--- a/tests/scripts/pricing.spec.js
+++ b/tests/scripts/pricing.spec.js
@@ -19,9 +19,7 @@ function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.custom?.originalPrice
-      ? parseFloat(offer.custom.originalPrice)
-      : (offer.priceSpecification?.price || null),
+    regular: offer.priceSpecification?.price || null,
   };
 }
 
@@ -94,37 +92,6 @@ test.describe('getOfferPricing', () => {
     const result = getOfferPricing(offer);
     expect(result.final).toBe(349.95);
     expect(result.regular).toBeNull();
-  });
-
-  test('uses custom.originalPrice as the regular price when present', () => {
-    const offer = {
-      price: '499.95',
-      priceCurrency: 'USD',
-      custom: { originalPrice: '549.95' },
-    };
-    const result = getOfferPricing(offer);
-    expect(result.final).toBe(499.95);
-    expect(result.regular).toBe(549.95);
-  });
-
-  test('prefers custom.originalPrice over priceSpecification', () => {
-    const offer = {
-      price: '499.95',
-      priceSpecification: { price: 519.95 },
-      custom: { originalPrice: '549.95' },
-    };
-    const result = getOfferPricing(offer);
-    expect(result.regular).toBe(549.95);
-  });
-
-  test('falls back to priceSpecification when custom.originalPrice is absent', () => {
-    const offer = {
-      price: '349.95',
-      priceSpecification: { price: 399.95 },
-      custom: {},
-    };
-    const result = getOfferPricing(offer);
-    expect(result.regular).toBe(399.95);
   });
 
   test('returns null for null offer', () => {


### PR DESCRIPTION
uses `custom.originalPrice` for the "regular price" when value is present
depends on https://github.com/dylandepass/vitamix-catalog-sync/pull/29

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a3500
- After: https://recon-price--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a3500
