### PR TITLE
fix(checkout): mark ID.me coupons as auto-applied

### DIFF
--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -243,6 +243,7 @@ export default async function decorate(block) {
 
   const updatePriceEstimate = async () => {
     const couponCode = sessionStorage.getItem('checkout_coupon_code') || '';
+    const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
     if (!couponCode || !cart.itemCount) {
       hideDiscountRow();
       updateTotals();
@@ -254,12 +255,18 @@ export default async function decorate(block) {
     showDiscountRow(couponCode);
 
     try {
-      const estimate = await estimatePrice(config.getLocale(), cart.getItemsForAPI(), couponCode);
+      const estimate = await estimatePrice(
+        config.getLocale(),
+        cart.getItemsForAPI(),
+        couponCode,
+        couponSource,
+      );
       if (requestId !== priceEstimateRequest) return;
       renderPriceEstimate(couponCode, estimate);
     } catch (err) {
       if (requestId !== priceEstimateRequest) return;
       sessionStorage.removeItem('checkout_coupon_code');
+      sessionStorage.removeItem('checkout_coupon_source');
       discountInput.value = '';
       hideDiscountRow();
       updateTotals();
@@ -272,6 +279,7 @@ export default async function decorate(block) {
 
   block.querySelector('.discount-remove').addEventListener('click', () => {
     sessionStorage.removeItem('checkout_coupon_code');
+    sessionStorage.removeItem('checkout_coupon_source');
     discountInput.value = '';
     couponErrorEl.hidden = true;
     hideDiscountRow();
@@ -279,18 +287,23 @@ export default async function decorate(block) {
   });
 
   const savedCoupon = sessionStorage.getItem('checkout_coupon_code') || '';
+  const savedCouponSource = sessionStorage.getItem('checkout_coupon_source') || '';
   if (savedCoupon) {
-    discountInput.value = savedCoupon;
+    if (savedCouponSource !== 'auto') discountInput.value = savedCoupon;
     showDiscountRow(savedCoupon);
     updatePriceEstimate();
   }
   discountApply.addEventListener('click', async () => {
     couponErrorEl.hidden = true;
     const code = discountInput.value.trim();
+    const existingCouponSource = sessionStorage.getItem('checkout_coupon_source') || '';
     if (!code) {
-      sessionStorage.removeItem('checkout_coupon_code');
-      hideDiscountRow();
-      updateTotals();
+      if (existingCouponSource !== 'auto') {
+        sessionStorage.removeItem('checkout_coupon_code');
+        sessionStorage.removeItem('checkout_coupon_source');
+        hideDiscountRow();
+        updateTotals();
+      }
       return;
     }
 
@@ -299,11 +312,15 @@ export default async function decorate(block) {
       const country = config.getLocale();
       const estimate = await estimatePrice(country, cart.getItemsForAPI(), code);
       sessionStorage.setItem('checkout_coupon_code', code);
+      sessionStorage.removeItem('checkout_coupon_source');
       renderPriceEstimate(code, estimate);
     } catch (err) {
-      sessionStorage.removeItem('checkout_coupon_code');
-      hideDiscountRow();
-      updateTotals();
+      if (existingCouponSource !== 'auto') {
+        sessionStorage.removeItem('checkout_coupon_code');
+        sessionStorage.removeItem('checkout_coupon_source');
+        hideDiscountRow();
+        updateTotals();
+      }
       couponErrorEl.textContent = getCouponErrorMessage(err?.errorHeader);
       couponErrorEl.hidden = false;
     } finally {
@@ -321,14 +338,20 @@ export default async function decorate(block) {
     strings: getStrings(),
     previewOrderDirect: async (body) => {
       const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
+      const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
       try {
-        const result = await previewOrder({ ...body, ...(couponCode ? { couponCode } : {}) });
+        const result = await previewOrder({
+          ...body,
+          ...(couponCode ? { couponCode } : {}),
+          ...(couponCode && couponSource ? { couponSource } : {}),
+        });
         if (result.estimateToken) state.currentEstimateToken = result.estimateToken;
         state.currentPreview = result;
         return result;
       } catch (err) {
         if (COUPON_ERRORS.has(err?.errorHeader)) {
           sessionStorage.removeItem('checkout_coupon_code');
+          sessionStorage.removeItem('checkout_coupon_source');
           discountInput.value = '';
           hideDiscountRow();
           couponErrorEl.textContent = getCouponErrorMessage(err.errorHeader);

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -71,7 +71,11 @@ export function buildOrderJSON(formData, form, cart, state, config) {
   }
 
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
-  if (couponCode) order.couponCode = couponCode;
+  const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
+  if (couponCode) {
+    order.couponCode = couponCode;
+    if (couponSource) order.couponSource = couponSource;
+  }
 
   order.locale = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
   order.country = locale;
@@ -155,7 +159,13 @@ export function initOrder(form, cart, state, config, strings) {
     getState: () => state,
     updatePreview: () => updatePreview(form, cart, state, config),
     previewOrderDirect: async (body) => {
-      const result = await previewOrder(body);
+      const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
+      const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
+      const result = await previewOrder({
+        ...body,
+        ...(couponCode && !body.couponCode ? { couponCode } : {}),
+        ...(couponCode && couponSource && !body.couponSource ? { couponSource } : {}),
+      });
       if (result.estimateToken) state.currentEstimateToken = result.estimateToken;
       state.currentPreview = result;
       return result;

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -119,7 +119,11 @@ export async function updatePreview(form, cart, state, config) {
   };
 
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
-  if (couponCode) orderBody.couponCode = couponCode;
+  const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
+  if (couponCode) {
+    orderBody.couponCode = couponCode;
+    if (couponSource) orderBody.couponSource = couponSource;
+  }
 
   if (email && firstName && lastName) {
     orderBody.customer = {
@@ -144,7 +148,10 @@ export async function updatePreview(form, cart, state, config) {
       'coupon_product_not_eligible', 'coupon_manual_entry_rejected', 'unauthorized',
     ]);
     const couponError = COUPON_ERRORS.has(err?.errorHeader) ? err.errorHeader : null;
-    if (couponError) sessionStorage.removeItem('checkout_coupon_code');
+    if (couponError) {
+      sessionStorage.removeItem('checkout_coupon_code');
+      sessionStorage.removeItem('checkout_coupon_source');
+    }
     document.dispatchEvent(new CustomEvent('checkout:preview', { detail: { preview: null, couponError } }));
   }
 }
@@ -168,6 +175,7 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
   const country = locale === 'ca' ? 'ca' : 'us';
 
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
+  const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
 
   try {
     const previousRadio = shippingContainer.querySelector('input[name="shippingMethod"]:checked');
@@ -177,7 +185,13 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
       label: previousRadio?.dataset.shippingLabel,
     };
 
-    const result = await estimateShipping(country, stateCode, cart.getItemsForAPI(), couponCode);
+    const result = await estimateShipping(
+      country,
+      stateCode,
+      cart.getItemsForAPI(),
+      couponCode,
+      couponSource,
+    );
     renderShippingMethods(shippingContainer, result.rates || [], strings, currencyCode);
 
     // Preserve the user's previous selection; fall back to the first method.

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -232,6 +232,7 @@ export default async function decorate(block) {
 
   const removeCoupon = () => {
     sessionStorage.removeItem('checkout_coupon_code');
+    sessionStorage.removeItem('checkout_coupon_source');
     discountInput.value = '';
     discountsEl.innerHTML = '';
     discountsEl.hidden = true;
@@ -310,6 +311,7 @@ export default async function decorate(block) {
 
   const updatePriceEstimate = async () => {
     const couponCode = sessionStorage.getItem('checkout_coupon_code') || '';
+    const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
     if (!couponCode || !cart.itemCount) {
       discountsEl.innerHTML = '';
       discountsEl.hidden = true;
@@ -325,6 +327,7 @@ export default async function decorate(block) {
         getLocaleAndLanguage().locale,
         cart.getItemsForAPI(),
         couponCode,
+        couponSource,
       );
       if (requestId !== priceEstimateRequest) return;
       renderPriceEstimate(estimate);
@@ -334,18 +337,23 @@ export default async function decorate(block) {
   };
 
   const savedCoupon = sessionStorage.getItem('checkout_coupon_code') || '';
+  const savedCouponSource = sessionStorage.getItem('checkout_coupon_source') || '';
   if (savedCoupon) {
-    discountInput.value = savedCoupon;
+    if (savedCouponSource !== 'auto') discountInput.value = savedCoupon;
     showPendingDiscount(savedCoupon);
   }
 
   discountApply.addEventListener('click', async () => {
     couponErrorEl.hidden = true;
     const code = discountInput.value.trim();
+    const existingCouponSource = sessionStorage.getItem('checkout_coupon_source') || '';
     if (!code) {
-      sessionStorage.removeItem('checkout_coupon_code');
-      discountsEl.innerHTML = '';
-      discountsEl.hidden = true;
+      if (existingCouponSource !== 'auto') {
+        sessionStorage.removeItem('checkout_coupon_code');
+        sessionStorage.removeItem('checkout_coupon_source');
+        discountsEl.innerHTML = '';
+        discountsEl.hidden = true;
+      }
       return;
     }
 
@@ -354,6 +362,7 @@ export default async function decorate(block) {
       const country = getLocaleAndLanguage().locale;
       const estimate = await estimatePrice(country, cart.getItemsForAPI(), code);
       sessionStorage.setItem('checkout_coupon_code', code);
+      sessionStorage.removeItem('checkout_coupon_source');
       renderPriceEstimate(estimate);
       document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
     } catch (err) {
@@ -464,6 +473,7 @@ export default async function decorate(block) {
     hasOrderPreview = Boolean(preview);
 
     if (couponError) {
+      sessionStorage.removeItem('checkout_coupon_source');
       discountsEl.innerHTML = '';
       discountInput.value = '';
       couponErrorEl.textContent = getCouponErrorMessage(couponError);

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -63,15 +63,17 @@ async function post(path, body, recaptchaAction) {
  * @param {Array<{sku: string, path: string, quantity: number, price: Object}>} items
  *   Cart items in API format
  * @param {string} [couponCode] - coupon code; free-shipping discounts apply when provided
+ * @param {string} [couponSource] - coupon source, for verified/auto-applied coupons
  * @returns {Promise<{ rates: Array<{ id: string, label: string, rate: string }> }>}
  * @throws {CommerceApiError}
  */
-export async function estimateShipping(country, state, items, couponCode) {
+export async function estimateShipping(country, state, items, couponCode, couponSource) {
   return post('/estimate/shipping', {
     country,
     shipping: { country, state },
     items,
     ...(couponCode ? { couponCode } : {}),
+    ...(couponCode && couponSource ? { couponSource } : {}),
   });
 }
 
@@ -83,12 +85,16 @@ export async function estimateShipping(country, state, items, couponCode) {
  * @param {string} country - ISO 3166-1 alpha-2 country code (e.g. 'us', 'ca')
  * @param {Array} items - Cart items in API format
  * @param {string} couponCode - The coupon code to validate
+ * @param {string} [couponSource] - coupon source, for verified/auto-applied coupons
  * @returns {Promise<{ subtotal: number, discounts: Array, orderDiscountTotal: number }>}
  * @throws {CommerceApiError}
  */
-export async function estimatePrice(country, items, couponCode) {
+export async function estimatePrice(country, items, couponCode, couponSource) {
   return post('/estimate/price', {
-    country, items, couponCode,
+    country,
+    items,
+    couponCode,
+    ...(couponCode && couponSource ? { couponSource } : {}),
   });
 }
 

--- a/scripts/commerce/idme.js
+++ b/scripts/commerce/idme.js
@@ -24,13 +24,12 @@ function buildIDMeAuthUrl(callbackUrl) {
 }
 
 /**
- * Reads ?idme_coupon= from the current URL, populates the discount input,
- * fires checkout:coupon-apply, and cleans the param from the address bar.
- * Returns the coupon code if found, otherwise null.
- * @param {HTMLInputElement} discountInput
+ * Reads ?idme_coupon= from the current URL, stores it as an auto-applied
+ * coupon, fires checkout:coupon-apply, and cleans the param from the address
+ * bar. Returns the coupon code if found, otherwise null.
  * @returns {string|null}
  */
-export function handleIDMeReturn(discountInput) {
+export function handleIDMeReturn() {
   const params = new URLSearchParams(window.location.search);
   const coupon = params.get('idme_coupon');
   if (!coupon) return null;
@@ -38,8 +37,8 @@ export function handleIDMeReturn(discountInput) {
   params.delete('idme_error');
   const qs = params.size ? `?${params}` : '';
   window.history.replaceState(null, '', window.location.pathname + qs);
-  discountInput.value = coupon;
   sessionStorage.setItem('checkout_coupon_code', coupon);
+  sessionStorage.setItem('checkout_coupon_source', 'auto');
   document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
   return coupon;
 }
@@ -51,10 +50,9 @@ export function handleIDMeReturn(discountInput) {
  * Returns the coupon code if the page was loaded after an ID.me redirect,
  * otherwise null.
  * @param {HTMLElement} insertAfterEl
- * @param {HTMLInputElement} discountInput
  * @returns {string|null}
  */
-export function initIDMe(insertAfterEl, discountInput) {
+export function initIDMe(insertAfterEl) {
   // only allow overrides via localStorage on non-prod hosts
   let redirectOrigin = window.location.origin;
   if (!isProd) {
@@ -94,5 +92,5 @@ export function initIDMe(insertAfterEl, discountInput) {
   }
 
   insertAfterEl.insertAdjacentElement('afterend', outer);
-  return handleIDMeReturn(discountInput);
+  return handleIDMeReturn();
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -229,6 +229,7 @@ function setAffiliateCoupon() {
 
   if (COUPON) {
     sessionStorage.setItem('checkout_coupon_code', COUPON);
+    sessionStorage.removeItem('checkout_coupon_source');
 
     // TODO: remove once all locales migrate off Magento — applies the coupon to the PHP cart
     const { locale, language } = getLocaleAndLanguage();

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -6,7 +6,7 @@
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getOrder, estimateShipping } from '../../scripts/commerce-api.js';
+import { getOrder, estimateShipping, estimatePrice } from '../../scripts/commerce-api.js';
 
 const API_ORIGIN = 'https://api.test.com/test-org/sites/test-site';
 
@@ -140,6 +140,14 @@ test('estimateShipping: includes couponCode in request body when provided', asyn
   assert.equal(body.couponCode, 'FREESHIP');
 });
 
+test('estimateShipping: includes couponSource when provided with couponCode', async () => {
+  mockFetch(200, { rates: [] });
+  await estimateShipping('us', 'CA', [], 'IDME10', 'auto');
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.couponCode, 'IDME10');
+  assert.equal(body.couponSource, 'auto');
+});
+
 test('estimateShipping: sends correct country, shipping, and items', async () => {
   const items = [{ sku: 'abc', quantity: 1, price: { final: '50.00' } }];
   mockFetch(200, { rates: [] });
@@ -158,4 +166,13 @@ test('estimateShipping: returns rates array from response', async () => {
   mockFetch(200, { rates });
   const result = await estimateShipping('us', 'NY', []);
   assert.deepEqual(result.rates, rates);
+});
+
+test('estimatePrice: includes couponSource when provided with couponCode', async () => {
+  mockFetch(200, { discounts: [], orderDiscountTotal: 0 });
+  await estimatePrice('us', [], 'IDME10', 'auto');
+  const body = JSON.parse(lastInit.body);
+  assert.equal(lastUrl, `${API_ORIGIN}/estimate/price`);
+  assert.equal(body.couponCode, 'IDME10');
+  assert.equal(body.couponSource, 'auto');
 });


### PR DESCRIPTION
Fixes #570

ID.me coupon codes arrive from a verified redirect, not manual promo entry, so send couponSource=auto through estimate and checkout requests. Clear the source whenever a customer enters or removes a manual coupon so ID.me manual-entry protection remains intact.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-idme-coupon-source--vitamix--aemsites.aem.network/