### PR TITLE
fix(paypal): keep Pay Later button visible on mobile

### DIFF
--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -133,7 +133,6 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
 }
 
 .cart-summary-express-buttons {
-  container-type: inline-size;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -158,17 +157,15 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   height: 55px;
 }
 
-/* Tablet (>=420px): Apple Pay on its own row, PayPal + Pay Later as two columns. */
-@container (min-width: 420px) {
+/* Desktop only: the order-summary sidebar is a fixed ~420px column, so pair
+   PayPal + Pay Later as two columns below Apple Pay. On tablet/mobile (<=999px)
+   the sidebar goes full-width and the cart layout stacks, so the buttons stay
+   stacked vertically there. (A viewport query is used rather than a container
+   query because the full-width mobile sidebar is a similar width to the desktop
+   sidebar and can't be distinguished by container width alone.) */
+@media (width >= 1000px) {
   .cart-summary-express-buttons .paypal-paypal-wrapper,
   .cart-summary-express-buttons .paypal-paylater-wrapper {
-    flex: 1 1 0;
-  }
-}
-
-/* Desktop (>=620px): all three buttons in a single row. */
-@container (min-width: 620px) {
-  .cart-summary-express-buttons apple-pay-button {
     flex: 1 1 0;
   }
 }

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -182,6 +182,15 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   }
 }
 
+/* Tablet (768px up to the 1000px sidebar switch): the summary is full-width with
+   plenty of room, so put all three express buttons in a single row. Above 999px
+   the summary becomes a narrow ~420px sidebar where three across won't fit. */
+@media (width >= 768px) and (width <= 999px) {
+  .cart-summary-express-buttons apple-pay-button {
+    flex: 1 1 0;
+  }
+}
+
 .cart-summary-express-divider {
   display: flex;
   align-items: center;

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -139,7 +139,8 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   gap: 10px;
 }
 
-/* Apple Pay takes its own full-width row on top. */
+/* Base (narrow / mobile): every button stacked full-width. PayPal SDK iframes
+   have a minimum width, so two columns would overflow in a tight container. */
 .cart-summary-express-buttons apple-pay-button {
   --apple-pay-button-width: 100%;
   --apple-pay-button-height: 55px;
@@ -150,22 +151,25 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   flex: 0 0 100%;
 }
 
-/* PayPal and Pay Later share the second row as two equal columns. When only
-   one of them is present it expands to fill the full row. */
 .cart-summary-express-buttons .paypal-paypal-wrapper,
 .cart-summary-express-buttons .paypal-paylater-wrapper {
-  flex: 1 1 0;
+  flex: 0 0 100%;
   min-width: 0;
   height: 55px;
 }
 
