### PR TITLE
feat(checkout): validate addresses with AddressDoctor

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -1,3 +1,4 @@
+import { logOperation } from '../../scripts/operations-log.js';
 import { validateField } from './checkout-validation.js';
 
 const US_STATES = [
@@ -218,6 +219,105 @@ export async function callValidateAddress(apiOrigin, payload, sessionToken) {
 
   if (!resp.ok) throw new Error(`address validation failed: ${resp.status}`);
   return resp.json();
+}
+
+function getComponentMap(result) {
+  const map = {};
+  result?.addressComponents?.forEach((component) => {
+    component.types?.forEach((type) => { map[type] = component; });
+  });
+  return map;
+}
+
+function normalizedComponentValue(map, type, field = 'longText') {
+  return (map[type]?.[field] || '').toString().trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function normalizedResultParts(result) {
+  const map = getComponentMap(result);
+  const street = [
+    normalizedComponentValue(map, 'street_number'),
+    normalizedComponentValue(map, 'route'),
+  ].filter(Boolean).join(' ');
+  const postalCode = normalizedComponentValue(map, 'postal_code');
+  const postalSuffix = normalizedComponentValue(map, 'postal_code_suffix');
+  return {
+    action: result?.action || '',
+    formattedAddress: (result?.formattedAddress || '').toString().trim().toLowerCase().replace(/\s+/g, ' '),
+    uspsDeliverable: result?.uspsDeliverable,
+    street,
+    unit: normalizedComponentValue(map, 'subpremise'),
+    city: normalizedComponentValue(map, 'locality')
+      || normalizedComponentValue(map, 'sublocality')
+      || normalizedComponentValue(map, 'postal_town'),
+    state: normalizedComponentValue(map, 'administrative_area_level_1', 'shortText'),
+    postalCode: postalSuffix ? `${postalCode}-${postalSuffix}` : postalCode,
+    country: normalizedComponentValue(map, 'country', 'shortText'),
+  };
+}
+
+export function compareAddressValidationResults(google, addressDoctor) {
+  const googleParts = normalizedResultParts(google);
+  const addressDoctorParts = normalizedResultParts(addressDoctor);
+  const fields = [
+    'action',
+    'formattedAddress',
+    'uspsDeliverable',
+    'street',
+    'unit',
+    'city',
+    'state',
+    'postalCode',
+    'country',
+  ];
+  const mismatchFields = fields.filter((field) => googleParts[field] !== addressDoctorParts[field]);
+  return {
+    mismatch: mismatchFields.length > 0,
+    mismatchFields,
+    googleAction: google?.action || null,
+    addressDoctorAction: addressDoctor?.action || null,
+  };
+}
+
+export function logAddressValidationMismatch(comparison, country) {
+  logOperation('error', {
+    kind: 'address-validation-mismatch',
+    providerPrimary: 'addressdoctor',
+    providerCompared: 'google',
+    mismatchFields: comparison.mismatchFields,
+    googleAction: comparison.googleAction,
+    addressDoctorAction: comparison.addressDoctorAction,
+    country,
+  });
+}
+
+function localAddressDoctorFix() {
+  return {
+    provider: 'addressdoctor',
+    action: 'FIX',
+    formattedAddress: null,
+    addressComponents: null,
+    uspsDeliverable: false,
+  };
+}
+
+export async function callDualValidateAddress(config, payload, sessionToken) {
+  const [googleResult, addressDoctorResult] = await Promise.allSettled([
+    callValidateAddress(config.apiOrigin, payload, sessionToken),
+    callValidateAddress(config.addressDoctorOrigin, payload, null),
+  ]);
+
+  const google = googleResult.status === 'fulfilled' ? googleResult.value : null;
+  const addressDoctor = addressDoctorResult.status === 'fulfilled' ? addressDoctorResult.value : null;
+
+  if (google && addressDoctor) {
+    const comparison = compareAddressValidationResults(google, addressDoctor);
+    if (comparison.mismatch) {
+      logAddressValidationMismatch(comparison, payload.address?.regionCode || null);
+    }
+  }
+
+  return addressDoctor || localAddressDoctorFix();
 }
 
 /**
@@ -746,7 +846,7 @@ export async function validateAndCollapseAddress(
     let result;
     try {
       // eslint-disable-next-line no-await-in-loop
-      result = await callValidateAddress(config.apiOrigin, payload, getToken?.() ?? null);
+      result = await callDualValidateAddress(config, payload, getToken?.() ?? null);
     } catch {
       showAddressError(
         section,

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -221,61 +221,35 @@ export async function callValidateAddress(apiOrigin, payload, sessionToken) {
   return resp.json();
 }
 
-function getComponentMap(result) {
-  const map = {};
-  result?.addressComponents?.forEach((component) => {
-    component.types?.forEach((type) => { map[type] = component; });
-  });
-  return map;
-}
-
-function normalizedComponentValue(map, type, field = 'longText') {
-  return (map[type]?.[field] || '').toString().trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-function normalizedResultParts(result) {
-  const map = getComponentMap(result);
-  const street = [
-    normalizedComponentValue(map, 'street_number'),
-    normalizedComponentValue(map, 'route'),
-  ].filter(Boolean).join(' ');
-  const postalCode = normalizedComponentValue(map, 'postal_code');
-  const postalSuffix = normalizedComponentValue(map, 'postal_code_suffix');
-  return {
-    action: result?.action || '',
-    formattedAddress: (result?.formattedAddress || '').toString().trim().toLowerCase().replace(/\s+/g, ' '),
-    uspsDeliverable: result?.uspsDeliverable,
-    street,
-    unit: normalizedComponentValue(map, 'subpremise'),
-    city: normalizedComponentValue(map, 'locality')
-      || normalizedComponentValue(map, 'sublocality')
-      || normalizedComponentValue(map, 'postal_town'),
-    state: normalizedComponentValue(map, 'administrative_area_level_1', 'shortText'),
-    postalCode: postalSuffix ? `${postalCode}-${postalSuffix}` : postalCode,
-    country: normalizedComponentValue(map, 'country', 'shortText'),
-  };
+function validationOutcome(result) {
+  const action = result?.action || null;
+  if (action === 'FIX') return 'block';
+  if (action === 'CONFIRM_ADD_SUBPREMISES') return 'needs-subpremise';
+  if (action === 'ACCEPT' || action === 'CONFIRM') return 'pass';
+  return action ? 'review' : 'unknown';
 }
 
 export function compareAddressValidationResults(google, addressDoctor) {
-  const googleParts = normalizedResultParts(google);
-  const addressDoctorParts = normalizedResultParts(addressDoctor);
-  const fields = [
-    'action',
-    'formattedAddress',
-    'uspsDeliverable',
-    'street',
-    'unit',
-    'city',
-    'state',
-    'postalCode',
-    'country',
-  ];
-  const mismatchFields = fields.filter((field) => googleParts[field] !== addressDoctorParts[field]);
+  const googleOutcome = validationOutcome(google);
+  const addressDoctorOutcome = validationOutcome(addressDoctor);
+  const mismatchReasons = [];
+
+  if (googleOutcome !== addressDoctorOutcome) {
+    mismatchReasons.push('outcome');
+  }
+  if (typeof google?.uspsDeliverable === 'boolean'
+    && typeof addressDoctor?.uspsDeliverable === 'boolean'
+    && google.uspsDeliverable !== addressDoctor.uspsDeliverable) {
+    mismatchReasons.push('deliverability');
+  }
+
   return {
-    mismatch: mismatchFields.length > 0,
-    mismatchFields,
+    mismatch: mismatchReasons.length > 0,
+    mismatchReasons,
     googleAction: google?.action || null,
     addressDoctorAction: addressDoctor?.action || null,
+    googleOutcome,
+    addressDoctorOutcome,
   };
 }
 
@@ -284,9 +258,11 @@ export function logAddressValidationMismatch(comparison, country) {
     kind: 'address-validation-mismatch',
     providerPrimary: 'addressdoctor',
     providerCompared: 'google',
-    mismatchFields: comparison.mismatchFields,
+    mismatchReasons: comparison.mismatchReasons,
     googleAction: comparison.googleAction,
     addressDoctorAction: comparison.addressDoctorAction,
+    googleOutcome: comparison.googleOutcome,
+    addressDoctorOutcome: comparison.addressDoctorOutcome,
     country,
   });
 }

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -237,11 +237,6 @@ export function compareAddressValidationResults(google, addressDoctor) {
   if (googleOutcome !== addressDoctorOutcome) {
     mismatchReasons.push('outcome');
   }
-  if (typeof google?.uspsDeliverable === 'boolean'
-    && typeof addressDoctor?.uspsDeliverable === 'boolean'
-    && google.uspsDeliverable !== addressDoctor.uspsDeliverable) {
-    mismatchReasons.push('deliverability');
-  }
 
   return {
     mismatch: mismatchReasons.length > 0,

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -27,6 +27,7 @@ const defaults = {
     return page ? `${base}/${page}` : base;
   },
   currency: (locale) => (locale === 'ca' ? 'CAD' : 'USD'),
+  addressDoctorOrigin: 'https://vitamix-address-doctor-proxy-worker.adobeaem.workers.dev',
   cardProvider: 'chase',
   maxCartQty: 3,
   affirmMinOrderTotal: 50,

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -50,6 +50,108 @@ async function callValidateAddress(apiOrigin, payload, sessionToken, fetchFn = f
 }
 
 // ---------------------------------------------------------------------------
+// Inlined dual validation comparison helpers
+// ---------------------------------------------------------------------------
+
+function getComponentMap(result) {
+  const map = {};
+  result?.addressComponents?.forEach((component) => {
+    component.types?.forEach((type) => { map[type] = component; });
+  });
+  return map;
+}
+
+function normalizedComponentValue(map, type, field = 'longText') {
+  return (map[type]?.[field] || '').toString().trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function normalizedResultParts(result) {
+  const map = getComponentMap(result);
+  const street = [
+    normalizedComponentValue(map, 'street_number'),
+    normalizedComponentValue(map, 'route'),
+  ].filter(Boolean).join(' ');
+  const postalCode = normalizedComponentValue(map, 'postal_code');
+  const postalSuffix = normalizedComponentValue(map, 'postal_code_suffix');
+  return {
+    action: result?.action || '',
+    formattedAddress: (result?.formattedAddress || '').toString().trim().toLowerCase().replace(/\s+/g, ' '),
+    uspsDeliverable: result?.uspsDeliverable,
+    street,
+    unit: normalizedComponentValue(map, 'subpremise'),
+    city: normalizedComponentValue(map, 'locality')
+      || normalizedComponentValue(map, 'sublocality')
+      || normalizedComponentValue(map, 'postal_town'),
+    state: normalizedComponentValue(map, 'administrative_area_level_1', 'shortText'),
+    postalCode: postalSuffix ? `${postalCode}-${postalSuffix}` : postalCode,
+    country: normalizedComponentValue(map, 'country', 'shortText'),
+  };
+}
+
+function compareAddressValidationResults(google, addressDoctor) {
+  const googleParts = normalizedResultParts(google);
+  const addressDoctorParts = normalizedResultParts(addressDoctor);
+  const fields = [
+    'action',
+    'formattedAddress',
+    'uspsDeliverable',
+    'street',
+    'unit',
+    'city',
+    'state',
+    'postalCode',
+    'country',
+  ];
+  const mismatchFields = fields.filter((field) => googleParts[field] !== addressDoctorParts[field]);
+  return {
+    mismatch: mismatchFields.length > 0,
+    mismatchFields,
+    googleAction: google?.action || null,
+    addressDoctorAction: addressDoctor?.action || null,
+  };
+}
+
+function localAddressDoctorFix() {
+  return {
+    provider: 'addressdoctor',
+    action: 'FIX',
+    formattedAddress: null,
+    addressComponents: null,
+    uspsDeliverable: false,
+  };
+}
+
+async function callDualValidateAddress(cfg, body, token, fetchFn = fetch, logFn = () => {}) {
+  async function call(apiOrigin, sessionToken) {
+    return callValidateAddress(apiOrigin, body, sessionToken, fetchFn);
+  }
+  const [googleResult, addressDoctorResult] = await Promise.allSettled([
+    call(cfg.apiOrigin, token),
+    call(cfg.addressDoctorOrigin, null),
+  ]);
+
+  const google = googleResult.status === 'fulfilled' ? googleResult.value : null;
+  const addressDoctor = addressDoctorResult.status === 'fulfilled' ? addressDoctorResult.value : null;
+
+  if (google && addressDoctor) {
+    const comparison = compareAddressValidationResults(google, addressDoctor);
+    if (comparison.mismatch) {
+      logFn('error', {
+        kind: 'address-validation-mismatch',
+        providerPrimary: 'addressdoctor',
+        providerCompared: 'google',
+        mismatchFields: comparison.mismatchFields,
+        googleAction: comparison.googleAction,
+        addressDoctorAction: comparison.addressDoctorAction,
+        country: body.address?.regionCode || null,
+      });
+    }
+  }
+
+  return addressDoctor || localAddressDoctorFix();
+}
+
+// ---------------------------------------------------------------------------
 // buildAddressPayload tests
 // ---------------------------------------------------------------------------
 
@@ -135,10 +237,11 @@ test.describe('buildAddressPayload', () => {
 // callValidateAddress tests
 // ---------------------------------------------------------------------------
 
-test.describe('callValidateAddress', () => {
-  const apiOrigin = 'https://api.adobecommerce.live/org/sites/site';
-  const payload = { address: { regionCode: 'US', addressLines: ['123 Main St', 'Springfield, IL 62701'] } };
+const apiOrigin = 'https://api.adobecommerce.live/org/sites/site';
+const addressDoctorOrigin = 'https://vitamix-address-doctor-proxy-worker.adobeaem.workers.dev';
+const payload = { address: { regionCode: 'US', addressLines: ['123 Main St', 'Springfield, IL 62701'] } };
 
+test.describe('callValidateAddress', () => {
   test('POSTs to the correct URL', async () => {
     let capturedUrl;
     const fetchFn = async (url) => {
@@ -231,6 +334,167 @@ test.describe('callValidateAddress', () => {
 
     await expect(callValidateAddress(apiOrigin, payload, null, fetchFn))
       .rejects.toThrow('network error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dual validation tests
+// ---------------------------------------------------------------------------
+
+test.describe('callDualValidateAddress', () => {
+  const googleAccept = {
+    action: 'ACCEPT',
+    formattedAddress: '123 Main St, Springfield, IL 62701',
+    addressComponents: [
+      { longText: '123', shortText: '123', types: ['street_number'] },
+      { longText: 'Main St', shortText: 'Main St', types: ['route'] },
+      { longText: 'Springfield', shortText: 'Springfield', types: ['locality'] },
+      { longText: 'IL', shortText: 'IL', types: ['administrative_area_level_1'] },
+      { longText: '62701', shortText: '62701', types: ['postal_code'] },
+      { longText: 'US', shortText: 'US', types: ['country'] },
+    ],
+    uspsDeliverable: true,
+  };
+
+  const addressDoctorConfirm = {
+    provider: 'addressdoctor',
+    action: 'CONFIRM',
+    formattedAddress: '123 Main St, Springfield IL 62701-0001',
+    addressComponents: [
+      { longText: '123', shortText: '123', types: ['street_number'] },
+      { longText: 'Main St', shortText: 'Main St', types: ['route'] },
+      { longText: 'Springfield', shortText: 'Springfield', types: ['locality'] },
+      { longText: 'Illinois', shortText: 'IL', types: ['administrative_area_level_1'] },
+      { longText: '62701-0001', shortText: '62701-0001', types: ['postal_code'] },
+      { longText: 'US', shortText: 'US', types: ['country'] },
+    ],
+    uspsDeliverable: true,
+  };
+
+  test('uses AddressDoctor result when both providers succeed', async () => {
+    const urls = [];
+    const fetchFn = async (url) => {
+      urls.push(url);
+      return {
+        ok: true,
+        json: async () => {
+          if (url.startsWith(addressDoctorOrigin)) return addressDoctorConfirm;
+          return googleAccept;
+        },
+      };
+    };
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const result = await callDualValidateAddress(cfg, payload, 'tok-1', fetchFn);
+
+    expect(result).toEqual(addressDoctorConfirm);
+    expect(urls[0]).toContain(`${apiOrigin}/places/validate?sessiontoken=tok-1`);
+    expect(urls[1]).toBe(`${addressDoctorOrigin}/places/validate`);
+  });
+
+  test('logs non-PII mismatch metadata when providers differ', async () => {
+    const logs = [];
+    const fetchFn = async (url) => ({
+      ok: true,
+      json: async () => {
+        if (url.startsWith(addressDoctorOrigin)) return addressDoctorConfirm;
+        return googleAccept;
+      },
+    });
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const logFn = (...args) => logs.push(args);
+    await callDualValidateAddress(cfg, payload, null, fetchFn, logFn);
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0][0]).toBe('error');
+    expect(logs[0][1]).toEqual(expect.objectContaining({
+      kind: 'address-validation-mismatch',
+      providerPrimary: 'addressdoctor',
+      providerCompared: 'google',
+      googleAction: 'ACCEPT',
+      addressDoctorAction: 'CONFIRM',
+      country: 'US',
+    }));
+    expect(logs[0][1].mismatchFields)
+      .toEqual(expect.arrayContaining(['action', 'formattedAddress', 'postalCode']));
+    expect(JSON.stringify(logs[0][1])).not.toContain('Springfield IL 62701-0001');
+  });
+
+  test('does not log when normalized provider results match', async () => {
+    const logs = [];
+    const fetchFn = async () => ({ ok: true, json: async () => googleAccept });
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const logFn = (...args) => logs.push(args);
+    const result = await callDualValidateAddress(cfg, payload, null, fetchFn, logFn);
+
+    expect(result).toEqual(googleAccept);
+    expect(logs).toHaveLength(0);
+  });
+
+  test('uses AddressDoctor when Google validation fails', async () => {
+    const fetchFn = async (url) => {
+      if (url.startsWith(apiOrigin)) throw new Error('google down');
+      return { ok: true, json: async () => addressDoctorConfirm };
+    };
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const result = await callDualValidateAddress(cfg, payload, null, fetchFn);
+
+    expect(result).toEqual(addressDoctorConfirm);
+  });
+
+  test('returns local FIX when AddressDoctor validation fails', async () => {
+    const fetchFn = async (url) => {
+      if (url.startsWith(addressDoctorOrigin)) throw new Error('addressdoctor down');
+      return { ok: true, json: async () => googleAccept };
+    };
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const result = await callDualValidateAddress(cfg, payload, null, fetchFn);
+
+    expect(result).toEqual({
+      provider: 'addressdoctor',
+      action: 'FIX',
+      formattedAddress: null,
+      addressComponents: null,
+      uspsDeliverable: false,
+    });
+  });
+});
+
+test.describe('compareAddressValidationResults', () => {
+  test('compares sublocality, postal suffix, unit, country, and missing actions', () => {
+    const google = {
+      addressComponents: [
+        { longText: '1', shortText: '1', types: ['street_number'] },
+        { longText: 'Main', shortText: 'Main', types: ['route'] },
+        { longText: 'Brooklyn', shortText: 'Brooklyn', types: ['sublocality'] },
+        { longText: 'NY', shortText: 'NY', types: ['administrative_area_level_1'] },
+        { longText: '11201', shortText: '11201', types: ['postal_code'] },
+        { longText: '1234', shortText: '1234', types: ['postal_code_suffix'] },
+        { longText: '4B', shortText: '4B', types: ['subpremise'] },
+        { longText: 'United States', shortText: 'US', types: ['country'] },
+      ],
+    };
+    const addressDoctor = {
+      action: 'CONFIRM',
+      addressComponents: [
+        { longText: '1', shortText: '1', types: ['street_number'] },
+        { longText: 'Main', shortText: 'Main', types: ['route'] },
+        { longText: 'Brooklyn', shortText: 'Brooklyn', types: ['postal_town'] },
+        { longText: 'NY', shortText: 'NY', types: ['administrative_area_level_1'] },
+        { longText: '11201-1234', shortText: '11201-1234', types: ['postal_code'] },
+        { longText: '5C', shortText: '5C', types: ['subpremise'] },
+        { longText: 'US', shortText: 'US', types: ['country'] },
+      ],
+    };
+
+    const result = compareAddressValidationResults(google, addressDoctor);
+    expect(result.mismatch).toBe(true);
+    expect(result.mismatchFields).toEqual(expect.arrayContaining(['action', 'unit']));
+    expect(result.googleAction).toBe(null);
+    expect(result.addressDoctorAction).toBe('CONFIRM');
   });
 });
 

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -53,61 +53,35 @@ async function callValidateAddress(apiOrigin, payload, sessionToken, fetchFn = f
 // Inlined dual validation comparison helpers
 // ---------------------------------------------------------------------------
 
-function getComponentMap(result) {
-  const map = {};
-  result?.addressComponents?.forEach((component) => {
-    component.types?.forEach((type) => { map[type] = component; });
-  });
-  return map;
-}
-
-function normalizedComponentValue(map, type, field = 'longText') {
-  return (map[type]?.[field] || '').toString().trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-function normalizedResultParts(result) {
-  const map = getComponentMap(result);
-  const street = [
-    normalizedComponentValue(map, 'street_number'),
-    normalizedComponentValue(map, 'route'),
-  ].filter(Boolean).join(' ');
-  const postalCode = normalizedComponentValue(map, 'postal_code');
-  const postalSuffix = normalizedComponentValue(map, 'postal_code_suffix');
-  return {
-    action: result?.action || '',
-    formattedAddress: (result?.formattedAddress || '').toString().trim().toLowerCase().replace(/\s+/g, ' '),
-    uspsDeliverable: result?.uspsDeliverable,
-    street,
-    unit: normalizedComponentValue(map, 'subpremise'),
-    city: normalizedComponentValue(map, 'locality')
-      || normalizedComponentValue(map, 'sublocality')
-      || normalizedComponentValue(map, 'postal_town'),
-    state: normalizedComponentValue(map, 'administrative_area_level_1', 'shortText'),
-    postalCode: postalSuffix ? `${postalCode}-${postalSuffix}` : postalCode,
-    country: normalizedComponentValue(map, 'country', 'shortText'),
-  };
+function validationOutcome(result) {
+  const action = result?.action || null;
+  if (action === 'FIX') return 'block';
+  if (action === 'CONFIRM_ADD_SUBPREMISES') return 'needs-subpremise';
+  if (action === 'ACCEPT' || action === 'CONFIRM') return 'pass';
+  return action ? 'review' : 'unknown';
 }
 
 function compareAddressValidationResults(google, addressDoctor) {
-  const googleParts = normalizedResultParts(google);
-  const addressDoctorParts = normalizedResultParts(addressDoctor);
-  const fields = [
-    'action',
-    'formattedAddress',
-    'uspsDeliverable',
-    'street',
-    'unit',
-    'city',
-    'state',
-    'postalCode',
-    'country',
-  ];
-  const mismatchFields = fields.filter((field) => googleParts[field] !== addressDoctorParts[field]);
+  const googleOutcome = validationOutcome(google);
+  const addressDoctorOutcome = validationOutcome(addressDoctor);
+  const mismatchReasons = [];
+
+  if (googleOutcome !== addressDoctorOutcome) {
+    mismatchReasons.push('outcome');
+  }
+  if (typeof google?.uspsDeliverable === 'boolean'
+    && typeof addressDoctor?.uspsDeliverable === 'boolean'
+    && google.uspsDeliverable !== addressDoctor.uspsDeliverable) {
+    mismatchReasons.push('deliverability');
+  }
+
   return {
-    mismatch: mismatchFields.length > 0,
-    mismatchFields,
+    mismatch: mismatchReasons.length > 0,
+    mismatchReasons,
     googleAction: google?.action || null,
     addressDoctorAction: addressDoctor?.action || null,
+    googleOutcome,
+    addressDoctorOutcome,
   };
 }
 
@@ -140,9 +114,11 @@ async function callDualValidateAddress(cfg, body, token, fetchFn = fetch, logFn 
         kind: 'address-validation-mismatch',
         providerPrimary: 'addressdoctor',
         providerCompared: 'google',
-        mismatchFields: comparison.mismatchFields,
+        mismatchReasons: comparison.mismatchReasons,
         googleAction: comparison.googleAction,
         addressDoctorAction: comparison.addressDoctorAction,
+        googleOutcome: comparison.googleOutcome,
+        addressDoctorOutcome: comparison.addressDoctorOutcome,
         country: body.address?.regionCode || null,
       });
     }
@@ -392,12 +368,17 @@ test.describe('callDualValidateAddress', () => {
     expect(urls[1]).toBe(`${addressDoctorOrigin}/places/validate`);
   });
 
-  test('logs non-PII mismatch metadata when providers differ', async () => {
+  test('logs concise non-PII mismatch metadata when provider outcomes differ', async () => {
     const logs = [];
+    const addressDoctorFix = {
+      ...addressDoctorConfirm,
+      action: 'FIX',
+      uspsDeliverable: false,
+    };
     const fetchFn = async (url) => ({
       ok: true,
       json: async () => {
-        if (url.startsWith(addressDoctorOrigin)) return addressDoctorConfirm;
+        if (url.startsWith(addressDoctorOrigin)) return addressDoctorFix;
         return googleAccept;
       },
     });
@@ -408,20 +389,22 @@ test.describe('callDualValidateAddress', () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0][0]).toBe('error');
-    expect(logs[0][1]).toEqual(expect.objectContaining({
+    expect(logs[0][1]).toEqual({
       kind: 'address-validation-mismatch',
       providerPrimary: 'addressdoctor',
       providerCompared: 'google',
+      mismatchReasons: ['outcome', 'deliverability'],
       googleAction: 'ACCEPT',
-      addressDoctorAction: 'CONFIRM',
+      addressDoctorAction: 'FIX',
+      googleOutcome: 'pass',
+      addressDoctorOutcome: 'block',
       country: 'US',
-    }));
-    expect(logs[0][1].mismatchFields)
-      .toEqual(expect.arrayContaining(['action', 'formattedAddress', 'postalCode']));
+    });
+    expect(logs[0][1]).not.toHaveProperty('mismatchFields');
     expect(JSON.stringify(logs[0][1])).not.toContain('Springfield IL 62701-0001');
   });
 
-  test('does not log when normalized provider results match', async () => {
+  test('does not log when provider outcomes match', async () => {
     const logs = [];
     const fetchFn = async () => ({ ok: true, json: async () => googleAccept });
     const cfg = { apiOrigin, addressDoctorOrigin };
@@ -464,37 +447,43 @@ test.describe('callDualValidateAddress', () => {
 });
 
 test.describe('compareAddressValidationResults', () => {
-  test('compares sublocality, postal suffix, unit, country, and missing actions', () => {
+  test('compares checkout outcomes instead of formatting differences', () => {
     const google = {
-      addressComponents: [
-        { longText: '1', shortText: '1', types: ['street_number'] },
-        { longText: 'Main', shortText: 'Main', types: ['route'] },
-        { longText: 'Brooklyn', shortText: 'Brooklyn', types: ['sublocality'] },
-        { longText: 'NY', shortText: 'NY', types: ['administrative_area_level_1'] },
-        { longText: '11201', shortText: '11201', types: ['postal_code'] },
-        { longText: '1234', shortText: '1234', types: ['postal_code_suffix'] },
-        { longText: '4B', shortText: '4B', types: ['subpremise'] },
-        { longText: 'United States', shortText: 'US', types: ['country'] },
-      ],
+      action: 'ACCEPT',
+      formattedAddress: '1 Main St, Brooklyn NY 11201',
+      uspsDeliverable: true,
     };
     const addressDoctor = {
       action: 'CONFIRM',
-      addressComponents: [
-        { longText: '1', shortText: '1', types: ['street_number'] },
-        { longText: 'Main', shortText: 'Main', types: ['route'] },
-        { longText: 'Brooklyn', shortText: 'Brooklyn', types: ['postal_town'] },
-        { longText: 'NY', shortText: 'NY', types: ['administrative_area_level_1'] },
-        { longText: '11201-1234', shortText: '11201-1234', types: ['postal_code'] },
-        { longText: '5C', shortText: '5C', types: ['subpremise'] },
-        { longText: 'US', shortText: 'US', types: ['country'] },
-      ],
+      formattedAddress: '1 Main Street, Brooklyn NY 11201-1234',
+      uspsDeliverable: true,
     };
 
     const result = compareAddressValidationResults(google, addressDoctor);
-    expect(result.mismatch).toBe(true);
-    expect(result.mismatchFields).toEqual(expect.arrayContaining(['action', 'unit']));
-    expect(result.googleAction).toBe(null);
-    expect(result.addressDoctorAction).toBe('CONFIRM');
+    expect(result).toEqual({
+      mismatch: false,
+      mismatchReasons: [],
+      googleAction: 'ACCEPT',
+      addressDoctorAction: 'CONFIRM',
+      googleOutcome: 'pass',
+      addressDoctorOutcome: 'pass',
+    });
+  });
+
+  test('reports outcome and deliverability mismatches', () => {
+    const result = compareAddressValidationResults(
+      { action: 'CONFIRM_ADD_SUBPREMISES', uspsDeliverable: true },
+      { action: 'FIX', uspsDeliverable: false },
+    );
+
+    expect(result).toEqual({
+      mismatch: true,
+      mismatchReasons: ['outcome', 'deliverability'],
+      googleAction: 'CONFIRM_ADD_SUBPREMISES',
+      addressDoctorAction: 'FIX',
+      googleOutcome: 'needs-subpremise',
+      addressDoctorOutcome: 'block',
+    });
   });
 });
 

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -69,11 +69,6 @@ function compareAddressValidationResults(google, addressDoctor) {
   if (googleOutcome !== addressDoctorOutcome) {
     mismatchReasons.push('outcome');
   }
-  if (typeof google?.uspsDeliverable === 'boolean'
-    && typeof addressDoctor?.uspsDeliverable === 'boolean'
-    && google.uspsDeliverable !== addressDoctor.uspsDeliverable) {
-    mismatchReasons.push('deliverability');
-  }
 
   return {
     mismatch: mismatchReasons.length > 0,
@@ -393,7 +388,7 @@ test.describe('callDualValidateAddress', () => {
       kind: 'address-validation-mismatch',
       providerPrimary: 'addressdoctor',
       providerCompared: 'google',
-      mismatchReasons: ['outcome', 'deliverability'],
+      mismatchReasons: ['outcome'],
       googleAction: 'ACCEPT',
       addressDoctorAction: 'FIX',
       googleOutcome: 'pass',
@@ -447,7 +442,7 @@ test.describe('callDualValidateAddress', () => {
 });
 
 test.describe('compareAddressValidationResults', () => {
-  test('compares checkout outcomes instead of formatting differences', () => {
+  test('compares checkout outcomes instead of formatting or deliverability differences', () => {
     const google = {
       action: 'ACCEPT',
       formattedAddress: '1 Main St, Brooklyn NY 11201',
@@ -456,7 +451,7 @@ test.describe('compareAddressValidationResults', () => {
     const addressDoctor = {
       action: 'CONFIRM',
       formattedAddress: '1 Main Street, Brooklyn NY 11201-1234',
-      uspsDeliverable: true,
+      uspsDeliverable: false,
     };
 
     const result = compareAddressValidationResults(google, addressDoctor);
@@ -470,7 +465,7 @@ test.describe('compareAddressValidationResults', () => {
     });
   });
 
-  test('reports outcome and deliverability mismatches', () => {
+  test('reports outcome mismatches', () => {
     const result = compareAddressValidationResults(
       { action: 'CONFIRM_ADD_SUBPREMISES', uspsDeliverable: true },
       { action: 'FIX', uspsDeliverable: false },
@@ -478,7 +473,7 @@ test.describe('compareAddressValidationResults', () => {
 
     expect(result).toEqual({
       mismatch: true,
-      mismatchReasons: ['outcome', 'deliverability'],
+      mismatchReasons: ['outcome'],
       googleAction: 'CONFIRM_ADD_SUBPREMISES',
       addressDoctorAction: 'FIX',
       googleOutcome: 'needs-subpremise',


### PR DESCRIPTION
Run Google and AddressDoctor validation in parallel while preserving the existing correction modal flow, logging non-PII mismatches, and using AddressDoctor as the authoritative checkout result.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://address-doctor-validation--vitamix--aemsites.aem.network/