### PR TITLE
fix: use custom.originalPrice when present (& sync main)

### DIFF
--- a/blocks/pdp/pricing.js
+++ b/blocks/pdp/pricing.js
@@ -14,7 +14,7 @@ export default function renderPricing(ph, block, variant) {
     return pricingContainer;
   }
 
-  const pricing = variant
+  let pricing = variant
     ? variant.price
     : getOfferPricing(window.jsonLdData?.offers?.[0]);
   if (!pricing) {
@@ -32,6 +32,20 @@ export default function renderPricing(ph, block, variant) {
   // If the variant is null, check if the location href includes 'reconditioned'
   // If both are false, item is not reconditioned
   const isReconditioned = variant && variant.itemCondition ? variant.itemCondition.includes('RefurbishedCondition') : window.location.href.includes('reconditioned') || false;
+
+  // Reconditioned products carry the original (pre-reconditioned) price in
+  // custom.originalPrice. Use it as the regular/"New" price so the savings row
+  // renders against the original price instead of the reconditioned price.
+  // Variant selection has custom on the variant; the initial (no-variant) render
+  // reads it from the parent product's custom in window.jsonLdData.
+  if (isReconditioned) {
+    const originalPrice = variant
+      ? variant.custom?.originalPrice
+      : window.jsonLdData?.custom?.originalPrice;
+    if (originalPrice) {
+      pricing = { ...pricing, regular: parseFloat(originalPrice) };
+    }
+  }
 
   if (pricing.regular && pricing.regular > pricing.final) {
     const nowLabel = document.createElement('div');

--- a/blocks/plp/plp.js
+++ b/blocks/plp/plp.js
@@ -39,6 +39,7 @@ function parseData(data, locale, language) {
         break;
       case 'price':
       case 'regularPrice':
+      case 'originalPrice':
         // convert price strings to numeric values
         parsed[key] = parseFloat(value, 10);
         break;
@@ -286,12 +287,16 @@ function createProductPrice(product, ph) {
   const price = document.createElement('p');
   price.className = 'plp-price';
   price.textContent = product.price ? formatPrice(product.price, ph) : '';
-  if (product.regularPrice && product.regularPrice > product.price) {
-    const savings = (product.regularPrice - product.price).toFixed(2);
+  // Reconditioned products carry the original (pre-reconditioned) price in
+  // originalPrice; use it as the regular/"was" price when present, otherwise
+  // fall back to the regular price.
+  const regular = product.originalPrice || product.regularPrice;
+  if (regular && regular > product.price) {
+    const savings = (regular - product.price).toFixed(2);
     const saleInfo = document.createElement('span');
     saleInfo.textContent = `| ${ph.save || 'Save'} ${formatPrice(savings, ph)}`;
     const regularPrice = document.createElement('del');
-    regularPrice.textContent = formatPrice(product.regularPrice, ph);
+    regularPrice.textContent = formatPrice(regular, ph);
     saleInfo.prepend(regularPrice);
     price.append(' ', saleInfo);
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,12 +44,7 @@ export function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    // Reconditioned products carry the original (pre-reconditioned) price in
-    // custom.originalPrice and use it as the regular/was price. Fall back to the
-    // offer's list price when originalPrice is not present.
-    regular: offer.custom?.originalPrice
-      ? parseFloat(offer.custom.originalPrice)
-      : (offer.priceSpecification?.price || null),
+    regular: offer.priceSpecification?.price || null,
   };
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,7 +44,12 @@ export function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.priceSpecification?.price || null,
+    // Reconditioned products carry the original (pre-reconditioned) price in
+    // custom.originalPrice and use it as the regular/was price. Fall back to the
+    // offer's list price when originalPrice is not present.
+    regular: offer.custom?.originalPrice
+      ? parseFloat(offer.custom.originalPrice)
+      : (offer.priceSpecification?.price || null),
   };
 }
 

--- a/tests/scripts/pricing.spec.js
+++ b/tests/scripts/pricing.spec.js
@@ -19,7 +19,9 @@ function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.priceSpecification?.price || null,
+    regular: offer.custom?.originalPrice
+      ? parseFloat(offer.custom.originalPrice)
+      : (offer.priceSpecification?.price || null),
   };
 }
 
@@ -92,6 +94,37 @@ test.describe('getOfferPricing', () => {
     const result = getOfferPricing(offer);
     expect(result.final).toBe(349.95);
     expect(result.regular).toBeNull();
+  });
+
+  test('uses custom.originalPrice as the regular price when present', () => {
+    const offer = {
+      price: '499.95',
+      priceCurrency: 'USD',
+      custom: { originalPrice: '549.95' },
+    };
+    const result = getOfferPricing(offer);
+    expect(result.final).toBe(499.95);
+    expect(result.regular).toBe(549.95);
+  });
+
+  test('prefers custom.originalPrice over priceSpecification', () => {
+    const offer = {
+      price: '499.95',
+      priceSpecification: { price: 519.95 },
+      custom: { originalPrice: '549.95' },
+    };
+    const result = getOfferPricing(offer);
+    expect(result.regular).toBe(549.95);
+  });
+
+  test('falls back to priceSpecification when custom.originalPrice is absent', () => {
+    const offer = {
+      price: '349.95',
+      priceSpecification: { price: 399.95 },
+      custom: {},
+    };
+    const result = getOfferPricing(offer);
+    expect(result.regular).toBe(399.95);
   });
 
   test('returns null for null offer', () => {

--- a/tests/scripts/pricing.spec.js
+++ b/tests/scripts/pricing.spec.js
@@ -19,9 +19,7 @@ function getOfferPricing(offer) {
   if (!offer) return null;
   return {
     final: parseFloat(offer.price),
-    regular: offer.custom?.originalPrice
-      ? parseFloat(offer.custom.originalPrice)
-      : (offer.priceSpecification?.price || null),
+    regular: offer.priceSpecification?.price || null,
   };
 }
 
@@ -94,37 +92,6 @@ test.describe('getOfferPricing', () => {
     const result = getOfferPricing(offer);
     expect(result.final).toBe(349.95);
     expect(result.regular).toBeNull();
-  });
-
-  test('uses custom.originalPrice as the regular price when present', () => {
-    const offer = {
-      price: '499.95',
-      priceCurrency: 'USD',
-      custom: { originalPrice: '549.95' },
-    };
-    const result = getOfferPricing(offer);
-    expect(result.final).toBe(499.95);
-    expect(result.regular).toBe(549.95);
-  });
-
-  test('prefers custom.originalPrice over priceSpecification', () => {
-    const offer = {
-      price: '499.95',
-      priceSpecification: { price: 519.95 },
-      custom: { originalPrice: '549.95' },
-    };
-    const result = getOfferPricing(offer);
-    expect(result.regular).toBe(549.95);
-  });
-
-  test('falls back to priceSpecification when custom.originalPrice is absent', () => {
-    const offer = {
-      price: '349.95',
-      priceSpecification: { price: 399.95 },
-      custom: {},
-    };
-    const result = getOfferPricing(offer);
-    expect(result.regular).toBe(399.95);
   });
 
   test('returns null for null offer', () => {

--- a/widgets/WIDGETS-ENGLISH-LITERALS.md
+++ b/widgets/WIDGETS-ENGLISH-LITERALS.md
@@ -139,15 +139,15 @@ These literals appear in more than one widget (good candidates for shared i18n).
 | **City** | product-registration, manage-address |
 | **Do you own a Vitamix?** | edit-account, create-account, giveaway |
 | **Email Address** | product-registration, media-contact, login, edit-account, create-account, contact-us |
-| **Enter your Email** | giveaway, pb |
+| **Enter your Email** | giveaway, pb, wineandfood |
 | **First Name** | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | **Last Name** | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | **Phone Number** | product-registration, wellness-program, media-contact, manage-address |
 | **Postal code** | product-registration, manage-address, edit-account, create-account |
-| **Sign up** | giveaway, pb |
+| **Sign up** | giveaway, pb, wineandfood |
 | **Submit** | wellness-program, media-contact, login, contact-us |
-| **Yes** | edit-account, create-account, giveaway, pb |
-| **No** | edit-account, create-account, giveaway, pb |
+| **Yes** | edit-account, create-account, giveaway, pb, wineandfood |
+| **No** | edit-account, create-account, giveaway, pb, wineandfood |
 
 ---
 
@@ -206,11 +206,12 @@ Forms use `labels` and `inputPlaceholders` from locale JSON; the following are t
 | Create account | create-account |
 | Default | article-center (sort) |
 | Did you attend a Vitamix Series Dining Event during the festival? | pb |
+| Did you attend a Wine and Food Dinner? | wineandfood |
 | Did you learn anything new about Vitamix Blenders? | pb |
 | Domestic | contact-us |
 | Do you own a Vitamix? | edit-account, create-account, giveaway |
 | Email Address | product-registration, media-contact, login, edit-account, create-account, contact-us |
-| Enter your Email | giveaway, pb |
+| Enter your Email | giveaway, pb, wineandfood |
 | Find your serial number | product-registration |
 | First Name | product-registration, media-contact, manage-address, edit-account, create-account, contact-us |
 | For commercial products | create-account |
@@ -240,14 +241,15 @@ Forms use `labels` and `inputPlaceholders` from locale JSON; the following are t
 | Select / Select an option | contact-us, product-registration |
 | Serial number / (18 digits) | product-registration |
 | Sending... / Searching... | multiple forms |
-| Sign up | giveaway, pb |
+| Sign up | giveaway, pb, wineandfood |
 | Submit | wellness-program, media-contact, login, contact-us |
-| Thank you for entering. | giveaway, pb |
+| Thank you for entering. | giveaway, pb, wineandfood |
 | Type of request | contact-us |
 | Use as default billing/shipping address | manage-address |
 | Verify Your Email / Enter verification code... | login |
-| Which one? | pb |
-| Yes / No | edit-account, create-account, giveaway, pb |
+| What would you make in a Vitamix Blender? | wineandfood |
+| Which one? | pb, wineandfood |
+| Yes / No | edit-account, create-account, giveaway, pb, wineandfood |
 | * Required fields | create-account |
 
 *(Form input-hint values are in each form’s `.json` under `inputPlaceholders`; the table above reflects the English defaults used in JS when the key is missing.)*

--- a/widgets/consistency-quiz/consistency-quiz.css
+++ b/widgets/consistency-quiz/consistency-quiz.css
@@ -1,0 +1,138 @@
+.consistency-quiz {
+  margin: 0 auto;
+  max-width: 600px;
+  overflow: hidden;
+  background: var(--color-white);
+  border-radius: var(--rounding-l);
+  box-shadow: 0 5px 10px var(--shadow-100);
+}
+
+.consistency-quiz [hidden] {
+  display: none;
+}
+
+.consistency-quiz > section {
+  display: none;
+  padding: var(--horizontal-spacing);
+}
+
+.consistency-quiz[data-stage='intro'] > .intro,
+.consistency-quiz[data-stage='quiz'] > .quiz,
+.consistency-quiz[data-stage='results'] > .results {
+  display: block;
+}
+
+/* intro */
+/* stylelint-disable-next-line no-descending-specificity */
+.consistency-quiz .intro {
+  font-size: var(--body-size-l);
+  line-height: var(--line-height-l);
+}
+
+/* quiz */
+.consistency-quiz .quiz fieldset:focus {
+  outline: none;
+}
+
+.consistency-quiz .quiz fieldset legend {
+  font-size: inherit;
+  margin-bottom: 1em;
+}
+
+.consistency-quiz .quiz fieldset legend .eyebrow {
+  display: block;
+  color: var(--color-gray-900);
+}
+
+.consistency-quiz .quiz .hint {
+  font-size: var(--detail-size-l);
+  color: var(--color-gray-900);
+  font-style: italic;
+}
+
+.consistency-quiz .quiz fieldset > label {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  padding: 1ch;
+  border-radius: var(--rounding-m);
+  font-size: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.consistency-quiz .quiz fieldset > label:hover {
+  background-color: var(--color-gray-200);
+}
+
+.consistency-quiz .quiz fieldset input[type='radio'],
+.consistency-quiz .quiz fieldset input[type='checkbox'] {
+  cursor: pointer;
+}
+
+.consistency-quiz .quiz .feedback [data-answer] {
+  background-color: var(--color-gray-100);
+  border-left: var(--border-l) solid var(--color-cerulean);
+  padding: var(--spacing-200) var(--spacing-300);
+  line-height: var(--line-height-l);
+}
+
+/* footer */
+.consistency-quiz .footer {
+  position: relative;
+  padding: var(--spacing-200) var(--horizontal-spacing);
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-900);
+  font-size: var(--detail-size-l);
+}
+
+.consistency-quiz .footer [data-stage] {
+  display: none;
+}
+
+.consistency-quiz[data-stage='intro'] .footer [data-stage='intro'],
+.consistency-quiz[data-stage='quiz'] .footer [data-stage='quiz'],
+.consistency-quiz[data-stage='results'] .footer [data-stage='results'] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1ch var(--spacing-400);
+}
+
+.consistency-quiz .footer .button-wrapper {
+  margin-top: 0;
+}
+
+.consistency-quiz .footer progress {
+  appearance: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: var(--border-l);
+  background: var(--color-gray-200);
+}
+
+.consistency-quiz .footer progress::-webkit-progress-bar {
+  background: var(--color-gray-200);
+}
+
+.consistency-quiz .footer progress::-webkit-progress-value {
+  background: var(--color-charcoal);
+}
+
+.consistency-quiz .footer progress::-moz-progress-bar {
+  background: var(--color-charcoal);
+}
+
+.consistency-quiz .results h2:focus {
+  outline: none;
+}
+
+.consistency-quiz .footer .button[disabled] {
+  background-color: var(--color-gray-200);
+  color: var(--color-gray-500);
+  border-color: var(--color-gray-200);
+}

--- a/widgets/consistency-quiz/consistency-quiz.html
+++ b/widgets/consistency-quiz/consistency-quiz.html
@@ -1,0 +1,204 @@
+<section class="intro">
+  <p>Customers return to your restaurant because they want the same experience as last time.</p>
+  <p>Are you doing everything you can to produce perfectly consistent beverages?</p>
+  <p><strong>Take our quiz and see.</strong></p>
+</section>
+
+<section class="quiz">
+
+  <fieldset data-step="1" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 1</span>Have you ever noticed a problem with beverages being inconsistent at your restaurants?</legend>
+    <label for="q1-yes">
+      <input type="radio" id="q1-yes" name="q1" value="yes"> Yes
+    </label>
+    <label for="q1-no">
+      <input type="radio" id="q1-no" name="q1" value="no" data-correct="true"> No
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="yes" hidden>OK. At the end of this quiz, we'll share a link with some suggestions that may help.</p>
+      <p data-answer="no" hidden>Good. You may have a rock-solid beverage program.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="2" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 2</span>Have you ever received customer complaints about inconsistent beverages?</legend>
+    <label for="q2-yes">
+      <input type="radio" id="q2-yes" name="q2" value="yes"> Yes
+    </label>
+    <label for="q2-no">
+      <input type="radio" id="q2-no" name="q2" value="no" data-correct="true"> No
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="yes" hidden>That's not uncommon. But there are some steps you can take to make beverages more consistent. We'll share a link at the end of this quiz.</p>
+      <p data-answer="no" hidden>That's good — as long as customers know how to share comments or complaints when they have them.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="3" hidden tabindex="-1" aria-describedby="q3-hint">
+    <legend><span class="eyebrow">Question 3</span>Which of the following could be probable causes of inconsistent beverages?</legend>
+    <p class="hint" id="q3-hint">Select all that apply.</p>
+    <label for="q3-long-lines">
+      <input type="checkbox" id="q3-long-lines" name="q3" value="long-lines"> Long lines
+    </label>
+    <label for="q3-understaffed">
+      <input type="checkbox" id="q3-understaffed" name="q3" value="understaffed"> Not enough help
+    </label>
+    <label for="q3-new-staff">
+      <input type="checkbox" id="q3-new-staff" name="q3" value="new-staff"> New or inexperienced staff
+    </label>
+    <label for="q3-wrong-order">
+      <input type="checkbox" id="q3-wrong-order" name="q3" value="wrong-order"> Ingredients loaded in wrong order
+    </label>
+    <label for="q3-measuring">
+      <input type="checkbox" id="q3-measuring" name="q3" value="measuring-issues" data-correct="true"> Measuring devices that are prone to inaccuracy
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="correct" hidden>Congratulations. Among your answers, you picked the last item: "Measuring devices that are prone to inaccuracy." In fact, there are many easy steps you can take, like having the right type of measuring devices, to help your front-of-house staff produce consistent beverages.</p>
+      <p data-answer="other" hidden>There are many stress-inducing factors, like long lines and not enough help, that can undermine the ability of front-of-house staff to perform their jobs well. But measuring devices can also lead to inconsistent beverages.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="4" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 4</span>What type of ice do you use for your blended frozen drinks? Choose one.</legend>
+    <label for="q4-dice">
+      <input type="radio" id="q4-dice" name="q4" value="dice" data-feedback="larger-ice"> Dice
+    </label>
+    <label for="q4-half-dice">
+      <input type="radio" id="q4-half-dice" name="q4" value="half-dice" data-feedback="larger-ice"> Half-dice
+    </label>
+    <label for="q4-crescents">
+      <input type="radio" id="q4-crescents" name="q4" value="crescents" data-feedback="larger-ice"> Crescents
+    </label>
+    <label for="q4-pearls">
+      <input type="radio" id="q4-pearls" name="q4" value="pearls-nuggets" data-feedback="smaller-ice" data-correct="true"> Pearls or nuggets
+    </label>
+    <label for="q4-flake">
+      <input type="radio" id="q4-flake" name="q4" value="flake" data-feedback="smaller-ice" data-correct="true"> Flake ice
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="larger-ice" hidden>Larger types of ice are great for soft drinks, but when making blended beverages, smaller forms of ice have definite advantages — they pack well in a measuring container and produce more consistent blends.</p>
+      <p data-answer="smaller-ice" hidden>Good choice! Smaller types of ice are the best types of ice for blended beverages because they pack well in a measuring container and produce more consistent blends.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="5" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 5</span>Which style of refrigerator and freezer do you have in your restaurants?</legend>
+    <label for="q5-side">
+      <input type="radio" id="q5-side" name="q5" value="side"> Doors open to the side
+    </label>
+    <label for="q5-top">
+      <input type="radio" id="q5-top" name="q5" value="top" data-correct="true"> Doors open from the top (dipping cabinet)
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="side" hidden>Refrigerator and freezer doors that open to the side are fine for some purposes. Just make sure you keep a close eye on the holding temperatures for your ingredients. At busy times, when the doors are opened and closed a lot, cold air may spill out. Dipping cabinets — where the doors open from the top — are the better style for maintaining consistent temperatures.</p>
+      <p data-answer="top" hidden>Fantastic! You have the best style of refrigerator or freezer doors. Still make sure the holding temperatures for your ingredients are consistent with your supplier's recommendation.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="6" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 6</span>Do you use color-coded measuring devices at your restaurants?</legend>
+    <label for="q6-yes">
+      <input type="radio" id="q6-yes" name="q6" value="yes" data-correct="true"> Yes
+    </label>
+    <label for="q6-no">
+      <input type="radio" id="q6-no" name="q6" value="no"> No
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="yes" hidden>Very good! That's very smart of you. Color-coded measuring devices help when training new staff and may even help experienced staff when the restaurant gets very busy.</p>
+      <p data-answer="no" hidden>Many restaurants find that color-coded measuring devices help when training new staff and may even help experienced staff when the restaurant gets very busy.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="7" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 7</span>Do you have a blender with optimized programs?</legend>
+    <label for="q7-yes">
+      <input type="radio" id="q7-yes" name="q7" value="yes" data-correct="true"> Yes
+    </label>
+    <label for="q7-no">
+      <input type="radio" id="q7-no" name="q7" value="no"> No
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="yes" hidden>Excellent! Double points if it's The Quiet One<sup>®</sup> by Vitamix<sup>®</sup> Commercial because it produces perfectly consistent blends every time. The Quiet One has 34 optimized programs covering all types of beverages.</p>
+      <p data-answer="no" hidden>There is a tremendous advantage to having a blender with optimized programs. With The Quiet One<sup>®</sup> by Vitamix<sup>®</sup> Commercial, you get 34 optimized programs covering all types of beverages for perfectly consistent blends every time.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="8" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 8</span>Which shapes do you use at your restaurants when measuring solid ingredients?</legend>
+    <label for="q8-narrow">
+      <input type="radio" id="q8-narrow" name="q8" value="narrow" data-correct="true"> Narrow and deep containers
+    </label>
+    <label for="q8-wide">
+      <input type="radio" id="q8-wide" name="q8" value="wide" data-feedback="not-narrow"> Wide and shallow containers
+    </label>
+    <label for="q8-any">
+      <input type="radio" id="q8-any" name="q8" value="any" data-feedback="not-narrow"> Whichever containers are available
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="narrow" hidden>You're a pro. Yes, in general, narrow containers are better for measuring solid ingredients because any mounding over the brim is minimized.</p>
+      <p data-answer="not-narrow" hidden>Narrow containers are usually better for measuring solid ingredients because they minimize any mounding over the brim. A wide container allows for more mounding if someone is not being careful.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="9" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 9</span>True or False: It's important to load ingredients in the blender container in the right order.</legend>
+    <label for="q9-true">
+      <input type="radio" id="q9-true" name="q9" value="true" data-correct="true"> True
+    </label>
+    <label for="q9-false">
+      <input type="radio" id="q9-false" name="q9" value="false"> False
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="true" hidden>Congratulations! You are correct. It's very important to load liquids and softer ingredients first, then harder or solid ingredients. Loaded in this way, liquids will initiate the blend, while heavier ingredients on top will push the lighter ones down.</p>
+      <p data-answer="false" hidden>It's very important to load liquids and softer ingredients first, then harder or solid ingredients. Loaded in this way, liquids will initiate the blend, while heavier ingredients on top will push the lighter ones down.</p>
+    </div>
+  </fieldset>
+
+  <fieldset data-step="10" hidden tabindex="-1">
+    <legend><span class="eyebrow">Question 10</span>True or False: The beverage build station should be staged in a certain way — so the staff member is moving toward the motor base while adding ingredients.</legend>
+    <label for="q10-true">
+      <input type="radio" id="q10-true" name="q10" value="true" data-correct="true"> True
+    </label>
+    <label for="q10-false">
+      <input type="radio" id="q10-false" name="q10" value="false"> False
+    </label>
+    <div class="feedback" aria-live="polite">
+      <p data-answer="true" hidden>Congratulations! That's right. A carefully staged beverage build station ensures that ingredients are loaded in the right order and that there are no wasted motions.</p>
+      <p data-answer="false" hidden>A carefully staged beverage build station ensures that ingredients are loaded in the right order and that there are no wasted motions. Staging the station so the staff member moves toward the motor base while adding ingredients helps achieve this.</p>
+    </div>
+  </fieldset>
+
+</section>
+
+<section class="results">
+  <h2 tabindex="-1">You scored <span class="score">0</span> out of 10</h2>
+  <p data-score="10" hidden>Congratulations! That's a perfect score! Sounds like you are very well informed.</p>
+  <p data-score="9" hidden>Congratulations! You did very well!</p>
+  <p data-score="low" hidden>Thank you so much for taking our quiz! We hope you found it helpful.</p>
+  <p data-result="high-none" hidden>And, you're not seeing evidence of inconsistent beverages at your restaurant. That's good to hear. Still, given the pressures that front-of-house staff are under, you probably want to do everything you can to safeguard your beverage program.</p>
+  <p data-result="high-some" hidden>Because you're seeing at least some evidence of inconsistent beverages at your restaurant, you may want to take some additional steps to safeguard your beverage program.</p>
+  <p data-result="low-none" hidden>Even though you're not seeing evidence of inconsistent beverages at this time, it makes sense to do everything you can to safeguard your beverage program. Your front-of-house staff needs every possible advantage so they can do their best work, even when they are under stress or experiencing a rush.</p>
+  <p data-result="low-some" hidden>Based on your answers, it looks like you're seeing at least some evidence of inconsistent beverages. Fortunately, there are steps you can take to safeguard your beverage program.</p>
+  <p>Learn more about what steps to take for consistent beverages. All the points we mention in this quiz are covered in depth in our article "Four Causes of Inconsistent Beverages" by Steve Hosey, Blending Applications Manager at Vitamix Commercial.</p>
+  <p class="button-wrapper">
+    <a href="/us/en_us/articles/four-causes-of-beverage-inconsistency" class="button emphasis">Read the Article</a>
+  </p>
+</section>
+
+<div class="footer">
+  <progress max="10" value="0" aria-label="Quiz progress"></progress>
+  <div data-stage="intro">
+    <p>Estimated time: 5 minutes</p>
+    <button class="button accent">Start Quiz</button>
+  </div>
+  <div data-stage="quiz">
+    <p>Question: <span class="step-label">1</span> of 10</p>
+    <div class="button-wrapper">
+      <button class="button link prev" hidden>← Previous</button>
+      <button class="button emphasis next" disabled>Next</button>
+    </div>
+  </div>
+  <div data-stage="results">
+    <button type="reset" class="button link">← Retake Quiz</button>
+  </div>
+</div>

--- a/widgets/consistency-quiz/consistency-quiz.js
+++ b/widgets/consistency-quiz/consistency-quiz.js
@@ -1,0 +1,128 @@
+/**
+ * Reveals the feedback paragraph matching the current selection in a question fieldset.
+ * @param {HTMLFieldSetElement} fieldset - The active question fieldset
+ */
+function showFeedback(fieldset) {
+  fieldset.querySelectorAll('.feedback [data-answer]').forEach((f) => {
+    f.setAttribute('hidden', '');
+  });
+
+  if (fieldset.dataset.step === '3') {
+    const anyChecked = fieldset.querySelector('input:checked');
+    if (!anyChecked) return;
+    const hasMeasuring = fieldset.querySelector('[value="measuring-issues"]').checked;
+    const key = hasMeasuring ? 'correct' : 'other';
+    const fb = fieldset.querySelector(`[data-answer="${key}"]`);
+    if (fb) fb.removeAttribute('hidden');
+    return;
+  }
+
+  const checked = fieldset.querySelector('input:checked');
+  if (!checked) return;
+  const feedbackKey = checked.dataset.feedback || checked.value;
+  const fb = fieldset.querySelector(`[data-answer="${feedbackKey}"]`);
+  if (fb) fb.removeAttribute('hidden');
+}
+
+/**
+ * Switches to the results stage and reveals the appropriate score and outcome messaging.
+ * @param {HTMLElement} widget - The widget root element
+ * @param {number} score - Number of correct answers (0–10)
+ * @param {boolean} hasIncidents - True if Q1 or Q2 was answered "yes"
+ */
+function showResults(widget, score, hasIncidents) {
+  widget.dataset.stage = 'results';
+
+  const resultsEl = widget.querySelector('.results');
+  widget.querySelector('.score').textContent = score;
+
+  resultsEl.querySelectorAll('[data-score]').forEach((el) => el.setAttribute('hidden', ''));
+  const scoreKey = score >= 9 ? score : 'low';
+  const headlineEl = resultsEl.querySelector(`[data-score="${scoreKey}"]`);
+  if (headlineEl) headlineEl.removeAttribute('hidden');
+
+  resultsEl.querySelectorAll('[data-result]').forEach((el) => el.setAttribute('hidden', ''));
+  const scoreGroup = score >= 9 ? 'high' : 'low';
+  const incidentGroup = hasIncidents ? 'some' : 'none';
+  const resultEl = resultsEl.querySelector(`[data-result="${scoreGroup}-${incidentGroup}"]`);
+  if (resultEl) resultEl.removeAttribute('hidden');
+
+  const heading = resultsEl.querySelector('h2');
+  if (heading) heading.focus();
+}
+
+/**
+ * Tallies correct answers and incident flags, then delegates to showResults.
+ * @param {HTMLElement} widget - The widget root element
+ */
+function scoreQuiz(widget) {
+  const tally = widget.querySelectorAll('input[data-correct="true"]:checked').length;
+  const q1Yes = widget.querySelector('input[name="q1"][value="yes"]').checked;
+  const q2Yes = widget.querySelector('input[name="q2"][value="yes"]').checked;
+  showResults(widget, tally, q1Yes || q2Yes);
+}
+
+export default function decorate(widget) {
+  const progressEl = widget.querySelector('progress');
+  const stepLabelEl = widget.querySelector('.step-label');
+  const questions = widget.querySelectorAll('fieldset[data-step]');
+  const prevBtn = widget.querySelector('.prev');
+  const nextBtn = widget.querySelector('.next');
+
+  let currentStep = 0;
+
+  const updateNext = (fieldset) => {
+    nextBtn.disabled = !fieldset.querySelector('input:checked');
+  };
+
+  const showStep = (step) => {
+    questions.forEach((q) => q.setAttribute('hidden', ''));
+
+    const question = widget.querySelector(`fieldset[data-step="${step}"]`);
+    question.removeAttribute('hidden');
+    question.focus();
+
+    progressEl.value = step;
+    stepLabelEl.textContent = step;
+
+    prevBtn[step > 1 ? 'removeAttribute' : 'setAttribute']('hidden', '');
+
+    updateNext(question);
+    showFeedback(question);
+  };
+
+  const retake = () => {
+    widget.querySelectorAll('input').forEach((input) => {
+      input.checked = false;
+    });
+    progressEl.value = 0;
+    currentStep = 0;
+    widget.dataset.stage = 'intro';
+  };
+
+  widget.dataset.stage = 'intro';
+
+  widget.querySelector('.footer [data-stage="intro"] button').addEventListener('click', () => {
+    widget.dataset.stage = 'quiz';
+    currentStep = 1;
+    showStep(1);
+  });
+
+  nextBtn.addEventListener('click', () => {
+    if (currentStep === 10) { scoreQuiz(widget); return; }
+    showStep(currentStep += 1);
+  });
+
+  prevBtn.addEventListener('click', () => {
+    showStep(currentStep -= 1);
+  });
+
+  widget.querySelector('button[type="reset"]').addEventListener('click', retake);
+
+  widget.addEventListener('change', (e) => {
+    const question = e.target.closest('fieldset');
+    if (!question) return;
+    showFeedback(question);
+    updateNext(question);
+  });
+}

--- a/widgets/forms/wineandfood.css
+++ b/widgets/forms/wineandfood.css
@@ -1,0 +1,23 @@
+.forms-wineandfood form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-200);
+}
+
+.forms-wineandfood [data-required]::after {
+  content: '*';
+  margin-left: 0.5ch;
+  color: var(--color-red);
+}
+
+.forms-wineandfood .radio-group legend {
+  margin-bottom: 0.5em;
+}
+
+.forms-wineandfood .radio-option {
+  cursor: pointer;
+}
+
+.forms-wineandfood .wf-thank-you {
+  color: var(--color-asparagus);
+}

--- a/widgets/forms/wineandfood.html
+++ b/widgets/forms/wineandfood.html
@@ -1,0 +1,30 @@
+<form method="post" action="" aria-label="Wine and Food Giveaway">
+  <fieldset class="field radio-group">
+    <legend data-required></legend>
+    <div class="radio-options">
+      <label class="radio-option">
+        <input type="radio" name="vitamixfoodandwine" value="True" required aria-required="true">
+        <span class="radio-label"></span>
+      </label>
+      <label class="radio-option">
+        <input type="radio" name="vitamixfoodandwine" value="False">
+        <span class="radio-label"></span>
+      </label>
+    </div>
+  </fieldset>
+  <div class="field">
+    <label for="wf-dinner"></label>
+    <select id="wf-dinner" name="name_of_dinner"></select>
+  </div>
+  <div class="field">
+    <label for="wf-open-text"></label>
+    <input id="wf-open-text" type="text" name="open-text-question-fw" autocomplete="off">
+  </div>
+  <div class="field">
+    <label for="wf-email" data-required></label>
+    <input id="wf-email" type="email" name="food-and-wine-email" required aria-required="true" placeholder="" autocomplete="email">
+  </div>
+  <p class="button-wrapper">
+    <button type="submit" class="button emphasis"></button>
+  </p>
+</form>

--- a/widgets/forms/wineandfood.js
+++ b/widgets/forms/wineandfood.js
@@ -1,0 +1,100 @@
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
+
+/**
+ * Fetches form copy from the co-located JSON file.
+ * @returns {Promise<Object>} Parsed JSON with labels, dinners, and input placeholders.
+ */
+async function loadFormCopy() {
+  const scriptPath = new URL(import.meta.url).pathname;
+  const jsonPath = scriptPath.replace(/\.js$/, '.json');
+  const url = `${(window.hlx && window.hlx.codeBasePath) || ''}${jsonPath}`;
+  const resp = await fetch(url);
+  return resp.json();
+}
+
+/**
+ * Decorates the Wine and Food giveaway form widget with copy and submission handling.
+ * @param {HTMLElement} widget - Widget container element
+ */
+export default async function decorate(widget) {
+  const form = widget.querySelector('form');
+  if (!form) return;
+
+  const { locale, language } = getLocaleAndLanguage();
+  const copy = await loadFormCopy();
+  const labels = copy.labels || {};
+
+  const attendLegend = form.querySelector('.radio-group legend');
+  if (attendLegend) attendLegend.textContent = labels.attendance ?? 'Did you attend a Wine and Food Dinner?';
+
+  const [yesLabel, noLabel] = form.querySelectorAll('.radio-label');
+  if (yesLabel) yesLabel.textContent = labels.yes ?? 'Yes';
+  if (noLabel) noLabel.textContent = labels.no ?? 'No';
+
+  const dinnerLabel = form.querySelector('[for="wf-dinner"]');
+  if (dinnerLabel) dinnerLabel.textContent = labels.whichDinner ?? 'Which one?';
+
+  const dinnerSelect = form.querySelector('#wf-dinner');
+  if (dinnerSelect) {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = (copy.inputPlaceholders && copy.inputPlaceholders.dinner) || 'Select Event';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    dinnerSelect.append(placeholder);
+
+    if (Array.isArray(copy.dinners)) {
+      copy.dinners.forEach((dinnerName) => {
+        const option = document.createElement('option');
+        option.value = dinnerName;
+        option.textContent = dinnerName;
+        dinnerSelect.append(option);
+      });
+    }
+  }
+
+  const openTextLabel = form.querySelector('[for="wf-open-text"]');
+  if (openTextLabel) openTextLabel.textContent = labels.openText ?? 'What would you make in a Vitamix Blender?';
+
+  const emailLabel = form.querySelector('[for="wf-email"]');
+  if (emailLabel) emailLabel.textContent = labels.email ?? 'Enter your Email';
+
+  const emailInput = form.querySelector('#wf-email');
+  if (emailInput && copy.inputPlaceholders) emailInput.placeholder = copy.inputPlaceholders.email || '';
+
+  const submitBtn = form.querySelector('button[type="submit"]');
+  if (submitBtn) submitBtn.textContent = labels.submit ?? 'Sign up';
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const params = new URLSearchParams();
+
+    [...data.entries()].forEach(([key, val]) => params.append(key, val));
+    params.set('pageUrl', window.location.href);
+    params.set('lead_source', 'foodandwine');
+    params.set('actionUrl', `/${locale}/${language}/rest/V1/partners`);
+
+    [...form.elements].forEach((el) => { el.disabled = true; });
+    if (submitBtn) {
+      submitBtn.dataset.originalLabel = submitBtn.textContent;
+      submitBtn.textContent = labels.sending ?? 'Sending...';
+    }
+
+    try {
+      const resp = await fetch(`https://www.vitamix.com/bin/vitamix/partnerform?${params.toString()}`);
+      if (!resp.ok) throw new Error(`Form submission failed with ${resp.status}`);
+      const thankYou = document.createElement('p');
+      thankYou.className = 'wf-thank-you';
+      thankYou.textContent = labels.thankYou ?? 'Thank you for entering.';
+      form.replaceWith(thankYou);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Wine and Food form submission failed', err);
+      [...form.elements].forEach((el) => { el.disabled = false; });
+      if (submitBtn) {
+        submitBtn.textContent = submitBtn.dataset.originalLabel || (labels.submit ?? 'Sign up');
+      }
+    }
+  });
+}

--- a/widgets/forms/wineandfood.json
+++ b/widgets/forms/wineandfood.json
@@ -1,0 +1,24 @@
+{
+  "labels": {
+    "attendance": "Did you attend a Wine and Food Dinner?",
+    "yes": "Yes",
+    "no": "No",
+    "whichDinner": "Which one?",
+    "openText": "What would you make in a Vitamix Blender?",
+    "email": "Enter your Email",
+    "submit": "Sign up",
+    "sending": "Sending...",
+    "thankYou": "Thank you for entering."
+  },
+  "inputPlaceholders": {
+    "dinner": "Select Event",
+    "email": ""
+  },
+  "dinners": [
+    "Chef's Corner hosted by Amanda Freitag and Leah Cohen",
+    "Chef's Corner hosted by Maneet Chauhan",
+    "Chef's Corner hosted by Chef Mario Emilio Vitolo",
+    "Chef's Corner hosted by Robbie Felice",
+    "Chef's Corner with Rachael Ray"
+  ]
+}


### PR DESCRIPTION
ref #552 
uses `custom.originalPrice` for the "regular price" when value is present
depends on https://github.com/dylandepass/vitamix-catalog-sync/pull/29

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a3500
- After: https://recon-price--vitamix--aemsites.aem.network/us/en_us/products/certified-reconditioned-a3500

