### PR TITLE
fix(checkout): open ID.me verification in popup

### DIFF
--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -297,6 +297,11 @@ dialog.paypal-not-configured-dialog::backdrop {
   margin-bottom: var(--commerce-card-padding);
   padding-bottom: var(--commerce-card-padding);
   border-bottom: 1px solid var(--commerce-color-border);
+  text-align: left;
+}
+
+.cart-summary .idme-verify .idme-trigger-link {
+  width: fit-content;
 }
 
 /* Remove bottom border from promo section when ID.me follows it */

--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -8,7 +8,7 @@ import applePay from '../../scripts/payments/apple-pay.js';
 import googlePay from '../../scripts/payments/google-pay.js';
 import paypal from '../../scripts/payments/paypal.js';
 import { getActiveProviders } from '../checkout/checkout-payment.js';
-import { initIDMe } from '../../scripts/commerce/idme.js';
+import { initIDMe, syncIDMeVisibility } from '../../scripts/commerce/idme.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 const ALL_PROVIDERS = [applePay, googlePay, paypal];
@@ -272,10 +272,15 @@ export default async function decorate(block) {
       updateTotals();
       couponErrorEl.textContent = getCouponErrorMessage(err?.errorHeader);
       couponErrorEl.hidden = false;
+      document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
     }
   };
 
   document.addEventListener('cart:change', updatePriceEstimate);
