### PR TITLE
feat(pdp): support authored metadata overrides for buy-box behavior

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -151,6 +151,17 @@ export default function renderAddToCart(ph, block, parent) {
     return renderFindDealer(ph, block);
   }
 
+  // When an authored `addToCart=No` override is set and no find-locally/dealer
+  // alternative applies, render nothing rather than falling through to the
+  // button. This is gated strictly on the authored override (a metadata-table
+  // value surfaced as a meta tag) and never on the product bus custom value,
+  // which only lives in JSON-LD and is left untouched. As the last branch, it
+  // also leaves every existing path (find locally/dealer, managed stock,
+  // availability) behaving exactly as before.
+  if (getPdpOverride('addToCart') === 'No') {
+    return '';
+  }
+
   // create main add to cart container
   const addToCartContainer = document.createElement('div');
   addToCartContainer.classList.add('add-to-cart');

--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -1,5 +1,5 @@
 import { getMetadata } from '../../scripts/aem.js';
-import { checkVariantOutOfStock, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { checkVariantOutOfStock, getLocaleAndLanguage, getPdpOverride } from '../../scripts/scripts.js';
 
 /**
  * Renders "Find Locally" button container.
@@ -80,12 +80,11 @@ function toggleFixedAddToCart(container) {
  * @returns {boolean} True if the variant is available for sale, false otherwise
  */
 export function isVariantAvailableForSale(variant) {
-  if (getMetadata('addToCart') === 'No') {
-    return false;
-  }
+  const { managedStock, addToCart } = variant?.custom || {};
 
-  const { managedStock, addToCart } = variant.custom;
-  if (!variant || addToCart === 'No') {
+  // Authored `addToCart` override wins over the product bus custom.addToCart.
+  const effectiveAddToCart = getPdpOverride('addToCart') || addToCart;
+  if (!variant || effectiveAddToCart === 'No') {
     return false;
   }
 
@@ -114,8 +113,10 @@ export default function renderAddToCart(ph, block, parent) {
     selectedVariant = parent.offers.find((variant) => variant.sku === selectedSku);
   }
 
-  // Only look at findLocally and findDealer from parent product
-  const { findLocally, findDealer } = parent.custom;
+  // Only look at findLocally and findDealer from parent product.
+  // Authored overrides win over the product bus custom values.
+  const findLocally = getPdpOverride('findLocally') || parent.custom.findLocally;
+  const findDealer = getPdpOverride('findDealer') || parent.custom.findDealer;
   block.classList.remove('pdp-find-locally');
   block.classList.remove('pdp-find-dealer');
 

--- a/blocks/pdp/pricing.js
+++ b/blocks/pdp/pricing.js
@@ -1,4 +1,4 @@
-import { formatPrice, getOfferPricing } from '../../scripts/scripts.js';
+import { formatPrice, getOfferPricing, getPdpOverride } from '../../scripts/scripts.js';
 
 /**
  * Renders the pricing section of the PDP block.
@@ -9,8 +9,10 @@ export default function renderPricing(ph, block, variant) {
   const pricingContainer = document.createElement('div');
   pricingContainer.classList.add('pricing');
 
-  // Don't render pricing if addToCart is set to No
-  if (window.jsonLdData?.custom?.addToCart === 'No') {
+  // Don't render pricing if addToCart is set to No.
+  // Authored `addToCart` override wins over the product bus custom.addToCart.
+  const effectiveAddToCart = getPdpOverride('addToCart') || window.jsonLdData?.custom?.addToCart;
+  if (effectiveAddToCart === 'No') {
     return pricingContainer;
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -438,13 +438,54 @@ function parseVariants(sections) {
   });
 }
 
-// eslint-disable-next-line no-unused-vars
+/**
+ * Reads an authored PDP override flag from the page metadata.
+ *
+ * Authors set these via a metadata table in the document. The Edge Delivery
+ * pipeline normalizes metadata keys (lowercases them and converts any
+ * non-alphanumeric character to a hyphen), so a key authored as `In Stock`,
+ * `inStock`, or `in-stock` all surface as different meta names. To make the
+ * override resilient to authoring style, both the requested name and each
+ * meta tag name are normalized to lowercase alphanumerics before comparison.
+ *
+ * Recognized values are `Yes`/`No` (case-insensitive); any other value is
+ * returned verbatim. Missing overrides return an empty string so callers can
+ * fall back to the value coming from the product bus.
+ *
+ * @param {string} name The override name (e.g. 'inStock', 'addToCart')
+ * @returns {string} 'Yes', 'No', the raw value, or '' when not authored
+ */
+export function getPdpOverride(name) {
+  const normalize = (value) => (value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  const target = normalize(name);
+  if (!target) return '';
+  const meta = [...document.head.querySelectorAll('meta[name]')]
+    .find((m) => normalize(m.getAttribute('name')) === target);
+  if (!meta) return '';
+  const value = (meta.content || '').trim();
+  if (/^yes$/i.test(value)) return 'Yes';
+  if (/^no$/i.test(value)) return 'No';
+  return value;
+}
+
 export function checkVariantOutOfStock(sku) {
+  // Authored `inStock` override wins over the product bus availability and
+  // applies to the whole product (every variant), per requirements.
+  const inStock = getPdpOverride('inStock');
+  if (inStock === 'Yes') return false;
+  if (inStock === 'No') return true;
+
   const { availability } = window.jsonLdData.offers.find((offer) => offer.sku === sku);
   return availability === 'https://schema.org/OutOfStock';
 }
 
 export function isProductOutOfStock() {
+  // Authored `inStock` override wins over the product bus availability and
+  // applies to the whole product, regardless of individual variants.
+  const inStock = getPdpOverride('inStock');
+  if (inStock === 'Yes') return false;
+  if (inStock === 'No') return true;
+
   // Check if all variants are out of stock, if any are in stock, return false
   const { offers, custom } = window.jsonLdData;
 


### PR DESCRIPTION
Let authors override product bus values via a document metadata table: `inStock`, `addToCart`, `findLocally`, and `findDealer` (Yes/No). A new getPdpOverride helper normalizes keys case/separator-insensitively and falls back to product bus values when an override is not authored.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://pdp-metadata-overrides--vitamix--aemsites.aem.network/