### PR TITLE
fix(checkout): omit coupon source from order payload

### DIFF
--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -71,11 +71,7 @@ export function buildOrderJSON(formData, form, cart, state, config) {
   }
 
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;
-  const couponSource = sessionStorage.getItem('checkout_coupon_source') || undefined;
-  if (couponCode) {
-    order.couponCode = couponCode;
-    if (couponSource) order.couponSource = couponSource;
-  }
+  if (couponCode) order.couponCode = couponCode;
 
   order.locale = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
   order.country = locale;


### PR DESCRIPTION
Fixes #570

couponSource is only needed while estimating and previewing auto-applied ID.me discounts. The order schema rejects it during order creation, so keep the final order payload limited to the coupon code and estimate token.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-idme-order-coupon-source--vitamix--aemsites.aem.network/