-/* Below ~420px there isn't room for two PayPal buttons side by side — their
-   SDK iframes have a minimum width and would overflow the gap. Stack all
-   buttons full-width vertically instead. */
-@container (max-width: 420px) {
+/* Tablet (>=420px): Apple Pay on its own row, PayPal + Pay Later as two columns. */
+@container (min-width: 420px) {
   .cart-summary-express-buttons .paypal-paypal-wrapper,
   .cart-summary-express-buttons .paypal-paylater-wrapper {
-    flex: 0 0 100%;
+    flex: 1 1 0;
+  }
+}
+
+/* Desktop (>=620px): all three buttons in a single row. */
+@container (min-width: 620px) {
+  .cart-summary-express-buttons apple-pay-button {
+    flex: 1 1 0;
   }
 }
 

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -126,10 +126,11 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
 
 .cart-summary-express-buttons {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 10px;
 }
 
+/* Apple Pay takes its own full-width row on top. */
 .cart-summary-express-buttons apple-pay-button {
   --apple-pay-button-width: 100%;
   --apple-pay-button-height: 55px;
@@ -137,6 +138,16 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   --apple-pay-button-padding: 0;
 
   display: block;
+  flex: 0 0 100%;
+}
+
+/* PayPal and Pay Later share the second row as two equal columns. When only
+   one of them is present it expands to fill the full row. */
+.cart-summary-express-buttons .paypal-paypal-wrapper,
+.cart-summary-express-buttons .paypal-paylater-wrapper {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 55px;
 }
 
 .cart-summary-express-divider {

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -14,6 +14,14 @@
   padding-block-start: 10px;
 }
 
+/* The progress bar is hidden on mobile, so add back some breathing room
+   above the summary. */
+@media (width <= 600px) {
+  .section:has(.cart-summary-wrapper):has(.checkout-progress-wrapper) {
+    padding-block-start: 20px;
+  }
+}
+
 /* Heading authored alongside the cart sits above the two columns */
 div.section.cart-section:has(.cart-summary-wrapper) > .default-content-wrapper {
   flex-basis: 100%;

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -133,6 +133,7 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
 }
 
 .cart-summary-express-buttons {
+  container-type: inline-size;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -157,12 +158,23 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   height: 55px;
 }
 
-/* Desktop only: the order-summary sidebar is a fixed ~420px column, so pair
-   PayPal + Pay Later as two columns below Apple Pay. On tablet/mobile (<=999px)
-   the sidebar goes full-width and the cart layout stacks, so the buttons stay
-   stacked vertically there. (A viewport query is used rather than a container
-   query because the full-width mobile sidebar is a similar width to the desktop
-   sidebar and can't be distinguished by container width alone.) */
+/* Pair PayPal + Pay Later as two columns below Apple Pay whenever there's room.
+   Two triggers are needed because the container can't tell two cases apart on
+   its own:
+   - Container >=420px: the full-width summary on tablet (and the wide checkout
+     surface) — pair them.
+   - Viewport >=1000px: the desktop cart sidebar is a fixed ~420px column whose
+     inner container (~360px) is too narrow for the container query but is wide
+     enough to pair — so pair them on desktop too.
+   The remaining case (narrow container AND narrow viewport = a phone) stays
+   stacked, which is what we want on mobile. */
+@container (min-width: 420px) {
+  .cart-summary-express-buttons .paypal-paypal-wrapper,
+  .cart-summary-express-buttons .paypal-paylater-wrapper {
+    flex: 1 1 0;
+  }
+}
+
 @media (width >= 1000px) {
   .cart-summary-express-buttons .paypal-paypal-wrapper,
   .cart-summary-express-buttons .paypal-paylater-wrapper {

--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -125,6 +125,7 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
 }
 
 .cart-summary-express-buttons {
+  container-type: inline-size;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
@@ -148,6 +149,16 @@ div.section.cart-section:has(.cart-summary-wrapper) > .cart-wrapper {
   flex: 1 1 0;
   min-width: 0;
   height: 55px;
+}
+
+/* Below ~420px there isn't room for two PayPal buttons side by side — their
+   SDK iframes have a minimum width and would overflow the gap. Stack all
+   buttons full-width vertically instead. */
+@container (max-width: 420px) {
+  .cart-summary-express-buttons .paypal-paypal-wrapper,
+  .cart-summary-express-buttons .paypal-paylater-wrapper {
+    flex: 0 0 100%;
+  }
 }
 
 .cart-summary-express-divider {

--- a/blocks/checkout-progress/checkout-progress.css
+++ b/blocks/checkout-progress/checkout-progress.css
@@ -4,8 +4,6 @@
 }
 
 .checkout-progress nav {
-  display: flex;
-  justify-content: center;
   padding: 16px 0;
 }
 
@@ -15,7 +13,8 @@
   width: 100%;
   max-width: 560px;
   list-style: none;
-  margin: 0;
+  margin-inline: auto;
+  margin-block: 0;
   padding: 0;
   gap: 0;
   counter-reset: step-counter;

--- a/blocks/checkout-progress/checkout-progress.css
+++ b/blocks/checkout-progress/checkout-progress.css
@@ -12,6 +12,8 @@
 .checkout-progress ol {
   display: flex;
   align-items: center;
+  width: 100%;
+  max-width: 560px;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -26,11 +28,12 @@
   color: var(--commerce-color-text-muted);
 }
 
-/* Connector line between steps */
+/* Connector line between steps — flexes to fill the space within its step */
 .checkout-progress .step + .step::before {
   content: '';
   display: block;
-  width: 48px;
+  flex: 1;
+  min-width: 24px;
   height: 2px;
   background: var(--commerce-step-color-inactive);
   margin: 0 12px;
@@ -100,4 +103,10 @@
 
 .checkout-progress .step-complete a:hover {
   text-decoration: underline;
+}
+
+/* Steps after the first grow so the connector line between them stretches,
+   giving an evenly-spaced bar instead of a small cluster lost in a wide row. */
+.checkout-progress .step + .step {
+  flex: 1;
 }

--- a/blocks/checkout-progress/checkout-progress.css
+++ b/blocks/checkout-progress/checkout-progress.css
@@ -3,6 +3,14 @@
   width: 100%;
 }
 
+/* The step indicator doesn't lay out cleanly on small screens — hide it on
+   mobile and let the page lead with the cart/checkout content. */
+@media (width <= 600px) {
+  .checkout-progress-wrapper {
+    display: none;
+  }
+}
+
 .checkout-progress nav {
   padding: 16px 0;
 }

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -102,37 +102,23 @@ main > .section:has(.checkout-wrapper) {
   max-width: 100%;
 }
 
-/* All buttons share one row at wide sizes — div covers SDK iframes, button covers stubs */
+/* PayPal and Pay Later share the second row as two equal columns. When only
+   one of them is present it expands to fill the full row. div covers SDK
+   iframes, button covers stubs. */
+.express-checkout-buttons > .paypal-paypal-wrapper,
+.express-checkout-buttons > .paypal-paylater-wrapper,
 .express-checkout-buttons > div,
 .express-checkout-buttons > button {
-  flex: 1;
+  flex: 1 1 0;
   min-width: 0;
   display: flex;
   height: 55px;
 }
 
-/* Stub Pay Later button fills its wrapper in the default (wide) state */
+/* Stub PayPal / Pay Later buttons fill their wrapper. */
+.paypal-paypal-wrapper .paypal-express-btn,
 .paypal-paylater-wrapper .paypal-express-btn {
   height: 55px;
-}
-
-/* Pay Later drops to a full-width second row when space is tight */
-@container (max-width: 480px) {
-  .express-checkout-buttons > .paypal-paylater-wrapper {
-    flex: 0 0 100%;
-  }
-}
-
-@media (width >= 1118px) and (width <= 1250px) {
-  .express-checkout-buttons > .paypal-paylater-wrapper {
-    flex: 0 0 100%;
-  }
-}
-
-@media (width >= 610px) and (width <= 714px) {
-  .express-checkout-buttons > .paypal-paylater-wrapper {
-    flex: 0 0 100%;
-  }
 }
 
 .express-checkout-divider {
@@ -689,6 +675,10 @@ main > .section:has(.checkout-wrapper) {
 
 /* Apple Pay */
 apple-pay-button {
+  /* Inside the express-checkout flex row Apple Pay takes its own full-width
+     row on top, leaving PayPal + Pay Later to share the second row. */
+  flex: 0 0 100%;
+
   --apple-pay-button-width: 100%;
   --apple-pay-button-height: 55px;
   --apple-pay-button-border-radius: var(--commerce-button-radius);

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -684,7 +684,6 @@ apple-pay-button {
   --apple-pay-button-border-radius: var(--commerce-button-radius);
   --apple-pay-button-padding: 0;
 
-  flex: 1;
   min-width: 0;
   display: block;
 }

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -102,28 +102,27 @@ main > .section:has(.checkout-wrapper) {
   max-width: 100%;
 }
 
-/* PayPal and Pay Later share the second row as two equal columns. When only
-   one of them is present it expands to fill the full row. div covers SDK
-   iframes, button covers stubs. */
+/* Base (narrow / mobile): every button stacked full-width. PayPal SDK iframes
+   have a minimum width, so two columns would overflow in a tight container.
+   div covers SDK iframes, button covers stubs. */
 .express-checkout-buttons > .paypal-paypal-wrapper,
 .express-checkout-buttons > .paypal-paylater-wrapper,
 .express-checkout-buttons > div,
 .express-checkout-buttons > button {
-  flex: 1 1 0;
+  flex: 0 0 100%;
   min-width: 0;
   display: flex;
   height: 55px;
 }
 
-/* Below ~420px there isn't room for two PayPal buttons side by side — their
-   SDK iframes have a minimum width and would overflow the gap. Stack all
-   buttons full-width vertically instead. */
-@container (max-width: 420px) {
+/* Tablet (>=420px): PayPal + Pay Later become two columns. Apple Pay stays on
+   its own full-width row above them (see apple-pay-button rule below). */
+@container (min-width: 420px) {
   .express-checkout-buttons > .paypal-paypal-wrapper,
   .express-checkout-buttons > .paypal-paylater-wrapper,
   .express-checkout-buttons > div,
   .express-checkout-buttons > button {
-    flex: 0 0 100%;
+    flex: 1 1 0;
   }
 }
 
@@ -687,8 +686,9 @@ main > .section:has(.checkout-wrapper) {
 
 /* Apple Pay */
 apple-pay-button {
-  /* Inside the express-checkout flex row Apple Pay takes its own full-width
-     row on top, leaving PayPal + Pay Later to share the second row. */
+  /* In the express-checkout row Apple Pay takes its own full-width row on top
+     at narrow/tablet widths, leaving PayPal + Pay Later to share the row below.
+     On desktop it joins the single row (see container query below). */
   flex: 0 0 100%;
 
   --apple-pay-button-width: 100%;
@@ -698,6 +698,15 @@ apple-pay-button {
 
   min-width: 0;
   display: block;
+}
+
+/* Desktop (>=620px): Apple Pay joins the row so all three express buttons sit
+   side by side. Keyed to the bare selector (placed after the base rule) to
+   avoid a descending-specificity conflict with it. */
+@container (min-width: 620px) {
+  apple-pay-button {
+    flex: 1 1 0;
+  }
 }
 
 

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -115,6 +115,18 @@ main > .section:has(.checkout-wrapper) {
   height: 55px;
 }
 
+/* Below ~420px there isn't room for two PayPal buttons side by side — their
+   SDK iframes have a minimum width and would overflow the gap. Stack all
+   buttons full-width vertically instead. */
+@container (max-width: 420px) {
+  .express-checkout-buttons > .paypal-paypal-wrapper,
+  .express-checkout-buttons > .paypal-paylater-wrapper,
+  .express-checkout-buttons > div,
+  .express-checkout-buttons > button {
+    flex: 0 0 100%;
+  }
+}
+
 /* Stub PayPal / Pay Later buttons fill their wrapper. */
 .paypal-paypal-wrapper .paypal-express-btn,
 .paypal-paylater-wrapper .paypal-express-btn {

--- a/blocks/order-summary/order-summary.css
+++ b/blocks/order-summary/order-summary.css
@@ -143,7 +143,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 20px 24px 12px;
+  padding: 20px 24px;
   border-bottom: 1px solid var(--commerce-color-border);
   transition: border-bottom-color 0.35s ease;
 }

--- a/blocks/order-summary/order-summary.css
+++ b/blocks/order-summary/order-summary.css
@@ -15,6 +15,14 @@
   padding-block-start: 10px;
 }
 
+/* The progress bar is hidden on mobile, so add back some breathing room
+   above the summary. */
+@media (width <= 600px) {
+  .section:has(.order-summary-wrapper):has(.checkout-progress-wrapper) {
+    padding-block-start: 20px;
+  }
+}
+
 .section:has(.order-summary-wrapper) > .default-content-wrapper h1 {
   margin-top: 0;
   padding-top: 0;

--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -123,9 +123,12 @@ export default {
     if (!window.paypal) {
       // No SDK — stub buttons with localized Pay Later label
       const label = getPayLaterLabel(callbacks.getConfig().getLanguage());
+      const paypalWrapper = document.createElement('div');
+      paypalWrapper.className = 'paypal-paypal-wrapper';
       const paypalBtn = createButton(PAYPAL_WORDMARK, 'paypal-express-btn');
       paypalBtn.addEventListener('click', showNotConfiguredDialog);
-      container.appendChild(paypalBtn);
+      paypalWrapper.appendChild(paypalBtn);
+      container.appendChild(paypalWrapper);
 
       const payLaterWrapper = document.createElement('div');
       payLaterWrapper.className = 'paypal-paylater-wrapper';
@@ -149,7 +152,7 @@ export default {
 
     const buttonConfig = {
       style: {
-        layout: 'horizontal',
+        layout: 'vertical',
         color: 'gold',
         shape: 'rect',
         label: 'paypal',
@@ -313,7 +316,29 @@ export default {
       },
     };
 
-    window.paypal.Buttons(buttonConfig).render(container);
+    // Render PayPal and Pay Later as two separate funding-source buttons,
+    // each in its own wrapper, so layout is controlled by CSS. Rendering a
+    // single horizontal button and relying on enable-funding=paylater caused
+    // PayPal's SDK to silently drop the Pay Later button at narrow (mobile)
+    // widths. Two explicit funding sources always render when eligible.
+    const paypalWrapper = document.createElement('div');
+    paypalWrapper.className = 'paypal-paypal-wrapper';
+    container.appendChild(paypalWrapper);
+    window.paypal.Buttons({
+      ...buttonConfig,
+      fundingSource: window.paypal.FUNDING.PAYPAL,
+    }).render(paypalWrapper);
+
+    const payLaterButtons = window.paypal.Buttons({
+      ...buttonConfig,
+      fundingSource: window.paypal.FUNDING.PAYLATER,
+    });
+    if (payLaterButtons.isEligible()) {
+      const payLaterWrapper = document.createElement('div');
+      payLaterWrapper.className = 'paypal-paylater-wrapper';
+      container.appendChild(payLaterWrapper);
+      payLaterButtons.render(payLaterWrapper);
+    }
   },
 
   renderCheckoutButton(container, callbacks) {

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -574,18 +574,65 @@ test.describe('SDK load parameters', () => {
 
 test.describe('button style config', () => {
   const BASE_STYLE = {
-    layout: 'horizontal', color: 'gold', shape: 'rect', label: 'paypal', disableMaxHeight: true,
+    layout: 'vertical', color: 'gold', shape: 'rect', label: 'paypal', tagline: false, height: 55,
   };
 
-  test('primary button has gold color, paypal label, and horizontal layout', () => {
+  test('primary button has gold color, paypal label, and vertical layout', () => {
     expect(BASE_STYLE.color).toBe('gold');
     expect(BASE_STYLE.label).toBe('paypal');
-    expect(BASE_STYLE.layout).toBe('horizontal');
+    expect(BASE_STYLE.layout).toBe('vertical');
   });
 });
 
-// Pay Later is included automatically by the horizontal layout when eligible
-// (via enable-funding=paylater in the SDK URL) — no separate button is rendered.
+// PayPal and Pay Later are rendered as two separate funding-source buttons
+// (FUNDING.PAYPAL and FUNDING.PAYLATER), each in its own wrapper. The Pay Later
+// button is only rendered when its Buttons instance reports isEligible(). This
+// guarantees Pay Later still appears at narrow (mobile) widths, where a single
+// horizontal button would otherwise drop it.
+
+test.describe('separate funding-source buttons', () => {
+  function renderSdkButtons(windowPaypal, container) {
+    const buttonConfig = { style: { layout: 'vertical' } };
+    const paypalWrapper = { className: 'paypal-paypal-wrapper' };
+    container.children.push(paypalWrapper);
+    windowPaypal.Buttons({ ...buttonConfig, fundingSource: 'paypal' }).render(paypalWrapper);
+
+    const payLater = windowPaypal.Buttons({ ...buttonConfig, fundingSource: 'paylater' });
+    if (payLater.isEligible()) {
+      const payLaterWrapper = { className: 'paypal-paylater-wrapper' };
+      container.children.push(payLaterWrapper);
+      payLater.render(payLaterWrapper);
+    }
+  }
+
+  test('renders Pay Later wrapper when the Pay Later button is eligible', () => {
+    const fundingSources = [];
+    const container = { children: [] };
+    const mockPaypal = {
+      FUNDING: { PAYPAL: 'paypal', PAYLATER: 'paylater' },
+      Buttons: (cfg) => {
+        fundingSources.push(cfg.fundingSource);
+        return { render: () => {}, isEligible: () => true };
+      },
+    };
+    renderSdkButtons(mockPaypal, container);
+    expect(fundingSources).toContain('paypal');
+    expect(fundingSources).toContain('paylater');
+    expect(container.children.map((c) => c.className)).toContain('paypal-paylater-wrapper');
+  });
+
+  test('skips Pay Later wrapper when the Pay Later button is not eligible', () => {
+    const container = { children: [] };
+    const mockPaypal = {
+      FUNDING: { PAYPAL: 'paypal', PAYLATER: 'paylater' },
+      Buttons: () => ({ render: () => {}, isEligible: () => false }),
+    };
+    renderSdkButtons(mockPaypal, container);
+    const classes = container.children.map((c) => c.className);
+    expect(classes).toContain('paypal-paypal-wrapper');
+    expect(classes).not.toContain('paypal-paylater-wrapper');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Stub fallback (no window.paypal)


### PR DESCRIPTION
Render PayPal and Pay Later as separate funding-source buttons (each in its own wrapper) so the Pay Later button stays visible at narrow widths, where PayPal's SDK previously dropped it from a single horizontal render. Express buttons now lay out as Apple Pay full-width on top, with PayPal + Pay Later as two columns below.

fixes: #541

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/
- After: https://pay-later-fix--vitamix--aemsites.aem.page/
