### PR TITLE
test(checkout): cover address validation gates

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -1,3 +1,5 @@
+import { validateField } from './checkout-validation.js';
+
 const US_STATES = [
   ['AL', 'Alabama'], ['AK', 'Alaska'], ['AS', 'American Samoa'], ['AZ', 'Arizona'],
   ['AR', 'Arkansas'], ['AE', 'Armed Forces Africa'], ['AA', 'Armed Forces Americas'],
@@ -304,17 +306,24 @@ function formatSuggestedAddressLines(components) {
  * @returns {{ dialog: HTMLDialogElement, body: HTMLElement, setChosen: Function }}
  */
 function buildDialogShell({
-  iconSvg, eyebrow, heading, subtitle, onClose,
+  iconSvg, eyebrow, heading, subtitle, onClose, showClose = true, preventDismiss = false,
 }) {
   const dialog = document.createElement('dialog');
   dialog.className = 'address-validation-dialog';
+  dialog.addEventListener('cancel', (e) => {
+    e.preventDefault();
+    if (!preventDismiss) onClose?.();
+  });
 
-  const closeBtn = document.createElement('button');
-  closeBtn.type = 'button';
-  closeBtn.className = 'address-validation-close';
-  closeBtn.setAttribute('aria-label', 'Close');
-  closeBtn.innerHTML = ICON_CLOSE;
-  closeBtn.addEventListener('click', onClose);
+  if (showClose) {
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'address-validation-close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.innerHTML = ICON_CLOSE;
+    closeBtn.addEventListener('click', onClose);
+    dialog.append(closeBtn);
+  }
 
   const header = document.createElement('div');
   header.className = 'address-validation-header';
@@ -340,7 +349,7 @@ function buildDialogShell({
 
   titleGroup.append(eyebrowEl, headingEl, subtitleEl);
   header.append(icon, titleGroup);
-  dialog.append(closeBtn, header);
+  dialog.append(header);
 
   const body = document.createElement('div');
   body.className = 'address-validation-body';
@@ -393,7 +402,7 @@ function buildAddressCard({
  * Shows the CONFIRM dialog: side-by-side entered vs. suggested address with diff highlighting.
  *
  * @param {Object} opts
- * @returns {Promise<{ choice: 'accept'|'keep' }>}
+ * @returns {Promise<{ choice: 'accept'|'edit' }>}
  */
 function showConfirmModal({
   addressComponents, formattedAddress, formData, strings,
@@ -405,8 +414,10 @@ function showConfirmModal({
       iconSvg: ICON_PIN,
       eyebrow: strings.addressEyebrow || 'Address verification',
       heading: strings.addressHeading || 'We found a more accurate version',
-      subtitle: strings.addressSubtitle || 'Choose which address to use for shipping.',
-      onClose: () => { chosen = { choice: 'keep' }; dialog.close(); },
+      subtitle: strings.addressSubtitle || 'Use the suggested address or edit your address before continuing.',
+      onClose: () => { chosen = { choice: 'edit' }; dialog.close(); },
+      showClose: false,
+      preventDismiss: true,
     });
 
     const enteredLines = formatEnteredAddressLines(formData);
@@ -446,21 +457,21 @@ function showConfirmModal({
       dialog.close();
     });
 
-    const keepMine = document.createElement('button');
-    keepMine.type = 'button';
-    keepMine.className = 'button address-validation-secondary';
-    keepMine.textContent = strings.addressKeepMine || 'Keep my address';
-    keepMine.addEventListener('click', () => {
-      chosen = { choice: 'keep' };
+    const editAddress = document.createElement('button');
+    editAddress.type = 'button';
+    editAddress.className = 'button address-validation-secondary';
+    editAddress.textContent = strings.addressEdit || 'Edit address';
+    editAddress.addEventListener('click', () => {
+      chosen = { choice: 'edit' };
       dialog.close();
     });
 
-    actions.append(useSuggested, keepMine);
+    actions.append(useSuggested, editAddress);
     body.append(actions);
 
     // Register close listener before showModal so we never miss a close event.
     dialog.addEventListener('close', () => {
-      resolve(chosen ?? { choice: 'keep' });
+      resolve(chosen ?? { choice: 'edit' });
       dialog.remove();
     });
     // Remove any stale dialog (defensive — should never have more than one).
@@ -474,7 +485,7 @@ function showConfirmModal({
  * Shows the CONFIRM_ADD_SUBPREMISES dialog: address card plus unit number input.
  *
  * @param {Object} opts
- * @returns {Promise<{ choice: 'add-unit', unit: string } | { choice: 'keep' }>}
+ * @returns {Promise<{ choice: 'add-unit', unit: string } | { choice: 'edit' }>}
  */
 function showAddUnitModal({
   addressComponents, formattedAddress, formData, strings,
@@ -487,8 +498,10 @@ function showAddUnitModal({
       eyebrow: strings.addressUnitEyebrow || 'One more thing',
       heading: strings.addressUnitHeading || 'Add an apartment or unit number?',
       subtitle: strings.addressUnitSubtitle
-        || 'Your building has multiple units. Adding one helps couriers reach you on the first try.',
-      onClose: () => { chosen = { choice: 'keep' }; dialog.close(); },
+        || 'Your building has multiple units. Add a unit or edit your address before continuing.',
+      onClose: () => { chosen = { choice: 'edit' }; dialog.close(); },
+      showClose: false,
+      preventDismiss: true,
     });
 
     let displayLines;
@@ -548,16 +561,16 @@ function showAddUnitModal({
       dialog.close();
     });
 
-    const noUnit = document.createElement('button');
-    noUnit.type = 'button';
-    noUnit.className = 'button address-validation-secondary';
-    noUnit.textContent = strings.addressUnitNoUnit || "I don't have one — continue";
-    noUnit.addEventListener('click', () => {
-      chosen = { choice: 'keep' };
+    const editAddress = document.createElement('button');
+    editAddress.type = 'button';
+    editAddress.className = 'button address-validation-secondary';
+    editAddress.textContent = strings.addressEdit || 'Edit address';
+    editAddress.addEventListener('click', () => {
+      chosen = { choice: 'edit' };
       dialog.close();
     });
 
-    actions.append(addBtn, noUnit);
+    actions.append(addBtn, editAddress);
     body.append(actions);
 
     input.addEventListener('input', () => {
@@ -575,7 +588,7 @@ function showAddUnitModal({
 
     // Register close listener before showModal so we never miss a close event.
     dialog.addEventListener('close', () => {
-      resolve(chosen ?? { choice: 'keep' });
+      resolve(chosen ?? { choice: 'edit' });
       dialog.remove();
     });
     // Remove any stale dialog (defensive — should never have more than one).
@@ -588,32 +601,42 @@ function showAddUnitModal({
 
 /**
  * Validates the shipping address via the Commerce API and collapses the section on success.
- * Falls open (collapses without error) on network failures so checkout is never blocked.
+ * Checkout must not advance until this returns true.
  *
  * 1. Clear any existing inline error.
- * 2. Loop (up to MAX_ITERATIONS): build payload, call validate, handle the action.
- *    - ACCEPT / unknown → collapse and return.
- *    - FIX → show inline error and return (section stays expanded).
- *    - CONFIRM → side-by-side modal; 'accept' applies corrections then collapses;
- *      'keep' collapses without changes.
+ * 2. Ensure required address fields pass browser and custom field validation.
+ * 3. Loop (up to MAX_ITERATIONS): build payload, call validate, handle the action.
+ *    - ACCEPT → collapse and return true.
+ *    - FIX → show inline error and return false (section stays expanded).
+ *    - CONFIRM → side-by-side modal; 'accept' applies corrections and collapses;
+ *      'edit' returns false so the customer can correct the address.
  *    - CONFIRM_ADD_SUBPREMISES → unit-input modal. If the user adds a unit,
  *      write it to street-2 and continue the loop to re-validate with the unit
- *      included — Google explicitly doesn't issue a verdict for this case, so the
- *      corrected zip/city/state only appears on the second pass. If the user
- *      declines, just collapse.
+ *      included. If the user chooses edit, return false.
+ *    - Unknown action / validation failure → show inline error and return false.
  *
  * @param {HTMLElement} section
  * @param {Function} collapse
  * @param {Object} config
  * @param {Object} strings
  * @param {Function} [getToken] - returns the current Places session token string
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>}
  */
 export async function validateAndCollapseShipping(section, collapse, config, strings, getToken) {
   clearAddressError(section);
 
-  const form = section.closest('form');
-  if (!form) { collapse(); return; }
+  const form = section?.closest('form');
+  if (!form) return false;
+
+  const requiredFieldsValid = [...section.querySelectorAll('[required]')]
+    .every((el) => el.checkValidity() && !validateField(el));
+  if (!requiredFieldsValid) {
+    showAddressError(
+      section,
+      strings.addressCompleteRequired || 'Please complete and correct your shipping address before continuing.',
+    );
+    return false;
+  }
 
   const regionCode = config.getLocale() === 'ca' ? 'CA' : 'US';
   const MAX_ITERATIONS = 3;
@@ -622,22 +645,31 @@ export async function validateAndCollapseShipping(section, collapse, config, str
     const formData = new FormData(form);
     const payload = buildAddressPayload(formData, regionCode);
 
-    if (!payload.address.addressLines.length) { collapse(); return; }
+    if (!payload.address.addressLines.length) {
+      showAddressError(
+        section,
+        strings.addressCompleteRequired || 'Please complete and correct your shipping address before continuing.',
+      );
+      return false;
+    }
 
     let result;
     try {
       // eslint-disable-next-line no-await-in-loop
       result = await callValidateAddress(config.apiOrigin, payload, getToken?.() ?? null);
     } catch {
-      collapse();
-      return;
+      showAddressError(
+        section,
+        strings.addressValidationUnavailable || 'Unable to verify this address. Please check it and try again.',
+      );
+      return false;
     }
 
     const { action, addressComponents, formattedAddress } = result;
 
     if (!action || action === 'ACCEPT') {
       collapse();
-      return;
+      return true;
     }
 
     if (action === 'FIX') {
@@ -645,7 +677,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
         section,
         strings.addressInvalid || "We couldn't verify this address. Please check and try again.",
       );
-      return;
+      return false;
     }
 
     if (action === 'CONFIRM') {
@@ -653,14 +685,20 @@ export async function validateAndCollapseShipping(section, collapse, config, str
       const { choice } = await showConfirmModal({
         addressComponents, formattedAddress, formData, strings,
       });
-      if (choice === 'accept' && addressComponents) {
-        // Use [name$="street-0"] — the autocomplete attr is rewritten to "off"
-        // by initPlacesAutocomplete to suppress Chrome's autofill dropdown.
-        const addressInput = section.querySelector('[name$="street-0"]');
-        if (addressInput) fillAddressFields(section, addressInput, addressComponents);
+      if (choice !== 'accept') return false;
+      if (!addressComponents) {
+        showAddressError(
+          section,
+          strings.addressInvalid || "We couldn't verify this address. Please check and try again.",
+        );
+        return false;
       }
+      // Use [name$="street-0"] — the autocomplete attr is rewritten to "off"
+      // by initPlacesAutocomplete to suppress Chrome's autofill dropdown.
+      const addressInput = section.querySelector('[name$="street-0"]');
+      if (addressInput) fillAddressFields(section, addressInput, addressComponents);
       collapse();
-      return;
+      return true;
     }
 
     if (action === 'CONFIRM_ADD_SUBPREMISES') {
@@ -668,11 +706,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
       const result2 = await showAddUnitModal({
         addressComponents, formattedAddress, formData, strings,
       });
-      if (result2.choice !== 'add-unit' || !result2.unit) {
-        // User declined — accept the address as-is.
-        collapse();
-        return;
-      }
+      if (result2.choice !== 'add-unit' || !result2.unit) return false;
       // Write the unit and let the loop iterate to re-validate. Google explicitly
       // does NOT issue corrections for CONFIRM_ADD_SUBPREMISES (per spec), so any
       // zip or city fixes only appear on the next validate call with the unit
@@ -684,14 +718,19 @@ export async function validateAndCollapseShipping(section, collapse, config, str
         address2Input.dispatchEvent(new Event('change', { bubbles: true }));
       }
     } else {
-      // Unknown action — fail open
-      collapse();
-      return;
+      showAddressError(
+        section,
+        strings.addressInvalid || "We couldn't verify this address. Please check and try again.",
+      );
+      return false;
     }
   }
 
-  // Hit max iterations without resolving — just collapse.
-  collapse();
+  showAddressError(
+    section,
+    strings.addressInvalid || "We couldn't verify this address. Please check and try again.",
+  );
+  return false;
 }
 
 function initPlacesAutocomplete(section, config) {
@@ -791,7 +830,7 @@ function initPlacesAutocomplete(section, config) {
  * @param {Object} state
  * @param {Object} config
  * @param {Object} strings
- * @returns {{ validateAndCollapse: (collapse: Function) => Promise<void> }}
+ * @returns {{ validateAndCollapse: (collapse: Function) => Promise<boolean> }}
  */
 export function initAddress(form, state, config, strings) {
   const isCanada = config.getLocale() === 'ca';
@@ -811,7 +850,11 @@ export function initAddress(form, state, config, strings) {
   // (e.g. the unit-number write in CONFIRM_ADD_SUBPREMISES) must not clear it.
   if (shippingSection) {
     shippingSection.addEventListener('input', (e) => {
+      state.shippingAddressValidated = false;
       if (e.isTrusted) clearAddressError(shippingSection);
+    });
+    shippingSection.addEventListener('change', () => {
+      state.shippingAddressValidated = false;
     });
   }
 
@@ -824,12 +867,16 @@ export function initAddress(form, state, config, strings) {
   });
 
   return {
-    validateAndCollapse: (collapse) => validateAndCollapseShipping(
-      shippingSection,
-      collapse,
-      config,
-      strings,
-      shippingAutoComplete?.getSessionToken,
-    ),
+    validateAndCollapse: async (collapse) => {
+      const isValid = await validateAndCollapseShipping(
+        shippingSection,
+        collapse,
+        config,
+        strings,
+        shippingAutoComplete?.getSessionToken,
+      );
+      state.shippingAddressValidated = isValid;
+      return isValid;
+    },
   };
 }

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -181,12 +181,12 @@ function fillAddressFields(section, addressInput, addressComponents) {
  * @param {string} [regionCode] - ISO 3166-1 alpha-2 country code, e.g. 'US' or 'CA'
  * @returns {{ address: { addressLines: string[], regionCode?: string } }}
  */
-export function buildAddressPayload(formData, regionCode) {
-  const line1 = formData.get('shipping-street-0') || '';
-  const line2 = formData.get('shipping-street-1') || '';
-  const city = formData.get('shipping-city') || '';
-  const state = formData.get('shipping-state') || '';
-  const zip = formData.get('shipping-zip') || '';
+export function buildAddressPayload(formData, regionCode, prefix = 'shipping-') {
+  const line1 = formData.get(`${prefix}street-0`) || '';
+  const line2 = formData.get(`${prefix}street-1`) || '';
+  const city = formData.get(`${prefix}city`) || '';
+  const state = formData.get(`${prefix}state`) || '';
+  const zip = formData.get(`${prefix}zip`) || '';
 
   const streetLines = [line1, line2].filter(Boolean);
   const cityStateZip = [city, [state, zip].filter(Boolean).join(' ')].filter(Boolean).join(', ');
@@ -256,12 +256,12 @@ const ICON_CLOSE = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" s
  * @param {FormData} formData
  * @returns {string[]}
  */
-function formatEnteredAddressLines(formData) {
-  const line1 = (formData.get('shipping-street-0') || '').toString().trim();
-  const line2 = (formData.get('shipping-street-1') || '').toString().trim();
-  const city = (formData.get('shipping-city') || '').toString().trim();
-  const state = (formData.get('shipping-state') || '').toString().trim();
-  const zip = (formData.get('shipping-zip') || '').toString().trim();
+function formatEnteredAddressLines(formData, prefix = 'shipping-') {
+  const line1 = (formData.get(`${prefix}street-0`) || '').toString().trim();
+  const line2 = (formData.get(`${prefix}street-1`) || '').toString().trim();
+  const city = (formData.get(`${prefix}city`) || '').toString().trim();
+  const state = (formData.get(`${prefix}state`) || '').toString().trim();
+  const zip = (formData.get(`${prefix}zip`) || '').toString().trim();
   const cityStateZip = [city, [state, zip].filter(Boolean).join(' ')]
     .filter(Boolean).join(', ');
   return [line1, line2, cityStateZip].filter(Boolean);
@@ -405,7 +405,7 @@ function buildAddressCard({
  * @returns {Promise<{ choice: 'accept'|'edit' }>}
  */
 function showConfirmModal({
-  addressComponents, formattedAddress, formData, strings,
+  addressComponents, formattedAddress, formData, strings, prefix = 'shipping-',
 }) {
   return new Promise((resolve) => {
     let chosen = null;
@@ -420,7 +420,7 @@ function showConfirmModal({
       preventDismiss: true,
     });
 
-    const enteredLines = formatEnteredAddressLines(formData);
+    const enteredLines = formatEnteredAddressLines(formData, prefix);
     let suggestedLines;
     if (formattedAddress) {
       suggestedLines = splitFormattedAddress(formattedAddress);
@@ -488,7 +488,7 @@ function showConfirmModal({
  * @returns {Promise<{ choice: 'add-unit', unit: string } | { choice: 'edit' }>}
  */
 function showAddUnitModal({
-  addressComponents, formattedAddress, formData, strings,
+  addressComponents, formattedAddress, formData, strings, prefix = 'shipping-',
 }) {
   return new Promise((resolve) => {
     let chosen = null;
@@ -510,7 +510,7 @@ function showAddUnitModal({
     } else if (addressComponents) {
       displayLines = formatSuggestedAddressLines(addressComponents).filter((line) => !line.startsWith('Apt '));
     } else {
-      displayLines = formatEnteredAddressLines(formData);
+      displayLines = formatEnteredAddressLines(formData, prefix);
     }
 
     const addressCard = document.createElement('div');
@@ -622,7 +622,14 @@ function showAddUnitModal({
  * @param {Function} [getToken] - returns the current Places session token string
  * @returns {Promise<boolean>}
  */
-export async function validateAndCollapseShipping(section, collapse, config, strings, getToken) {
+export async function validateAndCollapseAddress(
+  section,
+  collapse,
+  config,
+  strings,
+  getToken,
+  prefix = 'shipping-',
+) {
   clearAddressError(section);
 
   const form = section?.closest('form');
@@ -643,7 +650,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
 
   for (let i = 0; i < MAX_ITERATIONS; i += 1) {
     const formData = new FormData(form);
-    const payload = buildAddressPayload(formData, regionCode);
+    const payload = buildAddressPayload(formData, regionCode, prefix);
 
     if (!payload.address.addressLines.length) {
       showAddressError(
@@ -683,7 +690,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
     if (action === 'CONFIRM') {
       // eslint-disable-next-line no-await-in-loop
       const { choice } = await showConfirmModal({
-        addressComponents, formattedAddress, formData, strings,
+        addressComponents, formattedAddress, formData, strings, prefix,
       });
       if (choice !== 'accept') return false;
       if (!addressComponents) {
@@ -704,7 +711,7 @@ export async function validateAndCollapseShipping(section, collapse, config, str
     if (action === 'CONFIRM_ADD_SUBPREMISES') {
       // eslint-disable-next-line no-await-in-loop
       const result2 = await showAddUnitModal({
-        addressComponents, formattedAddress, formData, strings,
+        addressComponents, formattedAddress, formData, strings, prefix,
       });
       if (result2.choice !== 'add-unit' || !result2.unit) return false;
       // Write the unit and let the loop iterate to re-validate. Google explicitly
@@ -732,6 +739,11 @@ export async function validateAndCollapseShipping(section, collapse, config, str
   );
   return false;
 }
+
+export const validateAndCollapseShipping = (...args) => validateAndCollapseAddress(
+  ...args,
+  'shipping-',
+);
 
 function initPlacesAutocomplete(section, config) {
   const addressInput = section.querySelector('[autocomplete="address-line1"]');
@@ -830,7 +842,8 @@ function initPlacesAutocomplete(section, config) {
  * @param {Object} state
  * @param {Object} config
  * @param {Object} strings
- * @returns {{ validateAndCollapse: (collapse: Function) => Promise<boolean> }}
+ * @returns {{ validateAndCollapse: (collapse: Function) => Promise<boolean>,
+ *   validateBillingAndCollapse: (collapse: Function) => Promise<boolean> }}
  */
 export function initAddress(form, state, config, strings) {
   const isCanada = config.getLocale() === 'ca';
@@ -843,7 +856,9 @@ export function initAddress(form, state, config, strings) {
   const shippingAutoComplete = shippingSection
     ? initPlacesAutocomplete(shippingSection, config)
     : null;
-  if (billingSection) initPlacesAutocomplete(billingSection, config);
+  const billingAutoComplete = billingSection
+    ? initPlacesAutocomplete(billingSection, config)
+    : null;
 
   // Clear the section-level address-validation error when the user edits any field.
   // Only fires for trusted (user-initiated) events — programmatic input dispatches
@@ -857,6 +872,20 @@ export function initAddress(form, state, config, strings) {
       state.shippingAddressValidated = false;
     });
   }
+  if (billingSection) {
+    billingSection.addEventListener('input', (e) => {
+      state.billingAddressValidated = false;
+      if (e.isTrusted) clearAddressError(billingSection);
+    });
+    billingSection.addEventListener('change', () => {
+      state.billingAddressValidated = false;
+    });
+  }
+  form.querySelectorAll('[name="billing-choice"]').forEach((radio) => {
+    radio.addEventListener('change', () => {
+      state.billingAddressValidated = false;
+    });
+  });
 
   // Invalidate estimate token when estimate-affecting fields change
   form.addEventListener('change', (e) => {
@@ -868,14 +897,32 @@ export function initAddress(form, state, config, strings) {
 
   return {
     validateAndCollapse: async (collapse) => {
-      const isValid = await validateAndCollapseShipping(
+      const isValid = await validateAndCollapseAddress(
         shippingSection,
         collapse,
         config,
         strings,
         shippingAutoComplete?.getSessionToken,
+        'shipping-',
       );
       state.shippingAddressValidated = isValid;
+      return isValid;
+    },
+    validateBillingAndCollapse: async (collapse) => {
+      const isDifferent = form.querySelector('[name="billing-choice"]:checked')?.value === 'different';
+      if (!isDifferent) {
+        state.billingAddressValidated = true;
+        return true;
+      }
+      const isValid = await validateAndCollapseAddress(
+        billingSection,
+        collapse,
+        config,
+        strings,
+        billingAutoComplete?.getSessionToken,
+        'billing-',
+      );
+      state.billingAddressValidated = isValid;
       return isValid;
     },
   };

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -466,7 +466,7 @@ function showConfirmModal({
       dialog.close();
     });
 
-    actions.append(useSuggested, editAddress);
+    actions.append(editAddress, useSuggested);
     body.append(actions);
 
     // Register close listener before showModal so we never miss a close event.

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -224,6 +224,11 @@ export function initOrder(form, cart, state, config, strings) {
       }
 
       if (!state.selectedShippingMethodId) {
+        const checkedShippingMethod = form.querySelector('[name="shippingMethod"]:checked')?.value;
+        if (checkedShippingMethod) state.selectedShippingMethodId = checkedShippingMethod;
+      }
+
+      if (!state.selectedShippingMethodId) {
         showError(form, strings.errorSelectShipping);
         return;
       }

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -211,6 +211,18 @@ export function initOrder(form, cart, state, config, strings) {
         }
       }
 
+      const useDifferentBilling = form.querySelector('[name="billing-choice"]:checked')?.value === 'different';
+      if (useDifferentBilling && !state.billingAddressValidated) {
+        const validBillingAddress = await state.ensureValidBillingAddress?.();
+        if (!validBillingAddress) {
+          showError(
+            form,
+            strings.addressCompleteRequired || 'Please complete and verify your billing address before continuing.',
+          );
+          return;
+        }
+      }
+
       if (!state.selectedShippingMethodId) {
         showError(form, strings.errorSelectShipping);
         return;

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -200,6 +200,17 @@ export function initOrder(form, cart, state, config, strings) {
 
       if (!validateForm(form)) return;
 
+      if (!state.shippingAddressValidated) {
+        const validShippingAddress = await state.ensureValidShippingAddress?.();
+        if (!validShippingAddress) {
+          showError(
+            form,
+            strings.addressCompleteRequired || 'Please complete and verify your shipping address before continuing.',
+          );
+          return;
+        }
+      }
+
       if (!state.selectedShippingMethodId) {
         showError(form, strings.errorSelectShipping);
         return;

--- a/blocks/checkout/checkout-session-state.js
+++ b/blocks/checkout/checkout-session-state.js
@@ -17,6 +17,10 @@ export function saveFormState(form, locale) {
     if (shippingSection) {
       data.shippingCollapsed = shippingSection.classList.contains('is-collapsed');
     }
+    const billingSection = form.querySelector('.billing-section');
+    if (billingSection) {
+      data.billingCollapsed = billingSection.classList.contains('is-collapsed');
+    }
     sessionStorage.setItem(formStateKey(locale), JSON.stringify(data));
   } catch { /* ignore quota / private-mode errors */ }
 }

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -1012,7 +1012,13 @@ button.checkout-submit-btn {
   max-width: 560px;
   width: calc(100% - 32px);
   box-shadow: 0 24px 64px rgb(0 0 0 / 18%);
-  position: relative;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+  max-height: calc(100dvh - 32px);
+  overflow: auto;
 }
 
 .address-validation-dialog::backdrop {

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -83,7 +83,7 @@ const LOCAL_STRINGS = {
     addressUnitPlaceholder: 'Apt 4B, Floor 12, Suite 200…',
     addressUnitContinue: 'Add unit & continue',
     addressInvalid: "We couldn't verify this address. Please check and try again.",
-    addressCompleteRequired: 'Please complete and verify your shipping address before continuing.',
+    addressCompleteRequired: 'Please complete and verify your address before continuing.',
     addressValidationUnavailable: 'Unable to verify this address. Please check it and try again.',
   },
   'fr-ca': {
@@ -151,7 +151,7 @@ const LOCAL_STRINGS = {
     addressUnitPlaceholder: 'App. 4B, étage 12, suite 200…',
     addressUnitContinue: 'Ajouter et continuer',
     addressInvalid: "Nous n'avons pas pu vérifier cette adresse. Veuillez vérifier et réessayer.",
-    addressCompleteRequired: 'Veuillez compléter et vérifier votre adresse de livraison avant de continuer.',
+    addressCompleteRequired: 'Veuillez compléter et vérifier votre adresse avant de continuer.',
     addressValidationUnavailable: 'Impossible de vérifier cette adresse. Veuillez la vérifier et réessayer.',
   },
 };
@@ -202,7 +202,9 @@ export default async function decorate(block) {
     currentEstimateToken: null,
     currentPreview: null,
     shippingAddressValidated: false,
+    billingAddressValidated: false,
     ensureValidShippingAddress: null,
+    ensureValidBillingAddress: null,
   };
 
   // Build form
@@ -262,7 +264,10 @@ export default async function decorate(block) {
   }
 
   // Wire address fields and billing toggle
-  const { validateAndCollapse } = initAddress(form, state, config, strings);
+  const {
+    validateAndCollapse,
+    validateBillingAndCollapse,
+  } = initAddress(form, state, config, strings);
 
   // Restore any previously entered form data (e.g. after browser back from payment page)
   restoreFormState(form, locale);
@@ -329,6 +334,47 @@ export default async function decorate(block) {
       }
     } catch { /* ignore */ }
   })();
+
+  // Section collapse — billing address
+  const billingSection = form.querySelector('.billing-section');
+  const { collapse: collapseBilling } = initCollapse(billingSection, {
+    getIsValid: () => {
+      const useDifferent = form.querySelector('[name="billing-choice"]:checked')?.value === 'different';
+      if (!useDifferent) return true;
+      const billingFields = billingSection.querySelector('.billing-fields-wrapper');
+      return [...billingFields.querySelectorAll('[required]')].every(
+        (el) => el.checkValidity() && !validateField(el),
+      );
+    },
+    getSummary: () => {
+      const useDifferent = form.querySelector('[name="billing-choice"]:checked')?.value === 'different';
+      if (!useDifferent) return strings.billingSame;
+      const data = new FormData(form);
+      const name = `${data.get('billing-firstname') || ''} ${data.get('billing-lastname') || ''}`.trim();
+      const city = data.get('billing-city') || '';
+      const stateCode = data.get('billing-state') || '';
+      const location = [city, stateCode].filter(Boolean).join(', ');
+      return [name, location].filter(Boolean).join(' · ');
+    },
+    autoCollapse: false,
+  }, strings);
+
+  let billingValidationPromise = null;
+  const runBillingValidation = () => {
+    if (billingValidationPromise) return billingValidationPromise;
+    billingValidationPromise = validateBillingAndCollapse(collapseBilling)
+      .finally(() => { billingValidationPromise = null; });
+    return billingValidationPromise;
+  };
+  state.ensureValidBillingAddress = runBillingValidation;
+
+  const billingFieldsWrapper = billingSection.querySelector('.billing-fields-wrapper');
+  billingFieldsWrapper?.addEventListener('focusout', async (e) => {
+    if (!e.relatedTarget) return;
+    if (billingFieldsWrapper.contains(e.relatedTarget)) return;
+    if (e.relatedTarget.closest?.('.checkout-submit-btn')) return;
+    await runBillingValidation();
+  });
 
   // Wire shipping rate fetching and preview
   const shippingContainer = form.querySelector('.shipping-methods');

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -70,20 +70,21 @@ const LOCAL_STRINGS = {
     processing: 'Processing…',
     addressEyebrow: 'Address verification',
     addressHeading: 'We found a more accurate version',
-    addressSubtitle: 'Choose which address to use for shipping.',
+    addressSubtitle: 'Use the suggested address or edit your address before continuing.',
     addressWhatEntered: 'What you entered',
     addressSuggestedBy: 'Suggested',
     addressRecommended: 'Recommended',
-    addressUseSuggested: 'Use suggested address',
-    addressKeepMine: 'Keep my address',
+    addressUseSuggested: 'Use this address',
+    addressEdit: 'Edit address',
     addressUnitEyebrow: 'One more thing',
     addressUnitHeading: 'Add an apartment or unit number?',
-    addressUnitSubtitle: 'Your building has multiple units. Adding one helps couriers reach you on the first try.',
+    addressUnitSubtitle: 'Your building has multiple units. Add a unit or edit your address before continuing.',
     addressUnitLabel: 'Apartment, suite, floor, or unit',
     addressUnitPlaceholder: 'Apt 4B, Floor 12, Suite 200…',
     addressUnitContinue: 'Add unit & continue',
-    addressUnitNoUnit: "I don't have one — continue",
     addressInvalid: "We couldn't verify this address. Please check and try again.",
+    addressCompleteRequired: 'Please complete and verify your shipping address before continuing.',
+    addressValidationUnavailable: 'Unable to verify this address. Please check it and try again.',
   },
   'fr-ca': {
     signIn: 'Se connecter pour un paiement plus rapide',
@@ -137,20 +138,21 @@ const LOCAL_STRINGS = {
     processing: 'Traitement en cours…',
     addressEyebrow: "Vérification d'adresse",
     addressHeading: 'Nous avons trouvé une version plus précise',
-    addressSubtitle: 'Choisissez quelle adresse utiliser pour la livraison.',
+    addressSubtitle: "Utilisez l'adresse suggérée ou modifiez votre adresse avant de continuer.",
     addressWhatEntered: 'Ce que vous avez saisi',
     addressSuggestedBy: 'Suggérée',
     addressRecommended: 'Recommandée',
-    addressUseSuggested: "Utiliser l'adresse suggérée",
-    addressKeepMine: 'Garder mon adresse',
+    addressUseSuggested: 'Utiliser cette adresse',
+    addressEdit: "Modifier l'adresse",
     addressUnitEyebrow: 'Encore une chose',
     addressUnitHeading: "Ajouter un numéro d'appartement ou de suite ?",
-    addressUnitSubtitle: 'Votre immeuble compte plusieurs unités. En ajouter une aide les livreurs à vous trouver du premier coup.',
+    addressUnitSubtitle: 'Votre immeuble compte plusieurs unités. Ajoutez une unité ou modifiez votre adresse avant de continuer.',
     addressUnitLabel: 'Appartement, suite, étage ou unité',
     addressUnitPlaceholder: 'App. 4B, étage 12, suite 200…',
     addressUnitContinue: 'Ajouter et continuer',
-    addressUnitNoUnit: "Je n'en ai pas — continuer",
     addressInvalid: "Nous n'avons pas pu vérifier cette adresse. Veuillez vérifier et réessayer.",
+    addressCompleteRequired: 'Veuillez compléter et vérifier votre adresse de livraison avant de continuer.',
+    addressValidationUnavailable: 'Impossible de vérifier cette adresse. Veuillez la vérifier et réessayer.',
   },
 };
 
@@ -199,6 +201,8 @@ export default async function decorate(block) {
     selectedShippingMethodId: null,
     currentEstimateToken: null,
     currentPreview: null,
+    shippingAddressValidated: false,
+    ensureValidShippingAddress: null,
   };
 
   // Build form
@@ -296,16 +300,18 @@ export default async function decorate(block) {
     autoCollapse: false,
   }, strings);
 
-  let validatingShipping = false;
+  let shippingValidationPromise = null;
+  const runShippingValidation = () => {
+    if (shippingValidationPromise) return shippingValidationPromise;
+    shippingValidationPromise = validateAndCollapse(collapseShipping)
+      .finally(() => { shippingValidationPromise = null; });
+    return shippingValidationPromise;
+  };
+  state.ensureValidShippingAddress = runShippingValidation;
+
   shippingAddrSection.addEventListener('focusout', async (e) => {
     if (shippingAddrSection.contains(e.relatedTarget)) return;
-    if (validatingShipping) return;
-    validatingShipping = true;
-    try {
-      await validateAndCollapse(collapseShipping);
-    } finally {
-      validatingShipping = false;
-    }
+    await runShippingValidation();
   });
 
   // Re-apply shipping section collapse state from session storage. When the user
@@ -315,7 +321,10 @@ export default async function decorate(block) {
   (() => {
     try {
       const saved = JSON.parse(sessionStorage.getItem(formStateKey(locale)));
-      if (saved?.shippingCollapsed) collapseShipping();
+      if (saved?.shippingCollapsed) {
+        state.shippingAddressValidated = true;
+        collapseShipping();
+      }
     } catch { /* ignore */ }
   })();
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -369,6 +369,18 @@ export default async function decorate(block) {
   };
   state.ensureValidBillingAddress = runBillingValidation;
 
+  // Re-apply billing section collapse state from session storage after the
+  // collapse controller exists, matching the shipping-address restore path.
+  (() => {
+    try {
+      const saved = JSON.parse(sessionStorage.getItem(formStateKey(locale)));
+      if (saved?.billingCollapsed) {
+        state.billingAddressValidated = true;
+        collapseBilling();
+      }
+    } catch { /* ignore */ }
+  })();
+
   const billingFieldsWrapper = billingSection.querySelector('.billing-fields-wrapper');
   billingFieldsWrapper?.addEventListener('focusout', async (e) => {
     await Promise.resolve();

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -315,9 +315,10 @@ export default async function decorate(block) {
   state.ensureValidShippingAddress = runShippingValidation;
 
   shippingAddrSection.addEventListener('focusout', async (e) => {
-    if (!e.relatedTarget) return;
-    if (shippingAddrSection.contains(e.relatedTarget)) return;
-    if (e.relatedTarget.closest?.('.checkout-submit-btn')) return;
+    await Promise.resolve();
+    const nextTarget = e.relatedTarget || document.activeElement;
+    if (shippingAddrSection.contains(nextTarget)) return;
+    if (nextTarget?.closest?.('.checkout-submit-btn')) return;
     await runShippingValidation();
   });
 
@@ -370,9 +371,10 @@ export default async function decorate(block) {
 
   const billingFieldsWrapper = billingSection.querySelector('.billing-fields-wrapper');
   billingFieldsWrapper?.addEventListener('focusout', async (e) => {
-    if (!e.relatedTarget) return;
-    if (billingFieldsWrapper.contains(e.relatedTarget)) return;
-    if (e.relatedTarget.closest?.('.checkout-submit-btn')) return;
+    await Promise.resolve();
+    const nextTarget = e.relatedTarget || document.activeElement;
+    if (billingFieldsWrapper.contains(nextTarget)) return;
+    if (nextTarget?.closest?.('.checkout-submit-btn')) return;
     await runBillingValidation();
   });
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -311,6 +311,7 @@ export default async function decorate(block) {
 
   shippingAddrSection.addEventListener('focusout', async (e) => {
     if (shippingAddrSection.contains(e.relatedTarget)) return;
+    if (e.relatedTarget?.closest?.('.checkout-submit-btn')) return;
     await runShippingValidation();
   });
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -310,8 +310,9 @@ export default async function decorate(block) {
   state.ensureValidShippingAddress = runShippingValidation;
 
   shippingAddrSection.addEventListener('focusout', async (e) => {
+    if (!e.relatedTarget) return;
     if (shippingAddrSection.contains(e.relatedTarget)) return;
-    if (e.relatedTarget?.closest?.('.checkout-submit-btn')) return;
+    if (e.relatedTarget.closest?.('.checkout-submit-btn')) return;
     await runShippingValidation();
   });
 

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -120,6 +120,13 @@ async function setupCheckoutMocks(page, overrides = {}) {
     contentType: 'application/json',
     body: JSON.stringify({ result: null }),
   }));
+  await page.route('**/places/validate*', overrides.validateAddress || (async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ action: 'ACCEPT' }),
+    });
+  }));
 
   // Shipping rates
   await page.route('**/estimate/shipping', overrides.shipping || (async (route) => {
@@ -549,6 +556,169 @@ test.describe('Edge Checkout Page', () => {
 
       await expect(page.locator('.order-summary-coupon-error')).toBeVisible({ timeout: 10000 });
       console.log('✓ Coupon error message shown for invalid coupon');
+    });
+  });
+
+  // ─── Address validation ───────────────────────────────────────────────────
+
+  test.describe('Address validation', () => {
+    const SUGGESTED_COMPONENTS = [
+      { longText: '124', shortText: '124', types: ['street_number'] },
+      { longText: 'Main Street', shortText: 'Main St', types: ['route'] },
+      { longText: 'San Francisco', shortText: 'San Francisco', types: ['locality'] },
+      { longText: 'California', shortText: 'CA', types: ['administrative_area_level_1'] },
+      { longText: '94103', shortText: '94103', types: ['postal_code'] },
+    ];
+
+    test('blocks payment when address validation returns FIX', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      let orderCreateCalled = false;
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ action: 'FIX' }),
+          });
+        },
+        createOrder: async (route) => {
+          orderCreateCalled = true;
+          await route.continue();
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+
+      await expect(page.locator('.address-validation-error')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('.address-validation-error')).toContainText("couldn't verify");
+      await expect(page.locator('.checkout-form > .checkout-error')).toBeVisible({ timeout: 10000 });
+      expect(orderCreateCalled).toBe(false);
+      expect(page.url()).toContain('/order/checkout');
+      console.log('✓ FIX address verdict blocks payment');
+    });
+
+    test('does not allow suggestion dialog dismissal to approve the address', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      let orderCreateCalled = false;
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              action: 'CONFIRM',
+              formattedAddress: '124 Main Street, San Francisco, CA 94103, USA',
+              addressComponents: SUGGESTED_COMPONENTS,
+            }),
+          });
+        },
+        createOrder: async (route) => {
+          orderCreateCalled = true;
+          await route.continue();
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+
+      const dialog = page.locator('.address-validation-dialog');
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+      await expect(dialog.locator('button', { hasText: 'Use this address' })).toBeVisible();
+      await expect(dialog.locator('button', { hasText: 'Edit address' })).toBeVisible();
+      await expect(dialog.locator('button', { hasText: 'Keep my address' })).toHaveCount(0);
+      await expect(dialog.locator('.address-validation-close')).toHaveCount(0);
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeVisible();
+      expect(orderCreateCalled).toBe(false);
+
+      await dialog.locator('button', { hasText: 'Edit address' }).click();
+      await expect(dialog).toHaveCount(0);
+      await expect(page.locator('.checkout-form > .checkout-error')).toBeVisible({ timeout: 10000 });
+      expect(orderCreateCalled).toBe(false);
+      expect(page.url()).toContain('/order/checkout');
+      console.log('✓ Suggestion dialog only allows approved address or edit');
+    });
+
+    test('uses the suggested address before continuing to payment', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      const requestLog = [];
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              action: 'CONFIRM',
+              formattedAddress: '124 Main Street, San Francisco, CA 94103, USA',
+              addressComponents: SUGGESTED_COMPONENTS,
+            }),
+          });
+        },
+        createOrder: async (route) => {
+          if (route.request().method() !== 'POST') { await route.continue(); return; }
+          requestLog.push({ url: '/orders', body: route.request().postDataJSON() });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              order: {
+                id: MOCK_ORDER_ID,
+                customer: {
+                  firstName: VALID_ADDRESS.firstName,
+                  lastName: VALID_ADDRESS.lastName,
+                  email: TEST_EMAIL,
+                },
+              },
+            }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+
+      await page.locator('.checkout-submit-btn').click();
+      const dialog = page.locator('.address-validation-dialog');
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+      await dialog.locator('button', { hasText: 'Use this address' }).click();
+
+      await expect.poll(
+        () => page.url(),
+        { timeout: 15000, message: 'Page did not navigate to /order/complete' },
+      ).toMatch(/\/order\/complete\?orderId=/);
+
+      const orderRequest = requestLog.find((r) => r.url === '/orders');
+      expect(orderRequest).toBeDefined();
+      expect(orderRequest.body.shipping.address1).toBe('124 Main Street');
+      expect(orderRequest.body.shipping.zip).toBe('94103');
+      console.log('✓ Suggested address is applied before payment');
     });
   });
 

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -35,6 +35,16 @@ const VALID_ADDRESS = {
   phone: '5551234567',
 };
 
+const BILLING_ADDRESS = {
+  firstName: 'Billing',
+  lastName: 'User',
+  street: '500 Market St',
+  city: 'San Francisco',
+  state: 'CA',
+  zip: '94105',
+  phone: '5559876543',
+};
+
 const MOCK_RATES = [
   {
     id: 'standard', label: 'Standard Shipping', rate: 5.99, eta: '3-5 business days',
@@ -251,6 +261,16 @@ async function fillShipping(page, address = VALID_ADDRESS) {
   await field(page, 'shipping-zip').fill(address.zip);
   await field(page, 'shipping-telephone').fill(address.phone);
   await field(page, 'shipping-state').selectOption(address.state);
+}
+
+async function fillBilling(page, address = VALID_ADDRESS) {
+  await field(page, 'billing-firstname').fill(address.firstName);
+  await field(page, 'billing-lastname').fill(address.lastName);
+  await field(page, 'billing-street-0').fill(address.street);
+  await field(page, 'billing-city').fill(address.city);
+  await field(page, 'billing-zip').fill(address.zip);
+  await field(page, 'billing-telephone').fill(address.phone);
+  await field(page, 'billing-state').selectOption(address.state);
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -605,6 +625,46 @@ test.describe('Edge Checkout Page', () => {
       expect(orderCreateCalled).toBe(false);
       expect(page.url()).toContain('/order/checkout');
       console.log('✓ FIX address verdict blocks payment');
+    });
+
+    test('blocks payment when different billing address validation returns FIX', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      let orderCreateCalled = false;
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          const body = route.request().postDataJSON();
+          const isBilling = body?.address?.addressLines?.[0] === BILLING_ADDRESS.street;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ action: isBilling ? 'FIX' : 'ACCEPT' }),
+          });
+        },
+        createOrder: async (route) => {
+          orderCreateCalled = true;
+          await route.continue();
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+      await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
+      await fillBilling(page, BILLING_ADDRESS);
+
+      await page.locator('.checkout-submit-btn').click();
+
+      await expect(page.locator('.billing-fields-wrapper .address-validation-error'))
+        .toBeVisible({ timeout: 10000 });
+      expect(orderCreateCalled).toBe(false);
+      expect(page.url()).toContain('/order/checkout');
+      console.log('✓ FIX billing address verdict blocks payment');
     });
 
     test('does not allow suggestion dialog dismissal to approve the address', async ({ page }) => {

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -590,6 +590,14 @@ test.describe('Edge Checkout Page', () => {
       { longText: '94103', shortText: '94103', types: ['postal_code'] },
     ];
 
+    const BILLING_SUGGESTED_COMPONENTS = [
+      { longText: '501', shortText: '501', types: ['street_number'] },
+      { longText: 'Market Street', shortText: 'Market St', types: ['route'] },
+      { longText: 'San Francisco', shortText: 'San Francisco', types: ['locality'] },
+      { longText: 'California', shortText: 'CA', types: ['administrative_area_level_1'] },
+      { longText: '94105', shortText: '94105', types: ['postal_code'] },
+    ];
+
     test('blocks payment when address validation returns FIX', async ({ page }) => {
       await seedCart(page, baseUrl);
 
@@ -665,6 +673,119 @@ test.describe('Edge Checkout Page', () => {
       expect(orderCreateCalled).toBe(false);
       expect(page.url()).toContain('/order/checkout');
       console.log('✓ FIX billing address verdict blocks payment');
+    });
+
+    test('uses suggested different billing address before continuing to payment', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      const requestLog = [];
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          const body = route.request().postDataJSON();
+          const isBilling = body?.address?.addressLines?.[0] === BILLING_ADDRESS.street;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(isBilling ? {
+              action: 'CONFIRM',
+              formattedAddress: '501 Market Street, San Francisco, CA 94105, USA',
+              addressComponents: BILLING_SUGGESTED_COMPONENTS,
+            } : { action: 'ACCEPT' }),
+          });
+        },
+        createOrder: async (route) => {
+          if (route.request().method() !== 'POST') { await route.continue(); return; }
+          requestLog.push({ url: '/orders', body: route.request().postDataJSON() });
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              order: {
+                id: MOCK_ORDER_ID,
+                customer: {
+                  firstName: VALID_ADDRESS.firstName,
+                  lastName: VALID_ADDRESS.lastName,
+                  email: TEST_EMAIL,
+                },
+              },
+            }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+      await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
+      await fillBilling(page, BILLING_ADDRESS);
+
+      await page.locator('.checkout-submit-btn').click();
+      const dialog = page.locator('.address-validation-dialog');
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+      await dialog.locator('button', { hasText: 'Use this address' }).click();
+
+      await expect.poll(
+        () => page.url(),
+        { timeout: 15000, message: 'Page did not navigate to /order/complete' },
+      ).toMatch(/\/order\/complete\?orderId=/);
+
+      const orderRequest = requestLog.find((r) => r.url === '/orders');
+      expect(orderRequest).toBeDefined();
+      expect(orderRequest.body.billing.address1).toBe('501 Market Street');
+      expect(orderRequest.body.billing.zip).toBe('94105');
+      console.log('✓ Suggested billing address is applied before payment');
+    });
+
+    test('billing validation does not trigger order preview recalculation', async ({ page }) => {
+      await seedCart(page, baseUrl);
+
+      let previewCount = 0;
+      await setupCheckoutMocks(page, {
+        validateAddress: async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ action: 'ACCEPT' }),
+          });
+        },
+        preview: async (route) => {
+          previewCount += 1;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(MOCK_PREVIEW),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await fillContact(page);
+      await fillShipping(page);
+      await page.waitForResponse(
+        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+      previewCount = 0;
+
+      await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
+      await fillBilling(page, BILLING_ADDRESS);
+      await field(page, 'billing-telephone').focus();
+      const billingValidate = page.waitForResponse(
+        (res) => res.url().includes('/places/validate') && res.request().method() === 'POST',
+        { timeout: 15000 },
+      );
+      await page.keyboard.press('Tab');
+      await billingValidate;
+      await page.waitForTimeout(500);
+
+      expect(previewCount).toBe(0);
+      console.log('✓ Billing validation does not recalculate order preview');
     });
 
     test('does not allow suggestion dialog dismissal to approve the address', async ({ page }) => {

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -628,8 +628,7 @@ test.describe('Edge Checkout Page', () => {
       await page.locator('.checkout-submit-btn').click();
 
       await expect(page.locator('.address-validation-error')).toBeVisible({ timeout: 10000 });
-      await expect(page.locator('.address-validation-error')).toContainText("couldn't verify");
-      await expect(page.locator('.checkout-form > .checkout-error')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('.checkout-form > .checkout-error')).toBeHidden();
       expect(orderCreateCalled).toBe(false);
       expect(page.url()).toContain('/order/checkout');
       console.log('✓ FIX address verdict blocks payment');

--- a/tests/unit/checkout-session-state.test.js
+++ b/tests/unit/checkout-session-state.test.js
@@ -49,10 +49,23 @@ function makeEl(opts) {
   return el;
 }
 
-function buildForm(fieldDefs) {
+function makeSection(collapsed = false) {
+  return {
+    classList: {
+      _set: new Set(collapsed ? ['is-collapsed'] : []),
+      contains(cls) { return this._set.has(cls); },
+    },
+  };
+}
+
+function buildForm(fieldDefs, opts = {}) {
   const elements = fieldDefs.map(makeEl);
+  const shippingSection = opts.shippingSection ? makeSection(opts.shippingCollapsed) : null;
+  const billingSection = opts.billingSection ? makeSection(opts.billingCollapsed) : null;
 
   function querySelector(selector) {
+    if (selector === '.shipping-address-section') return shippingSection;
+    if (selector === '.billing-section') return billingSection;
     const checkedMatch = selector.match(/\[name="([^"]+)"\]:checked/);
     if (checkedMatch) {
       const n = checkedMatch[1].replace(/\\/g, '');
@@ -134,6 +147,22 @@ describe('saveFormState', () => {
     const saved = JSON.parse(sessionStorage.getItem(FORM_STATE_KEY));
     assert.equal(Object.keys(saved).length, 1);
     assert.equal(saved.email, 'kept@example.com');
+  });
+
+  test('saves shipping and billing collapsed state', () => {
+    const form = buildForm(
+      [{ name: 'email', type: 'email', value: 'test@example.com' }],
+      {
+        shippingSection: true,
+        shippingCollapsed: true,
+        billingSection: true,
+        billingCollapsed: true,
+      },
+    );
+    saveFormState(form, LOCALE);
+    const saved = JSON.parse(sessionStorage.getItem(FORM_STATE_KEY));
+    assert.equal(saved.shippingCollapsed, true);
+    assert.equal(saved.billingCollapsed, true);
   });
 });
 


### PR DESCRIPTION
Add checkout flow coverage for invalid address verdicts and required suggested-address approval so regressions cannot reintroduce bypass paths.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://enforce-valid-checkout-address--vitamix--aemsites.aem.network/