### PR TITLE
fix(checkout): hide ID.me discount number prefix

### DIFF
--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -8,6 +8,7 @@ import applePay from '../../scripts/payments/apple-pay.js';
 import googlePay from '../../scripts/payments/google-pay.js';
 import paypal from '../../scripts/payments/paypal.js';
 import { getActiveProviders } from '../checkout/checkout-payment.js';
+import formatDiscountLabel from '../../scripts/commerce/discount-label.js';
 import { initIDMe, syncIDMeVisibility } from '../../scripts/commerce/idme.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
@@ -224,7 +225,7 @@ export default async function decorate(block) {
 
   // 4. Restore saved promo code; persist to sessionStorage on apply
   const showDiscountRow = (code, amount = '--') => {
-    discountRowLabel.textContent = `${s.discount} (${code})`;
+    discountRowLabel.textContent = `${s.discount} (${formatDiscountLabel(code)})`;
     discountRowAmount.textContent = amount;
     discountRow.hidden = false;
   };

--- a/blocks/order-complete/order-complete.js
+++ b/blocks/order-complete/order-complete.js
@@ -1,5 +1,6 @@
 import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
 import { getOrder } from '../../scripts/commerce-api.js';
+import formatDiscountLabel from '../../scripts/commerce/discount-label.js';
 
 export function normalizeTotalsDiscounts(discounts = []) {
   return discounts.filter((discount) => Math.abs(parseFloat(discount?.amount)) > 0);
@@ -252,7 +253,7 @@ export default async function decorate(block) {
     ];
 
     normalizeTotalsDiscounts(totalsDiscounts).forEach((discount) => {
-      const label = discount.name || s.discount;
+      const label = formatDiscountLabel(discount.name || s.discount);
       const amount = Math.abs(parseFloat(discount.amount));
       const value = formatPrice(-amount, currencyCode);
       rows.push([label, value, 'order-totals-discount']);

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -5,6 +5,7 @@ import buildCartItem, { buildGiftItem } from '../../scripts/commerce/cart-item.j
 import buildWarrantySelector from '../cart/warranty-selector.js';
 import { parsePreview, estimatePrice } from '../../scripts/commerce-api.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
+import formatDiscountLabel from '../../scripts/commerce/discount-label.js';
 import { initIDMe, syncIDMeVisibility } from '../../scripts/commerce/idme.js';
 
 const COUPON_ERROR_MESSAGES = {
@@ -264,12 +265,12 @@ export default async function decorate(block) {
         const labelGroup = document.createElement('span');
         labelGroup.className = 'discount-label-group';
         const label = document.createElement('span');
-        label.textContent = d.name || s.discount;
+        label.textContent = formatDiscountLabel(d.name || s.discount);
         labelGroup.append(label, makeRemoveBtn());
         row.append(labelGroup, amount);
       } else {
         const label = document.createElement('span');
-        label.textContent = d.name || s.discount;
+        label.textContent = formatDiscountLabel(d.name || s.discount);
         row.append(label, amount);
       }
       discountsEl.appendChild(row);
@@ -284,7 +285,7 @@ export default async function decorate(block) {
     const labelGroup = document.createElement('span');
     labelGroup.className = 'discount-label-group';
     const label = document.createElement('span');
-    label.textContent = `${s.discount} (${code})`;
+    label.textContent = `${s.discount} (${formatDiscountLabel(code)})`;
     labelGroup.append(label, makeRemoveBtn());
     const amount = document.createElement('span');
     amount.className = 'order-summary-discount-amount';

--- a/scripts/commerce/discount-label.js
+++ b/scripts/commerce/discount-label.js
@@ -1,0 +1,4 @@
+export default function formatDiscountLabel(label) {
+  const value = String(label || '').trim();
+  return value.replace(/^#\d+\s+(ID\.me\b.*)$/i, '$1');
+}

--- a/tests/unit/discount-label.test.js
+++ b/tests/unit/discount-label.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import formatDiscountLabel from '../../scripts/commerce/discount-label.js';
+
+describe('formatDiscountLabel', () => {
+  it('removes the generated ID.me coupon number prefix', () => {
+    assert.equal(formatDiscountLabel('#993 ID.me'), 'ID.me');
+    assert.equal(formatDiscountLabel('#993 ID.me discount'), 'ID.me discount');
+  });
+
+  it('leaves other discount labels unchanged', () => {
+    assert.equal(formatDiscountLabel('SAVE10'), 'SAVE10');
+    assert.equal(formatDiscountLabel('#993 Summer Sale'), '#993 Summer Sale');
+    assert.equal(formatDiscountLabel('ID.me'), 'ID.me');
+  });
+});


### PR DESCRIPTION
Normalize generated ID.me discount labels so checkout, cart, and order confirmation show the customer-facing ID.me name without the internal numeric prefix.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://strip-idme-coupon-suffix--vitamix--aemsites.aem.network/