### PR TITLE
fix(checkout): keep continue shopping in locale

### DIFF
--- a/blocks/cart/cart.js
+++ b/blocks/cart/cart.js
@@ -3,6 +3,7 @@ import cart from '../../scripts/cart.js';
 import { getConfig } from '../../scripts/commerce-config.js';
 import buildCartItem, { buildGiftItem } from '../../scripts/commerce/cart-item.js';
 import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 const LOCAL_STRINGS = {
   'en-us': {
@@ -39,7 +40,7 @@ function buildCartItemExtensions(extensions, context) {
     .filter((content) => content instanceof HTMLElement);
 }
 
-function buildTemplate(s) {
+function buildTemplate(s, storeRootPath) {
   return /* html */`
 <div class="cart">
     <div class="cart-items">
@@ -48,7 +49,7 @@ function buildTemplate(s) {
     </div>
     <div class="cart-empty-message">
         <p>${s.cartEmpty}</p>
-        <a href="/" class="button">${s.continueShopping}</a>
+        <a href="${storeRootPath}" class="button">${s.continueShopping}</a>
     </div>
     <div class="cart-controls">
         <a href="#" class="button cart-view-cart">${s.viewCart}</a>
@@ -66,10 +67,12 @@ export default async function decorate(block) {
 
   const config = getConfig();
   const s = getStrings(config);
+  const { locale, language } = getLocaleAndLanguage();
+  const storeRootPath = `/${locale}/${language}/`;
   const currencyCode = typeof config.currency === 'function' ? config.currency(config.getLocale()) : config.currency;
   const cartItemExtensions = await loadCartItemExtensions(config);
 
-  block.innerHTML = buildTemplate(s);
+  block.innerHTML = buildTemplate(s, storeRootPath);
   block.querySelector('.cart-checkout').href = config.getOrderPath('checkout');
 
   const isMinicart = Boolean(block.closest('.minicart'));
@@ -86,9 +89,8 @@ export default async function decorate(block) {
 
   const heading = block.closest('.section')?.querySelector('.default-content-wrapper h1, .default-content-wrapper h2');
   if (heading) {
-    const shopRoot = `/${config.getLocale()}/${config.getLanguage()}/`;
     const link = document.createElement('a');
-    link.href = shopRoot;
+    link.href = storeRootPath;
     link.className = 'cart-continue-shopping';
     link.textContent = s.continueShopping;
     heading.insertAdjacentElement('afterend', link);

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -14,6 +14,7 @@ import { parsePreview } from '../../scripts/commerce-api.js';
 import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
 import { validateField } from './checkout-validation.js';
 import { formStateKey, saveFormState, restoreFormState } from './checkout-session-state.js';
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -166,6 +167,8 @@ export default async function decorate(block) {
   const config = getConfig();
   const strings = getStrings(config);
   const locale = config.getLocale();
+  const { locale: currentLocale, language } = getLocaleAndLanguage();
+  const storeRootPath = `/${currentLocale}/${language}/`;
 
   // Reconcile gift-with-purchase before the empty-cart guard — a returning
   // visitor whose cart no longer qualifies needs the stale gift removed,
@@ -181,7 +184,7 @@ export default async function decorate(block) {
     const p = document.createElement('p');
     p.textContent = strings.cartEmpty;
     const link = document.createElement('a');
-    link.href = '/';
+    link.href = storeRootPath;
     link.className = 'button';
     link.textContent = strings.continueShopping;
     empty.append(p, link);

--- a/blocks/order-cancel/order-cancel.js
+++ b/blocks/order-cancel/order-cancel.js
@@ -1,4 +1,5 @@
 import { getConfig } from '../../scripts/commerce-config.js';
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 /**
  * Order cancellation page block.
@@ -21,6 +22,8 @@ import { getConfig } from '../../scripts/commerce-config.js';
 export default async function decorate(block) {
   const config = getConfig();
   const strings = config.getStrings();
+  const { locale, language } = getLocaleAndLanguage();
+  const storeRootPath = `/${locale}/${language}/`;
   const params = Object.fromEntries(new URLSearchParams(window.location.search).entries());
 
   const reason = params.reason || '';
@@ -70,7 +73,7 @@ export default async function decorate(block) {
   actions.appendChild(returnLink);
 
   const shopLink = document.createElement('a');
-  shopLink.href = `/${config.getLocale()}/${config.getLanguage()}`;
+  shopLink.href = storeRootPath;
   shopLink.className = 'button secondary';
   shopLink.textContent = strings.continueShopping;
   actions.appendChild(shopLink);

--- a/blocks/order-complete/order-complete.js
+++ b/blocks/order-complete/order-complete.js
@@ -1,5 +1,6 @@
 import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
 import { getOrder } from '../../scripts/commerce-api.js';
+import { getLocaleAndLanguage } from '../../scripts/scripts.js';
 
 export function normalizeTotalsDiscounts(discounts = []) {
   return discounts.filter((discount) => Math.abs(parseFloat(discount?.amount)) > 0);
@@ -36,6 +37,8 @@ export function calculateConfirmationTotal({
 export default async function decorate(block) {
   const config = getConfig();
   const s = config.getStrings();
+  const { locale, language } = getLocaleAndLanguage();
+  const storeRootPath = `/${locale}/${language}/`;
   const currencyCode = typeof config.currency === 'function' ? config.currency(config.getLocale()) : config.currency;
   const params = Object.fromEntries(new URLSearchParams(window.location.search).entries());
 
@@ -74,7 +77,7 @@ export default async function decorate(block) {
   const cartItemsData = sessionStorage.getItem('checkout_cart_items');
 
   if (!orderId) {
-    window.location.href = '/';
+    window.location.href = storeRootPath;
     return;
   }
 
@@ -359,7 +362,7 @@ export default async function decorate(block) {
   const actions = document.createElement('div');
   actions.className = 'order-actions';
   const continueLink = document.createElement('a');
-  continueLink.href = '/';
+  continueLink.href = storeRootPath;
   continueLink.className = 'button emphasis';
   continueLink.textContent = s.continueShopping;
   actions.appendChild(continueLink);


### PR DESCRIPTION
Fixes #587

Use the current path locale and language for continue shopping links so testers remain on the intended regional site instead of triggering root-level geo redirects.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-continue-shopping-locale--vitamix--aemsites.aem.network/