### PR TITLE
fix(checkout): refresh shipping after quantity changes

### DIFF
--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -29,6 +29,8 @@ export function renderShippingMethods(container, rates, strings, currencyCode = 
     radio.type = 'radio';
     radio.name = 'shippingMethod';
     radio.value = rate.id;
+    if (rate.type) radio.dataset.shippingType = rate.type;
+    if (rate.label) radio.dataset.shippingLabel = rate.label;
     if (i === 0) radio.checked = true;
 
     const body = document.createElement('div');
@@ -56,6 +58,25 @@ export function renderShippingMethods(container, rates, strings, currencyCode = 
 
     container.appendChild(label);
   });
+}
+
+/**
+ * Finds the best shipping radio after rates have been re-rendered.
+ * Prefer the exact provider id, then the stable method type/label. Some
+ * providers issue quantity/weight-specific ids for the same shipping service.
+ *
+ * @param {HTMLFieldSetElement} container
+ * @param {{id?: string, type?: string, label?: string}} previousSelection
+ * @returns {HTMLInputElement|null}
+ */
+export function findShippingMethodRadio(container, previousSelection = {}) {
+  const { id, type, label } = previousSelection;
+  const radios = [...container.querySelectorAll('input[type="radio"]')];
+  return radios.find((radio) => id && radio.value === id)
+    || radios.find((radio) => type && radio.dataset.shippingType === type)
+    || radios.find((radio) => label && radio.dataset.shippingLabel === label)
+    || radios[0]
+    || null;
 }
 
 /**
@@ -149,13 +170,18 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
 
   try {
+    const previousRadio = shippingContainer.querySelector('input[name="shippingMethod"]:checked');
+    const previousSelection = {
+      id: state.selectedShippingMethodId,
+      type: previousRadio?.dataset.shippingType,
+      label: previousRadio?.dataset.shippingLabel,
+    };
+
     const result = await estimateShipping(country, stateCode, cart.getItemsForAPI(), couponCode);
     renderShippingMethods(shippingContainer, result.rates || [], strings, currencyCode);
 
     // Preserve the user's previous selection; fall back to the first method.
-    const previousId = state.selectedShippingMethodId;
-    const targetRadio = (previousId && shippingContainer.querySelector(`input[value="${previousId}"]`))
-      || shippingContainer.querySelector('input[type="radio"]');
+    const targetRadio = findShippingMethodRadio(shippingContainer, previousSelection);
     if (targetRadio) {
       targetRadio.checked = true;
       state.selectedShippingMethodId = targetRadio.value;

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -403,16 +403,16 @@ export default async function decorate(block) {
     refreshShipping();
   }
 
-  // When the cart changes mid-checkout, invalidate the stale estimate and
-  // re-run the preview so totals stay accurate. The empty-cart listener above
-  // handles the zero-items case via reload; this handles qty changes and
-  // partial removes while items remain.
+  // When the cart changes mid-checkout, invalidate stale estimates and
+  // re-fetch shipping rates before previewing. Some shipping providers issue
+  // quantity/weight-specific method ids, so reusing the previous id can make
+  // the preview request invalid after a quantity change.
   document.addEventListener('cart:change', () => {
     if (cart.itemCount === 0) return;
     state.currentEstimateToken = null;
     state.currentPreview = null;
     if (state.selectedShippingMethodId) {
-      updatePreview(form, cart, state, config);
+      refreshShipping();
     }
   });
 

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -466,6 +466,89 @@ test.describe('Edge Checkout Page', () => {
       console.log('✓ First shipping rate is auto-selected');
     });
 
+    test('re-estimates shipping and previews with the new method id after quantity changes', async ({ page }) => {
+      const shippingRequests = [];
+      const previewRequests = [];
+      const idByQty = { 2: '797', 3: '798' };
+
+      await seedCart(page, baseUrl);
+      await setupCheckoutMocks(page, {
+        shipping: async (route) => {
+          const body = route.request().postDataJSON();
+          shippingRequests.push(body);
+          const qty = body.items?.[0]?.quantity ?? 1;
+          const standardId = idByQty[qty] || '796';
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              rates: [
+                {
+                  id: standardId,
+                  label: 'Standard Shipping',
+                  type: 'standard',
+                  rate: '0.00',
+                },
+                {
+                  id: `priority-${qty}`,
+                  label: 'Priority Shipping',
+                  type: 'priority',
+                  rate: '19.99',
+                },
+              ],
+            }),
+          });
+        },
+        preview: async (route) => {
+          const body = route.request().postDataJSON();
+          previewRequests.push(body);
+          const qty = body.items?.[0]?.quantity ?? 1;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              ...MOCK_PREVIEW,
+              subtotal: qty * 549.99,
+              taxAmount: qty * 48.12,
+              shippingMethod: {
+                id: body.shippingMethod.id,
+                label: 'Standard Shipping',
+                type: 'standard',
+                rate: '0.00',
+              },
+              total: qty * 598.11,
+            }),
+          });
+        },
+      });
+      await gotoCheckout(page, baseUrl);
+      await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
+      await expandOrderSummary(page);
+
+      // Start from quantity 2, then select a shipping address. The first
+      // estimate/preview should use the qty-2 standard id.
+      await page.locator('.order-summary-items .qty-inc').first().click();
+      await fillShipping(page);
+      await expect(page.locator('.checkout-form [name="shippingMethod"][value="797"]')).toBeChecked({ timeout: 10000 });
+      await expect.poll(() => previewRequests.some(
+        (body) => body.items?.[0]?.quantity === 2 && body.shippingMethod?.id === '797',
+      )).toBe(true);
+
+      // Changing quantity invalidates the provider-specific shipping id. The
+      // checkout should re-fetch rates, preserve the Standard service by type,
+      // and preview with the new qty-3 id — never the stale qty-2 id.
+      await page.locator('.order-summary-items .qty-inc').first().click();
+      await expect(page.locator('.checkout-form [name="shippingMethod"][value="798"]')).toBeChecked({ timeout: 10000 });
+      await expect.poll(() => previewRequests.some(
+        (body) => body.items?.[0]?.quantity === 3 && body.shippingMethod?.id === '798',
+      )).toBe(true);
+      expect(previewRequests.some(
+        (body) => body.items?.[0]?.quantity === 3 && body.shippingMethod?.id === '797',
+      )).toBe(false);
+      expect(shippingRequests.some((body) => body.items?.[0]?.quantity === 3)).toBe(true);
+      console.log('✓ Quantity changes re-estimate shipping and preview with the new method id');
+    });
+
     test('shows an error / empty state when no rates are available', async ({ page }) => {
       await seedCart(page, baseUrl);
       await setupCheckoutMocks(page, {

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -390,8 +390,9 @@ test.describe('PDP Integration Tests', () => {
       const productUrl = buildProductUrl(productPath, currentBranch, { cart: 'magento' });
       await page.goto(productUrl);
 
-      // Wait for add to cart button
-      await waitForElement(page, '.quantity-container button');
+      // Wait for add to cart button. Bundle PDP data can take longer to hydrate
+      // on branch previews, especially while AEM cache is warming.
+      await waitForElement(page, '.quantity-container button', 30000);
 
       const addToCartButton = page.locator('.quantity-container button');
       await expect(addToCartButton).toContainText(/add to cart/i);

--- a/tests/unit/checkout-shipping.test.js
+++ b/tests/unit/checkout-shipping.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findShippingMethodRadio } from '../../blocks/checkout/checkout-shipping.js';
+
+function radio(value, type, label) {
+  return {
+    value,
+    dataset: {
+      ...(type ? { shippingType: type } : {}),
+      ...(label ? { shippingLabel: label } : {}),
+    },
+  };
+}
+
+function container(radios) {
+  return {
+    querySelectorAll(selector) {
+      assert.equal(selector, 'input[type="radio"]');
+      return radios;
+    },
+  };
+}
+
+test('findShippingMethodRadio prefers exact shipping method id', () => {
+  const standard = radio('219', 'standard', 'Standard Shipping');
+  const priority = radio('2275', 'priority', 'Priority Shipping');
+
+  const selected = findShippingMethodRadio(container([standard, priority]), {
+    id: '2275',
+    type: 'standard',
+    label: 'Standard Shipping',
+  });
+
+  assert.equal(selected, priority);
+});
+
+test('findShippingMethodRadio preserves selection by method type when provider id changes', () => {
+  const standard = radio('220', 'standard', 'Standard Shipping');
+  const priority = radio('2276', 'priority', 'Priority Shipping');
+
+  const selected = findShippingMethodRadio(container([standard, priority]), {
+    id: '2275',
+    type: 'priority',
+    label: 'Priority Shipping',
+  });
+
+  assert.equal(selected, priority);
+});
+
+test('findShippingMethodRadio falls back to label, then first method', () => {
+  const standard = radio('220', null, 'Standard Shipping');
+  const priority = radio('2276', null, 'Priority Shipping');
+
+  assert.equal(
+    findShippingMethodRadio(container([standard, priority]), { id: '218', label: 'Priority Shipping' }),
+    priority,
+  );
+  assert.equal(
+    findShippingMethodRadio(container([standard, priority]), { id: '218', label: 'Missing' }),
+    standard,
+  );
+  assert.equal(findShippingMethodRadio(container([]), { id: '218' }), null);
+});

--- a/tests/unit/mocks/commerce-config.mjs
+++ b/tests/unit/mocks/commerce-config.mjs
@@ -18,6 +18,10 @@ export function __resetConfig() {
   currencyOverride = undefined;
 }
 
+export function formatPrice(value, currency = 'USD') {
+  return `${currency} ${Number(value).toFixed(2)}`;
+}
+
 export function getConfig() {
   return {
     getLocale: () => 'us',


### PR DESCRIPTION
Re-fetch shipping rates before previewing when checkout cart quantities change so provider-specific method ids stay valid across weight bands. Preserve the selected service by stable type/label and cover the flow with unit and checkout regression tests.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-checkout-refresh-shipping-on-qty-change--vitamix--aemsites.aem.network/