+  document.addEventListener('checkout:coupon-apply', () => {
+    syncIDMeVisibility();
+    updatePriceEstimate();
+  });
 
   block.querySelector('.discount-remove').addEventListener('click', () => {
     sessionStorage.removeItem('checkout_coupon_code');
@@ -284,6 +289,7 @@ export default async function decorate(block) {
     couponErrorEl.hidden = true;
     hideDiscountRow();
     updateTotals();
+    document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
   });
 
   const savedCoupon = sessionStorage.getItem('checkout_coupon_code') || '';
@@ -313,6 +319,7 @@ export default async function decorate(block) {
       const estimate = await estimatePrice(country, cart.getItemsForAPI(), code);
       sessionStorage.setItem('checkout_coupon_code', code);
       sessionStorage.removeItem('checkout_coupon_source');
+      syncIDMeVisibility();
       renderPriceEstimate(code, estimate);
     } catch (err) {
       if (existingCouponSource !== 'auto') {
@@ -356,6 +363,7 @@ export default async function decorate(block) {
           hideDiscountRow();
           couponErrorEl.textContent = getCouponErrorMessage(err.errorHeader);
           couponErrorEl.hidden = false;
+          document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
         }
         throw err;
       }
@@ -395,7 +403,7 @@ export default async function decorate(block) {
 
   if (getLocaleAndLanguage().locale === 'us') {
     const promoEl = block.querySelector('.cart-summary-promo');
-    const returnedCoupon = initIDMe(promoEl, discountInput);
+    const returnedCoupon = initIDMe(promoEl);
     if (returnedCoupon) {
       showDiscountRow(returnedCoupon);
       updatePriceEstimate();

--- a/blocks/order-summary/order-summary.css
+++ b/blocks/order-summary/order-summary.css
@@ -217,6 +217,11 @@
   margin-bottom: var(--commerce-card-padding);
   padding-bottom: var(--commerce-card-padding);
   border-bottom: 1px solid var(--commerce-color-border);
+  text-align: left;
+}
+
+.idme-verify .idme-trigger-link {
+  width: fit-content;
 }
 
 /* Totals */

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -5,7 +5,7 @@ import buildCartItem from '../../scripts/commerce/cart-item.js';
 import buildWarrantySelector from '../cart/warranty-selector.js';
 import { parsePreview, estimatePrice } from '../../scripts/commerce-api.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
-import { initIDMe } from '../../scripts/commerce/idme.js';
+import { initIDMe, syncIDMeVisibility } from '../../scripts/commerce/idme.js';
 
 const COUPON_ERROR_MESSAGES = {
   'en-us': {
@@ -293,6 +293,16 @@ export default async function decorate(block) {
     discountsEl.appendChild(row);
   };
 
+  const updateTotals = () => {
+    const currency = getCurrencyCode();
+    const subtotal = formatPrice(cart.subtotal, currency);
+    subtotalEl.textContent = subtotal;
+    shippingEl.textContent = '--';
+    taxesEl.textContent = '--';
+    grandTotalEl.textContent = subtotal;
+    headerTotalEl.textContent = subtotal;
+  };
+
   let priceEstimateRequest = 0;
   let hasOrderPreview = false;
   const renderPriceEstimate = (estimate) => {
@@ -315,6 +325,7 @@ export default async function decorate(block) {
     if (!couponCode || !cart.itemCount) {
       discountsEl.innerHTML = '';
       discountsEl.hidden = true;
+      updateTotals();
       return;
     }
 
@@ -431,16 +442,6 @@ export default async function decorate(block) {
       });
   };
 
-  const updateTotals = () => {
-    const currency = getCurrencyCode();
-    const subtotal = formatPrice(cart.subtotal, currency);
-    subtotalEl.textContent = subtotal;
-    shippingEl.textContent = '--';
-    taxesEl.textContent = '--';
-    grandTotalEl.textContent = subtotal;
-    headerTotalEl.textContent = subtotal;
-  };
-
   renderItems();
   updateTotals();
   updatePriceEstimate();
@@ -460,6 +461,12 @@ export default async function decorate(block) {
 
   document.addEventListener('cart:change', refreshSummary);
   document.addEventListener('cart:limit', refreshSummary);
+  document.addEventListener('checkout:coupon-apply', () => {
+    syncIDMeVisibility();
+    const couponCode = sessionStorage.getItem('checkout_coupon_code') || '';
+    const couponSource = sessionStorage.getItem('checkout_coupon_source') || '';
+    if (!couponCode || couponSource === 'auto') updatePriceEstimate();
+  });
 
   const summaryContent = block.querySelector('.order-summary-content');
   document.addEventListener('checkout:preview-loading', () => {
@@ -478,6 +485,7 @@ export default async function decorate(block) {
       discountInput.value = '';
       couponErrorEl.textContent = getCouponErrorMessage(couponError);
       couponErrorEl.hidden = false;
+      syncIDMeVisibility();
       return;
     }
 
@@ -504,6 +512,6 @@ export default async function decorate(block) {
   syncVisibility();
   initMobileCollapse(block);
   if (getLocaleAndLanguage().locale === 'us') {
-    initIDMe(block.querySelector('.order-summary-discount'), discountInput);
+    initIDMe(block.querySelector('.order-summary-discount'));
   }
 }

--- a/scripts/commerce/idme.js
+++ b/scripts/commerce/idme.js
@@ -6,6 +6,7 @@ const IDME_SCOPES = 'military,medical,nurse,responder,teacher';
 // ID.me Groups product — single hostname for both sandbox and production.
 // The environment is determined by the client_id, not the URL.
 const IDME_GROUPS_BASE = 'https://groups.id.me';
+const IDME_COUPON_SOURCE = 'auto';
 
 function buildIDMeAuthUrl(callbackUrl) {
   const clientId = (!isProd && localStorage.getItem('idme-client-id')?.trim()) || IDME_CLIENT_ID;
@@ -23,6 +24,89 @@ function buildIDMeAuthUrl(callbackUrl) {
   })}`;
 }
 
+function hasIDMeCoupon() {
+  return sessionStorage.getItem('checkout_coupon_source') === IDME_COUPON_SOURCE
+    && !!sessionStorage.getItem('checkout_coupon_code');
+}
+
+export function syncIDMeVisibility() {
+  const hidden = hasIDMeCoupon();
+  document.querySelectorAll('.idme-verify').forEach((el) => {
+    el.hidden = hidden;
+  });
+}
+
+function applyIDMeCoupon(coupon) {
+  sessionStorage.setItem('checkout_coupon_code', coupon);
+  sessionStorage.setItem('checkout_coupon_source', IDME_COUPON_SOURCE);
+  syncIDMeVisibility();
+  document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
+}
+
+function notifyOpenerIDMeCoupon(coupon) {
+  if (!window.opener || window.opener.closed) return false;
+  window.opener.postMessage({ type: 'idme:coupon', coupon }, window.location.origin);
+  return true;
+}
+
+function openIDMePopup(url) {
+  const width = 775;
+  const height = 850;
+  const screenLeft = window.screenLeft ?? window.screenX ?? 0;
+  const screenTop = window.screenTop ?? window.screenY ?? 0;
+  const left = Math.round(((window.innerWidth - width) / 2) + screenLeft);
+  const top = Math.round(((window.innerHeight - height) / 2) + screenTop);
+
+  return window.open(
+    url,
+    'ID.me',
+    `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`,
+  );
+}
+
+function watchIDMePopup(popupWindow) {
+  let intervalId;
+  let handleMessage;
+
+  function finish(coupon) {
+    window.clearInterval(intervalId);
+    window.removeEventListener('message', handleMessage);
+    if (coupon) applyIDMeCoupon(coupon);
+    popupWindow.close();
+  }
+
+  handleMessage = (event) => {
+    if (event.origin !== window.location.origin || event.source !== popupWindow) return;
+    if (event.data?.type !== 'idme:coupon') return;
+    finish(event.data.coupon);
+  };
+
+  window.addEventListener('message', handleMessage);
+  intervalId = window.setInterval(() => {
+    if (popupWindow.closed) {
+      window.clearInterval(intervalId);
+      window.removeEventListener('message', handleMessage);
+      return;
+    }
+
+    let popupUrl;
+    try {
+      popupUrl = new URL(popupWindow.location.href);
+    } catch {
+      // The popup is still on ID.me, so its location is cross-origin.
+      return;
+    }
+
+    if (popupUrl.origin !== window.location.origin) return;
+
+    const coupon = popupUrl.searchParams.get('idme_coupon');
+    const error = popupUrl.searchParams.get('idme_error');
+    if (!coupon && !error) return;
+
+    finish(coupon);
+  }, 100);
+}
+
 /**
  * Reads ?idme_coupon= from the current URL, stores it as an auto-applied
  * coupon, fires checkout:coupon-apply, and cleans the param from the address
@@ -37,9 +121,11 @@ export function handleIDMeReturn() {
   params.delete('idme_error');
   const qs = params.size ? `?${params}` : '';
   window.history.replaceState(null, '', window.location.pathname + qs);
-  sessionStorage.setItem('checkout_coupon_code', coupon);
-  sessionStorage.setItem('checkout_coupon_source', 'auto');
-  document.dispatchEvent(new CustomEvent('checkout:coupon-apply'));
+  if (notifyOpenerIDMeCoupon(coupon)) {
+    window.close();
+    return coupon;
+  }
+  applyIDMeCoupon(coupon);
   return coupon;
 }
 
@@ -53,6 +139,8 @@ export function handleIDMeReturn() {
  * @returns {string|null}
  */
 export function initIDMe(insertAfterEl) {
+  const returnedCoupon = handleIDMeReturn();
+
   // only allow overrides via localStorage on non-prod hosts
   let redirectOrigin = window.location.origin;
   if (!isProd) {
@@ -82,15 +170,25 @@ export function initIDMe(insertAfterEl) {
       </div>`;
 
     outer.querySelector('.idme-trigger-link').addEventListener('click', () => {
-      window.location.href = buildIDMeAuthUrl(callbackUrl);
+      const authUrl = buildIDMeAuthUrl(callbackUrl);
+      const popupWindow = openIDMePopup(authUrl);
+
+      if (!popupWindow || popupWindow.closed) {
+        window.location.href = authUrl;
+        return;
+      }
+
+      popupWindow.focus();
+      watchIDMePopup(popupWindow);
     });
 
-    const script = document.createElement('script');
-    script.src = 'https://s3.amazonaws.com/idme/developer/idme-buttons/assets/js/idme-wallet-button.js';
-    script.async = true;
-    outer.querySelector('.idme-wrapper').appendChild(script);
+    const style = document.createElement('link');
+    style.href = 'https://s3.amazonaws.com/idme/developer/idme-buttons/assets/css/unified/button.css';
+    style.rel = 'stylesheet';
+    outer.querySelector('.idme-wrapper').appendChild(style);
   }
 
   insertAfterEl.insertAdjacentElement('afterend', outer);
-  return handleIDMeReturn();
+  syncIDMeVisibility();
+  return returnedCoupon;
 }

--- a/tests/unit/idme.test.js
+++ b/tests/unit/idme.test.js
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+function setLocation(url) {
+  const next = new URL(url);
+  globalThis.location = next;
+  globalThis.window.location = next;
+}
+
+function installHistory() {
+  globalThis.window.history = {
+    replaced: null,
+    replaceState(_state, _title, url) {
+      this.replaced = url;
+    },
+  };
+}
+
+function installIDMeDom() {
+  const anchor = {
+    handler: null,
+    addEventListener(type, handler) {
+      if (type === 'click') this.handler = handler;
+    },
+    click() {
+      this.handler?.();
+    },
+  };
+  const wrapper = { appendChild() {} };
+  const outer = {
+    className: '',
+    set innerHTML(value) {
+      this.html = value;
+    },
+    querySelector(selector) {
+      if (selector === '.idme-trigger-link') return anchor;
+      if (selector === '.idme-wrapper') return wrapper;
+      return null;
+    },
+  };
+  const inserted = [];
+  const insertAfterEl = {
+    insertAdjacentElement(position, element) {
+      inserted.push({ position, element });
+    },
+  };
+
+  globalThis.document.createElement = (tagName) => (
+    tagName === 'div' ? outer : { tagName, async: false, href: '', rel: '', src: '' }
+  );
+  globalThis.document.getElementById = () => null;
+  globalThis.document.querySelectorAll = (selector) => (
+    selector === '.idme-verify' ? inserted.map(({ element }) => element) : []
+  );
+
+  return {
+    anchor, inserted, insertAfterEl, outer,
+  };
+}
+
+async function importIDMe() {
+  return import('../../scripts/commerce/idme.js');
+}
+
+describe('ID.me checkout integration', () => {
+  beforeEach(() => {
+    globalThis.__resetTestState();
+    setLocation('https://www.vitamix.com/us/en_us/checkout/cart');
+    installHistory();
+    globalThis.innerWidth = 1440;
+    globalThis.innerHeight = 900;
+    globalThis.screenLeft = 0;
+    globalThis.screenTop = 0;
+    globalThis.opener = null;
+    globalThis.close = () => {};
+    globalThis.document.querySelectorAll = () => [];
+    globalThis.addEventListener = () => {};
+    globalThis.removeEventListener = () => {};
+  });
+
+  afterEach(() => {
+    globalThis.__resetTestState();
+  });
+
+  it('applies an ID.me coupon returned on the current page URL', async () => {
+    setLocation('https://www.vitamix.com/us/en_us/checkout/cart?idme_coupon=IDME10&idme_error=ignored');
+    const { handleIDMeReturn } = await importIDMe();
+
+    assert.equal(handleIDMeReturn(), 'IDME10');
+    assert.equal(sessionStorage.getItem('checkout_coupon_code'), 'IDME10');
+    assert.equal(sessionStorage.getItem('checkout_coupon_source'), 'auto');
+    assert.equal(globalThis.__events.at(-1).type, 'checkout:coupon-apply');
+    assert.equal(globalThis.window.history.replaced, '/us/en_us/checkout/cart');
+  });
+
+  it('posts a returned coupon to the opener and closes the popup return page', async () => {
+    setLocation('https://www.vitamix.com/us/en_us/checkout/cart?idme_coupon=IDME10');
+    let postedMessage;
+    let closeCalled = false;
+    globalThis.opener = {
+      closed: false,
+      postMessage(message, origin) {
+        postedMessage = { message, origin };
+      },
+    };
+    globalThis.close = () => {
+      closeCalled = true;
+    };
+    const { handleIDMeReturn } = await importIDMe();
+
+    assert.equal(handleIDMeReturn(), 'IDME10');
+    assert.deepEqual(postedMessage, {
+      message: { type: 'idme:coupon', coupon: 'IDME10' },
+      origin: 'https://www.vitamix.com',
+    });
+    assert.equal(closeCalled, true);
+    assert.equal(sessionStorage.getItem('checkout_coupon_code'), null);
+    assert.equal(globalThis.__events.length, 0);
+  });
+
+  it('renders ID.me hidden when an ID.me coupon is already applied and shows it again when removed', async () => {
+    sessionStorage.setItem('checkout_coupon_code', 'IDME10');
+    sessionStorage.setItem('checkout_coupon_source', 'auto');
+    const { inserted, insertAfterEl } = installIDMeDom();
+    const { initIDMe, syncIDMeVisibility } = await importIDMe();
+
+    assert.equal(initIDMe(insertAfterEl), null);
+    assert.equal(inserted.length, 1);
+    assert.equal(inserted[0].element.hidden, true);
+
+    sessionStorage.removeItem('checkout_coupon_code');
+    sessionStorage.removeItem('checkout_coupon_source');
+    syncIDMeVisibility();
+
+    assert.equal(inserted[0].element.hidden, false);
+  });
+
+  it('opens ID.me in a popup and applies the returned coupon in the opener', async () => {
+    const { anchor, inserted, insertAfterEl } = installIDMeDom();
+    const popupWindow = {
+      closed: false,
+      location: { href: 'https://groups.id.me/' },
+      closeCalled: false,
+      focusCalled: false,
+      close() {
+        this.closeCalled = true;
+        this.closed = true;
+      },
+      focus() {
+        this.focusCalled = true;
+      },
+    };
+    let openedUrl;
+    globalThis.open = (url) => {
+      openedUrl = url;
+      return popupWindow;
+    };
+
+    const { initIDMe } = await importIDMe();
+    initIDMe(insertAfterEl);
+    anchor.click();
+
+    assert.match(openedUrl, /^https:\/\/groups\.id\.me\//);
+    assert.equal(popupWindow.focusCalled, true);
+
+    popupWindow.location.href = 'https://www.vitamix.com/us/en_us/checkout/cart?idme_coupon=IDME10';
+    await new Promise((resolve) => {
+      setTimeout(resolve, 650);
+    });
+
+    assert.equal(sessionStorage.getItem('checkout_coupon_code'), 'IDME10');
+    assert.equal(sessionStorage.getItem('checkout_coupon_source'), 'auto');
+    assert.equal(globalThis.__events.at(-1).type, 'checkout:coupon-apply');
+    assert.equal(inserted[0].element.hidden, true);
+    assert.equal(popupWindow.closeCalled, true);
+  });
+
+  it('applies the ID.me coupon from a popup postMessage', async () => {
+    const { anchor, inserted, insertAfterEl } = installIDMeDom();
+    const popupWindow = {
+      closed: false,
+      location: { href: 'https://groups.id.me/' },
+      closeCalled: false,
+      close() {
+        this.closeCalled = true;
+        this.closed = true;
+      },
+      focus() {},
+    };
+    let messageHandler;
+    let removedHandler;
+    globalThis.addEventListener = (type, handler) => {
+      if (type === 'message') messageHandler = handler;
+    };
+    globalThis.removeEventListener = (type, handler) => {
+      if (type === 'message') removedHandler = handler;
+    };
+    globalThis.open = () => popupWindow;
+
+    const { initIDMe } = await importIDMe();
+    initIDMe(insertAfterEl);
+    anchor.click();
+    messageHandler({
+      origin: 'https://www.vitamix.com',
+      source: popupWindow,
+      data: { type: 'idme:coupon', coupon: 'IDME10' },
+    });
+
+    assert.equal(sessionStorage.getItem('checkout_coupon_code'), 'IDME10');
+    assert.equal(sessionStorage.getItem('checkout_coupon_source'), 'auto');
+    assert.equal(globalThis.__events.at(-1).type, 'checkout:coupon-apply');
+    assert.equal(inserted[0].element.hidden, true);
+    assert.equal(popupWindow.closeCalled, true);
+    assert.equal(removedHandler, messageHandler);
+  });
+
+  it('falls back to full-page redirect when the popup is blocked', async () => {
+    const { anchor, insertAfterEl } = installIDMeDom();
+    globalThis.open = () => null;
+
+    const { initIDMe } = await importIDMe();
+    initIDMe(insertAfterEl);
+    anchor.click();
+
+    assert.match(globalThis.window.location.href, /^https:\/\/groups\.id\.me\//);
+  });
+});

--- a/tests/unit/loader.mjs
+++ b/tests/unit/loader.mjs
@@ -16,7 +16,7 @@ const mockUrl = (file) => pathToFileURL(resolvePath(here, 'mocks', file)).href;
 
 const redirects = [
   { match: (s) => s === './commerce-config.js' || s.endsWith('/commerce-config.js'), file: 'commerce-config.mjs' },
-  { match: (s) => s === './aem.js' || s.endsWith('/scripts/aem.js'), file: 'aem.mjs' },
+  { match: (s) => s === './aem.js' || s === '../aem.js' || s.endsWith('/scripts/aem.js'), file: 'aem.mjs' },
   { match: (s) => s === './scripts.js' || s.endsWith('/scripts/scripts.js'), file: 'scripts.mjs' },
 ];
 


### PR DESCRIPTION
fixes: #571

Match the Magento ID.me experience without API changes by applying returned coupons through the opener window. Refresh cart and checkout totals immediately when ID.me coupon state changes and restore the verification prompt after removal.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://idme-popup-auth--vitamix--aemsites.aem.network/