### PR TITLE
feat(cart): add lazy cart item extensions

### DIFF
--- a/blocks/cart/cart.js
+++ b/blocks/cart/cart.js
@@ -2,7 +2,6 @@ import { loadCSS, createOptimizedPicture } from '../../scripts/aem.js';
 import cart from '../../scripts/cart.js';
 import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
 import buildCartItem from '../../scripts/commerce/cart-item.js';
-import buildWarrantySelector from './warranty-selector.js';
 import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
 
 const LOCAL_STRINGS = {
@@ -71,6 +70,23 @@ function getStrings(config) {
   return { ...config.getStrings(), ...(LOCAL_STRINGS[lang] || LOCAL_STRINGS['en-us']) };
 }
 
+async function loadCartItemExtensions(config) {
+  const configuredExtensions = config.cartItemExtensions || [];
+  const extensionModules = await Promise.all(
+    (config.cartItemExtensionModules || []).map((modulePath) => import(modulePath)),
+  );
+  return [
+    ...configuredExtensions,
+    ...extensionModules.map((module) => module.default).filter(Boolean),
+  ];
+}
+
+function buildCartItemExtensions(extensions, context) {
+  return extensions
+    .map((buildExtension) => buildExtension(context))
+    .filter((content) => content instanceof HTMLElement);
+}
+
 function buildTemplate(s) {
   return /* html */`
 <div class="cart">
@@ -99,6 +115,7 @@ export default async function decorate(block) {
   const config = getConfig();
   const s = getStrings(config);
   const currencyCode = typeof config.currency === 'function' ? config.currency(config.getLocale()) : config.currency;
+  const cartItemExtensions = await loadCartItemExtensions(config);
 
   block.innerHTML = buildTemplate(s);
   block.querySelector('.cart-checkout').href = config.getOrderPath('checkout');
@@ -148,48 +165,33 @@ export default async function decorate(block) {
           return;
         }
 
-        const linkedWarranty = cart.items
-          .find((i) => i.custom?.linkedTo === item.sku) || null;
-
-        // The minicart keeps the row compact — the warranty selector renders
-        // only in the full cart view.
-        const extraContent = isMinicart ? null : buildWarrantySelector(
-          item,
-          linkedWarranty,
-          (tier) => {
-            if (linkedWarranty) {
-              cart.removeItem(linkedWarranty.sku, linkedWarranty.custom?.linkedTo);
-            }
-            if (tier && !tier.isDefault && parseFloat(tier.price) > 0) {
-              cart.addItem({
-                sku: tier.sku,
-                path: tier.path,
-                quantity: item.quantity,
-                price: tier.price,
-                name: tier.name,
-                custom: {
-                  linkedTo: item.sku,
-                  ...(tier.coverageYears ? { coverageYears: tier.coverageYears } : {}),
-                },
-                local: { showInCart: false },
-              }, { allowSeparateEntry: true });
-            }
-          },
-          currencyCode,
-          { heading: s.warranty, included: s.included },
-        );
+        const extraContent = [
+          ...buildCartItemExtensions(cartItemExtensions, {
+            item,
+            items: cart.items,
+            cart,
+            isMinicart,
+            strings: s,
+            currencyCode,
+          }),
+        ].filter(Boolean);
 
         const itemEl = buildCartItem(
           item,
           {
             onQtyChange: (sku, qty) => {
               cart.updateItem(sku, qty);
-              if (linkedWarranty) cart.updateItem(linkedWarranty.sku, qty);
+              cart.items
+                .filter((i) => i.custom?.linkedTo === sku)
+                .forEach((linkedItem) => cart.updateItem(linkedItem.sku, qty));
             },
             onRemove: (sku) => {
-              if (linkedWarranty) {
-                cart.removeItem(linkedWarranty.sku, linkedWarranty.custom?.linkedTo);
-              }
+              cart.items
+                .filter((i) => i.custom?.linkedTo === sku)
+                .forEach((linkedItem) => cart.removeItem(
+                  linkedItem.sku,
+                  linkedItem.custom?.linkedTo,
+                ));
               cart.removeItem(sku);
             },
             currencyCode,

--- a/blocks/cart/warranty-selector-extension.js
+++ b/blocks/cart/warranty-selector-extension.js
@@ -1,0 +1,59 @@
+import buildWarrantySelector from './warranty-selector.js';
+
+/**
+ * Builds the site-specific warranty selector extension for a cart row.
+ *
+ * The generic cart block invokes this through CommerceConfig.cartItemExtensionModules;
+ * this module owns Vitamix warranty behavior, including hidden linked warranty
+ * line items.
+ *
+ * @param {{
+ *   item: Object,
+ *   items: Object[],
+ *   cart: Object,
+ *   isMinicart: boolean,
+ *   strings: Object,
+ *   currencyCode: string,
+ * }} context
+ * @returns {HTMLElement|null}
+ */
+export default function buildWarrantySelectorExtension({
+  item,
+  items,
+  cart,
+  isMinicart,
+  strings,
+  currencyCode,
+}) {
+  // The minicart keeps the row compact — the warranty selector renders only in
+  // the full cart view.
+  if (isMinicart) return null;
+
+  const linkedWarranty = items.find((i) => i.custom?.linkedTo === item.sku) || null;
+
+  return buildWarrantySelector(
+    item,
+    linkedWarranty,
+    (tier) => {
+      if (linkedWarranty) {
+        cart.removeItem(linkedWarranty.sku, linkedWarranty.custom?.linkedTo);
+      }
+      if (tier && !tier.isDefault && parseFloat(tier.price) > 0) {
+        cart.addItem({
+          sku: tier.sku,
+          path: tier.path,
+          quantity: item.quantity,
+          price: tier.price,
+          name: tier.name,
+          custom: {
+            linkedTo: item.sku,
+            ...(tier.coverageYears ? { coverageYears: tier.coverageYears } : {}),
+          },
+          local: { showInCart: false },
+        }, { allowSeparateEntry: true });
+      }
+    },
+    currencyCode,
+    { heading: strings.warranty, included: strings.included },
+  );
+}

--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -119,6 +119,16 @@ export function shippingDimensionsFromOffer(offer) {
   return { weight: { value: w.value, unit: w.unitText } };
 }
 
+function getCartCompatibility(parent) {
+  const { type, compatibleWith, compatibilityGroup } = parent.custom || {};
+  if (!compatibleWith && !compatibilityGroup) return null;
+  return {
+    ...(type ? { type } : {}),
+    ...(compatibleWith ? { compatibleWith } : {}),
+    ...(compatibilityGroup ? { compatibilityGroup } : {}),
+  };
+}
+
 /**
  * Checks if a variant is available for sale.
  * @param {Object} variant - The variant object
@@ -311,6 +321,7 @@ export default function renderAddToCart(ph, block, parent) {
           ...(parseFloat(opt.finalPrice ?? opt.price) === 0 ? { isDefault: true } : {}),
         }));
         const availableWarranties = warrantyOptions.length > 0 ? warrantyOptions : null;
+        const compatibility = getCartCompatibility(parent);
 
         // For simple products, `selectedVariant === parent` and shippingDetails
         // lives on the auto-generated single Offer; for variants it lives on
@@ -334,7 +345,12 @@ export default function renderAddToCart(ph, block, parent) {
           variant: window.selectedVariant?.options?.color || '',
           selectedOptions: semanticOptions,
           ...(parent.bundleItems ? { bundleItems: parent.bundleItems } : {}),
-          ...(availableWarranties ? { local: { availableWarranties } } : {}),
+          ...((availableWarranties || compatibility) ? {
+            local: {
+              ...(availableWarranties ? { availableWarranties } : {}),
+              ...(compatibility ? { compatibility } : {}),
+            },
+          } : {}),
           ...(shippingDimensions ? { shippingDimensions } : {}),
         };
         await cartApi.addItem(item);

--- a/scripts/cart-compatibility.css
+++ b/scripts/cart-compatibility.css
@@ -1,0 +1,9 @@
+.cart-item-compatibility-warning {
+  grid-column: 1 / -1;
+  margin: 4px 0 0;
+  padding: 8px 10px;
+  background: #f2e6e3;
+  color: #b00020;
+  font-size: var(--commerce-font-size-xs);
+  line-height: 1.4;
+}

--- a/scripts/cart-compatibility.js
+++ b/scripts/cart-compatibility.js
@@ -1,0 +1,81 @@
+import { loadCSS } from './aem.js';
+import { getConfig } from './commerce-config.js';
+
+loadCSS('/scripts/cart-compatibility.css');
+
+const STRINGS = {
+  'en-us': {
+    notCompatibleWith: 'This item is not compatible with the {products}',
+  },
+  'fr-ca': {
+    notCompatibleWith: 'Cet article n’est pas compatible avec {products}',
+  },
+};
+
+function getStrings() {
+  const config = getConfig();
+  const key = config.getLanguage().toLowerCase().replace('_', '-');
+  return STRINGS[key] || STRINGS['en-us'];
+}
+
+function getCompatibilityData(item) {
+  return item.local?.compatibility || item.custom || {};
+}
+
+function normalize(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function getAllowedLabels(compatibleWith) {
+  if (!Array.isArray(compatibleWith)) return new Set();
+  return new Set(
+    compatibleWith
+      .map((entry) => normalize(entry?.label ?? entry))
+      .filter(Boolean),
+  );
+}
+
+function getVisibleCartItems(items) {
+  return items.filter((item) => item.local?.showInCart !== false && !item.custom?.giftWithPurchase);
+}
+
+/**
+ * Builds an optional compatibility warning for a cart line item.
+ *
+ * This module is site-specific, but the cart consumes it through the generic
+ * CommerceConfig.cartItemExtensions hook. The generic cart/cart-item components
+ * do not know about Vitamix compatibility rules or Product Bus custom fields.
+ *
+ * @param {{ item: Object, items: Object[] }} context
+ * @returns {HTMLElement|null}
+ */
+export default function buildCartCompatibilityWarning({ item, items }) {
+  const compatibility = getCompatibilityData(item);
+
+  // Match Magento cart behavior: warnings render on non-configurable products
+  // that declare allowed compatibility groups.
+  if (compatibility.type === 'configurable') return null;
+
+  const allowedLabels = getAllowedLabels(compatibility.compatibleWith);
+  if (!allowedLabels.size) return null;
+
+  const incompatibleProducts = getVisibleCartItems(items)
+    .filter((other) => other !== item)
+    .filter((other) => getCompatibilityData(other).type === 'configurable')
+    .filter((other) => {
+      const group = normalize(getCompatibilityData(other).compatibilityGroup);
+      return group && !allowedLabels.has(group);
+    })
+    .map((other) => other.name)
+    .filter(Boolean);
+
+  if (!incompatibleProducts.length) return null;
+
+  const warning = document.createElement('p');
+  warning.className = 'cart-item-compatibility-warning';
+  warning.textContent = getStrings().notCompatibleWith.replace(
+    '{products}',
+    incompatibleProducts.join(', '),
+  );
+  return warning;
+}

--- a/scripts/commerce/cart-item.js
+++ b/scripts/commerce/cart-item.js
@@ -27,7 +27,7 @@ const TRASH_ICON = /* html */`<svg width="14" height="14" viewBox="0 0 24 24" fi
  *   onQtyChange: Function,
  *   onRemove: Function,
  *   currencyCode?: string,
- *   extraContent?: HTMLElement|null,
+ *   extraContent?: HTMLElement|HTMLElement[]|null,
  * }} callbacks
  * @param {{ remove?: string, removeItem?: string, maxQtyMessage?: string }} [strings]
  * @returns {HTMLElement}
