### PR TITLE
fix(checkout): dedupe free shipping confirmation discounts

### DIFF
--- a/blocks/order-complete/order-complete.js
+++ b/blocks/order-complete/order-complete.js
@@ -1,6 +1,26 @@
 import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
 import { getOrder } from '../../scripts/commerce-api.js';
 
+export function normalizeTotalsDiscounts(discounts = []) {
+  return discounts.filter((discount) => Math.abs(parseFloat(discount?.amount)) > 0);
+}
+
+export function calculateConfirmationTotal({
+  subtotal = 0,
+  tax = 0,
+  shippingRate = 0,
+  discounts = [],
+} = {}) {
+  const hasFreeShipping = discounts.some((discount) => discount?.freeShipping);
+  const shippingAmount = hasFreeShipping ? 0 : (parseFloat(shippingRate) || 0);
+  const discountAmount = normalizeTotalsDiscounts(discounts).reduce(
+    (sum, discount) => sum + (Math.abs(parseFloat(discount.amount)) || 0),
+    0,
+  );
+
+  return Math.round(Math.max(0, subtotal - discountAmount + shippingAmount + tax) * 100) / 100;
+}
+
 /**
  * Order confirmation / cancellation page.
  *
@@ -209,15 +229,21 @@ export default async function decorate(block) {
   const totalsShippingMethod = est ? (est.shippingMethod || {}) : (preview?.shippingMethod || {});
   const totalsDiscounts = est ? (est.discounts || []) : (preview?.discounts || []);
   const totalsTax = parseFloat(est ? (est.tax?.amount || 0) : (preview?.taxAmount || 0));
-  const totalsTotal = parseFloat(est ? (order.payment?.amount || 0) : (preview?.total || 0));
+  const totalsTotal = calculateConfirmationTotal({
+    subtotal: totalsSubtotal,
+    tax: totalsTax,
+    shippingRate: totalsShippingMethod.rate,
+    discounts: totalsDiscounts,
+  });
 
   if (est || preview) {
     const totalsSection = document.createElement('div');
     totalsSection.className = 'order-totals';
 
     const shippingRate = totalsShippingMethod.rate;
-    const shippingDisplay = shippingRate === 0
-      ? s.free
+    const hasFreeShipping = totalsDiscounts.some((discount) => discount?.freeShipping);
+    const shippingDisplay = hasFreeShipping || shippingRate === 0
+      ? (s.free || 'Free')
       : formatPrice(parseFloat(shippingRate || 0), currencyCode);
 
     const rows = [
@@ -225,16 +251,12 @@ export default async function decorate(block) {
       [s.shipping, shippingDisplay],
     ];
 
-    if (totalsDiscounts.length) {
-      totalsDiscounts.forEach((discount) => {
-        const label = discount.name || s.discount;
-        const amount = discount.freeShipping
-          ? parseFloat(shippingRate || 0)
-          : Math.abs(parseFloat(discount.amount));
-        const value = formatPrice(-amount, currencyCode);
-        rows.push([label, value, 'order-totals-discount']);
-      });
-    }
+    normalizeTotalsDiscounts(totalsDiscounts).forEach((discount) => {
+      const label = discount.name || s.discount;
+      const amount = Math.abs(parseFloat(discount.amount));
+      const value = formatPrice(-amount, currencyCode);
+      rows.push([label, value, 'order-totals-discount']);
+    });
 
     rows.push([s.orderTax, formatPrice(totalsTax, currencyCode)]);
 

--- a/tests/unit/order-complete.test.js
+++ b/tests/unit/order-complete.test.js
@@ -1,0 +1,59 @@
+import { test, beforeEach, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calculateConfirmationTotal,
+  normalizeTotalsDiscounts,
+} from '../../blocks/order-complete/order-complete.js';
+
+beforeEach(() => {
+  globalThis.__resetTestState();
+});
+
+describe('calculateConfirmationTotal', () => {
+  test('subtracts coupon amount when the same discount also grants free shipping', () => {
+    assert.equal(calculateConfirmationTotal({
+      subtotal: 379.95,
+      tax: 33.72,
+      shippingRate: 9.95,
+      discounts: [{ name: '25% off total order + Free Shipping', amount: 94.99, freeShipping: true }],
+    }), 318.68);
+  });
+
+  test('includes paid shipping when no free-shipping discount applies', () => {
+    assert.equal(calculateConfirmationTotal({
+      subtotal: 100,
+      tax: 8,
+      shippingRate: 10,
+      discounts: [{ name: 'SAVE20', amount: 20 }],
+    }), 98);
+  });
+});
+
+describe('normalizeTotalsDiscounts', () => {
+  test('omits free-shipping-only discounts from discount rows', () => {
+    const discounts = [
+      { name: 'Free shipping coupon', freeShipping: true },
+      { name: 'Automatic free shipping', freeShipping: true },
+      { name: 'SAVE10', amount: 10 },
+    ];
+
+    assert.deepEqual(normalizeTotalsDiscounts(discounts), [discounts[2]]);
+  });
+
+  test('keeps coupon amount when the same discount also grants free shipping', () => {
+    const discounts = [
+      { name: '25% off total order + Free Shipping', amount: 94.99, freeShipping: true },
+    ];
+
+    assert.deepEqual(normalizeTotalsDiscounts(discounts), discounts);
+  });
+
+  test('keeps non-free-shipping discounts unchanged', () => {
+    const discounts = [
+      { name: 'SAVE10', amount: 10 },
+      { name: 'VIP', amount: 5 },
+    ];
+
+    assert.deepEqual(normalizeTotalsDiscounts(discounts), discounts);
+  });
+});


### PR DESCRIPTION
Fixes #579

Avoid showing stacked free-shipping benefits multiple times on the order confirmation page while preserving regular discount rows. This keeps the displayed discount rows aligned with the selected shipping rate.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-579-free-shipping-confirmation--vitamix--aemsites.aem.network/