### PR TITLE
fix(ops-log): more error stack extraction

### DIFF
--- a/scripts/operations-log.js
+++ b/scripts/operations-log.js
@@ -10,20 +10,16 @@
  * everywhere else we POST to the AEM network origin.
  */
 
-const OPERATIONS_LOG_PATH = '/us/en_us/products/operations-log';
-<<<<<<< Updated upstream
-=======
-const CHECKOUT_ID_KEY = 'vmx_checkout_log_id';
-
 // V8 captures at most `stackTraceLimit` frames when an Error is constructed
 // (default 10). Raising it early — this module is imported during initial page
 // bootstrap — gives deeper stacks for async errors and unhandled rejections,
 // where the relevant app frame is often buried below framework/await frames.
 // No-op in engines that don't honour it (Firefox/Safari).
 try { Error.stackTraceLimit = 100; } catch { /* read-only in some engines */ }
->>>>>>> Stashed changes
-const AEM_NETWORK_ORIGIN = 'https://main--vitamix--aemsites.aem.network';
+
+const OPERATIONS_LOG_PATH = '/us/en_us/products/operations-log';
 const CHECKOUT_ID_KEY = 'vmx_checkout_log_id';
+const AEM_NETWORK_ORIGIN = 'https://main--vitamix--aemsites.aem.network';
 
 /**
  * Valid `action` values. Mirrors the endpoint contract — the only required

--- a/scripts/operations-log.js
+++ b/scripts/operations-log.js
@@ -11,6 +11,17 @@
  */
 
 const OPERATIONS_LOG_PATH = '/us/en_us/products/operations-log';
+<<<<<<< Updated upstream
+=======
+const CHECKOUT_ID_KEY = 'vmx_checkout_log_id';
+
+// V8 captures at most `stackTraceLimit` frames when an Error is constructed
+// (default 10). Raising it early — this module is imported during initial page
+// bootstrap — gives deeper stacks for async errors and unhandled rejections,
+// where the relevant app frame is often buried below framework/await frames.
+// No-op in engines that don't honour it (Firefox/Safari).
+try { Error.stackTraceLimit = 100; } catch { /* read-only in some engines */ }
+>>>>>>> Stashed changes
 const AEM_NETWORK_ORIGIN = 'https://main--vitamix--aemsites.aem.network';
 const CHECKOUT_ID_KEY = 'vmx_checkout_log_id';
 
@@ -115,14 +126,22 @@ export function anonymize(body) {
   return out;
 }
 
+// Keep enough frames that the originating app frame (often buried below
+// framework/await frames in async stacks) survives, but cap total size so a
+// pathological stack can't bloat the payload.
+const STACK_MAX_LINES = 30;
+const STACK_MAX_CHARS = 4000;
+
 /**
- * Trims an error stack to its first few frames to keep payloads small.
+ * Trims an error stack: keeps the leading frames (where the originating call
+ * site lives) and caps total length to keep payloads bounded.
  * @param {string} [stack]
  * @returns {string|undefined}
  */
 function trimStack(stack) {
   if (!stack) return undefined;
-  return stack.split('\n').slice(0, 5).join('\n');
+  const trimmed = stack.split('\n').slice(0, STACK_MAX_LINES).join('\n');
+  return trimmed.length > STACK_MAX_CHARS ? `${trimmed.slice(0, STACK_MAX_CHARS)}…` : trimmed;
 }
 
 /**
@@ -134,6 +153,7 @@ function trimStack(stack) {
 export function logError(scope, error, extra = {}) {
   logOperation('error', {
     scope,
+    name: error?.name,
     message: error?.message || String(error),
     stack: trimStack(error?.stack),
     ...extra,

--- a/tests/unit/operations-log.test.js
+++ b/tests/unit/operations-log.test.js
@@ -7,7 +7,7 @@
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  logOperation, getCheckoutId, clearCheckoutId, anonymize, logApiError, logNetworkError,
+  logOperation, getCheckoutId, clearCheckoutId, anonymize, logApiError, logNetworkError, logError,
 } from '../../scripts/operations-log.js';
 
 const PATH = '/us/en_us/products/operations-log';
@@ -166,4 +166,32 @@ test('logNetworkError: logs error action with kind network and anonymized body',
   assert.equal(body.message, 'Failed to fetch');
   // undefined keys (country/zip) are dropped by JSON serialization.
   assert.deepEqual(body.requestBody, { country: 'us', shipping: { state: 'CA' } });
+});
+
+// --- logError ---------------------------------------------------------------
+
+test('logError: records the error name alongside message', () => {
+  captureFetch();
+  const err = new TypeError('cannot read property');
+  logError('checkout-order', err, { orderId: 'ord-1' });
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.action, 'error');
+  assert.equal(body.scope, 'checkout-order');
+  assert.equal(body.name, 'TypeError');
+  assert.equal(body.message, 'cannot read property');
+  assert.equal(body.orderId, 'ord-1');
+});
+
+test('logError: retains stack frames past the old 5-line cap', () => {
+  captureFetch();
+  const err = new Error('boom');
+  // Simulate a deep async stack where the originating app frame is line 8.
+  err.stack = ['Error: boom', ...Array.from(
+    { length: 15 },
+    (_, i) => `    at fn${i} (https://x/scripts/mod.js:${i + 1}:3)`,
+  )].join('\n');
+  logError('global', err);
+  const body = JSON.parse(lastInit.body);
+  assert.ok(body.stack.includes('fn8'), 'frame past line 5 should be retained');
+  assert.ok(body.stack.includes(':9:3'), 'line numbers should be preserved');
 });


### PR DESCRIPTION
- include more stack lines in error logs

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://ops-log-stack--vitamix--aemsites.aem.network/