@@ -170,9 +170,10 @@ export default function buildCartItem(item, {
 
   // Optional caller-provided content appended below the row (e.g. a
   // site-specific add-on selector). Spans the full row width via CSS.
-  if (extraContent instanceof HTMLElement) {
-    el.appendChild(extraContent);
-  }
+  const extraContentItems = Array.isArray(extraContent) ? extraContent : [extraContent];
+  extraContentItems
+    .filter((content) => content instanceof HTMLElement)
+    .forEach((content) => el.appendChild(content));
 
   return el;
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -44,6 +44,10 @@ const siteLocale = window.location.pathname.split('/').filter(Boolean)[0] || 'us
 window.CommerceConfig = {
   org: 'aemsites',
   site: 'vitamix',
+  cartItemExtensionModules: [
+    '/blocks/cart/warranty-selector-extension.js',
+    '/scripts/cart-compatibility.js',
+  ],
   paypal: {
     clientId: PAYPAL_CLIENT_IDS[siteLocale] ?? PAYPAL_CLIENT_IDS.us,
     intent: 'authorize',

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -590,7 +590,8 @@ test.describe('Edge Checkout', () => {
       await page.waitForLoadState('domcontentloaded');
 
       const caCart = await getCart(page, CART_KEY_CA);
-      expect(caCart.items).toHaveLength(1);
+      const visibleItems = caCart.items.filter((item) => !item.custom?.giftWithPurchase);
+      expect(visibleItems).toHaveLength(1);
       console.log('✓ FR-CA cart persists after page reload');
     });
   });

--- a/tests/unit/cart-compatibility.test.js
+++ b/tests/unit/cart-compatibility.test.js
@@ -1,0 +1,93 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import buildCartCompatibilityWarning from '../../scripts/cart-compatibility.js';
+
+beforeEach(() => {
+  globalThis.__resetTestState();
+  globalThis.HTMLElement = class HTMLElement {};
+  globalThis.document.createElement = (tagName) => ({
+    tagName,
+    className: '',
+    textContent: '',
+  });
+});
+
+test('buildCartCompatibilityWarning returns null when item is compatible with blender group', () => {
+  const accessory = {
+    name: 'Accessory',
+    local: {
+      compatibility: {
+        type: 'simple',
+        compatibleWith: [{ id: '453', label: 'Ascent & Venturist Series' }],
+      },
+    },
+  };
+  const blender = {
+    name: 'Ascent X2',
+    local: {
+      compatibility: {
+        type: 'configurable',
+        compatibilityGroup: 'Ascent & Venturist Series',
+      },
+    },
+  };
+
+  assert.equal(
+    buildCartCompatibilityWarning({ item: accessory, items: [accessory, blender] }),
+    null,
+  );
+});
+
+test('buildCartCompatibilityWarning renders incompatible blender names', () => {
+  const accessory = {
+    name: 'Accessory',
+    local: {
+      compatibility: {
+        type: 'simple',
+        compatibleWith: [{ id: '453', label: 'Ascent & Venturist Series' }],
+      },
+    },
+  };
+  const blender = {
+    name: 'Explorian Blender',
+    local: {
+      compatibility: {
+        type: 'configurable',
+        compatibilityGroup: 'Explorian Series',
+      },
+    },
+  };
+
+  const warning = buildCartCompatibilityWarning({ item: accessory, items: [accessory, blender] });
+
+  assert.ok(warning);
+  assert.equal(warning.className, 'cart-item-compatibility-warning');
+  assert.equal(warning.textContent, 'This item is not compatible with the Explorian Blender');
+});
+
+test('buildCartCompatibilityWarning does not render on configurable items', () => {
+  const blender = {
+    name: 'Ascent X2',
+    local: {
+      compatibility: {
+        type: 'configurable',
+        compatibleWith: [{ id: '453', label: 'Ascent & Venturist Series' }],
+        compatibilityGroup: 'Ascent & Venturist Series',
+      },
+    },
+  };
+  const otherBlender = {
+    name: 'Explorian Blender',
+    local: {
+      compatibility: {
+        type: 'configurable',
+        compatibilityGroup: 'Explorian Series',
+      },
+    },
+  };
+
+  assert.equal(
+    buildCartCompatibilityWarning({ item: blender, items: [blender, otherBlender] }),
+    null,
+  );
+});

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -35,7 +35,3 @@ export async function loggedFetch(...args) {
 }
 
 export const isProdHost = false;
-
-export function loggedFetch(...args) {
-  return fetch(...args);
-}

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -35,3 +35,7 @@ export async function loggedFetch(...args) {
 }
 
 export const isProdHost = false;
+
+export function loggedFetch(...args) {
+  return fetch(...args);
+}


### PR DESCRIPTION
Fixes #527

Move warranty and compatibility row behavior behind lazy-loaded cart item extensions so the generic cart stays reusable and site-specific logic only loads when cart UI renders. Adds compatibility extension.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://add-cart-compatibility-warning--vitamix--aemsites.aem.network/