### PR TITLE
fix(checkout): improve address validation context

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -135,7 +135,8 @@ function wireBillingToggle(form) {
 export function setAddressFieldValue(input, value) {
   input.value = value;
   clearFieldError(input);
-  input.dispatchEvent(new Event('input', { bubbles: true }));
+  // Dispatch change, but not input: the Places autocomplete listener is bound
+  // to input and should only open for user typing, not programmatic corrections.
   input.dispatchEvent(new Event('change', { bubbles: true }));
 }
 

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -1,5 +1,5 @@
 import { logOperation } from '../../scripts/operations-log.js';
-import { validateField } from './checkout-validation.js';
+import { clearFieldError, validateField } from './checkout-validation.js';
 
 const US_STATES = [
   ['AL', 'Alabama'], ['AK', 'Alaska'], ['AS', 'American Samoa'], ['AZ', 'Arizona'],
@@ -132,6 +132,13 @@ function wireBillingToggle(form) {
   updateBillingVisibility();
 }
 
+export function setAddressFieldValue(input, value) {
+  input.value = value;
+  clearFieldError(input);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
 function fillAddressFields(section, addressInput, addressComponents) {
   const c = {};
   addressComponents.forEach((comp) => {
@@ -142,24 +149,24 @@ function fillAddressFields(section, addressInput, addressComponents) {
   // Clearing an existing user-typed value can blank a required field and make the
   // section fail validation, which silently prevents collapse() from collapsing.
   const street = [c.street_number?.longText, c.route?.longText].filter(Boolean).join(' ');
-  if (street) addressInput.value = street;
+  if (street) setAddressFieldValue(addressInput, street);
 
   const address2Input = section.querySelector('[autocomplete="address-line2"]');
   if (address2Input && c.subpremise) {
-    address2Input.value = c.subpremise.longText;
+    setAddressFieldValue(address2Input, c.subpremise.longText);
   }
 
   const cityInput = section.querySelector('[autocomplete="address-level2"]');
   const cityValue = (c.locality || c.sublocality || c.postal_town)?.longText;
   if (cityInput && cityValue) {
-    cityInput.value = cityValue;
+    setAddressFieldValue(cityInput, cityValue);
   }
 
   const zipInput = section.querySelector('[autocomplete="postal-code"]');
   if (zipInput && c.postal_code?.longText) {
     const zip = c.postal_code.longText;
     const zipSuffix = c.postal_code_suffix?.longText || '';
-    zipInput.value = zipSuffix ? `${zip}-${zipSuffix}` : zip;
+    setAddressFieldValue(zipInput, zipSuffix ? `${zip}-${zipSuffix}` : zip);
   }
 
   // Set state last so FormData is complete when the change event triggers fetchAndPreview.

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -267,7 +267,10 @@ export function compareAddressValidationResults(google, addressDoctor) {
   const addressDoctorOutcome = validationOutcome(addressDoctor);
   const mismatchReasons = [];
 
-  if (googleOutcome !== addressDoctorOutcome) {
+  const expectedSubpremiseOverride = googleOutcome === 'needs-subpremise'
+    && addressDoctorOutcome === 'pass';
+
+  if (googleOutcome !== addressDoctorOutcome && !expectedSubpremiseOverride) {
     mismatchReasons.push('outcome');
   }
 

--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -221,6 +221,31 @@ export async function callValidateAddress(apiOrigin, payload, sessionToken) {
   return resp.json();
 }
 
+/**
+ * Builds a Google Places autocomplete query from the street field plus any
+ * locality fields the shopper has already entered. Google receives a single
+ * input string, so adding city/state/ZIP here gives the street lookup enough
+ * context to rank the intended address.
+ *
+ * @param {HTMLElement} section
+ * @param {string} addressValue
+ * @param {string} prefix
+ * @returns {string}
+ */
+export function buildPlacesAutocompleteInput(section, addressValue, prefix = 'shipping-') {
+  const line1 = addressValue.trim();
+  const city = section.querySelector(`[name="${prefix}city"]`)?.value?.trim() || '';
+  const stateSelect = section.querySelector(`[name="${prefix}state"]`);
+  const state = stateSelect?.selectedOptions?.[0]?.textContent?.trim()
+    || stateSelect?.value?.trim()
+    || '';
+  const zip = section.querySelector(`[name="${prefix}zip"]`)?.value?.trim() || '';
+
+  const stateZip = [state, zip].filter(Boolean).join(' ');
+  const locality = [city, stateZip].filter(Boolean).join(', ');
+  return [line1, locality].filter(Boolean).join(', ');
+}
+
 function validationOutcome(result) {
   const action = result?.action || null;
   if (action === 'FIX') return 'block';
@@ -285,6 +310,13 @@ export async function callDualValidateAddress(config, payload, sessionToken) {
     const comparison = compareAddressValidationResults(google, addressDoctor);
     if (comparison.mismatch) {
       logAddressValidationMismatch(comparison, payload.address?.regionCode || null);
+    }
+
+    // Google has the explicit US-only signal for a missing apartment/suite.
+    // Keep AddressDoctor primary for normal correction decisions, but preserve
+    // this add-unit flow unless AddressDoctor says the address should be fixed.
+    if (google.action === 'CONFIRM_ADD_SUBPREMISES' && addressDoctor.action !== 'FIX') {
+      return google;
     }
   }
 
@@ -908,6 +940,7 @@ function initPlacesAutocomplete(section, config) {
   if (!addressInput) return null;
 
   const regionCode = config.getLocale() === 'ca' ? 'CA' : 'US';
+  const prefix = addressInput.name.replace(/street-0$/, '');
 
   const wrapper = document.createElement('div');
   wrapper.className = 'places-autocomplete-wrapper';
@@ -978,7 +1011,9 @@ function initPlacesAutocomplete(section, config) {
     debounceTimer = setTimeout(async () => {
       try {
         const params = new URLSearchParams({
-          input: value, sessiontoken: sessionToken, regioncode: regionCode,
+          input: buildPlacesAutocompleteInput(section, value, prefix),
+          sessiontoken: sessionToken,
+          regioncode: regionCode,
         });
         const resp = await fetch(`${config.apiOrigin}/places/autocomplete?${params}`);
         if (!resp.ok) return;

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -66,7 +66,10 @@ function compareAddressValidationResults(google, addressDoctor) {
   const addressDoctorOutcome = validationOutcome(addressDoctor);
   const mismatchReasons = [];
 
-  if (googleOutcome !== addressDoctorOutcome) {
+  const expectedSubpremiseOverride = googleOutcome === 'needs-subpremise'
+    && addressDoctorOutcome === 'pass';
+
+  if (googleOutcome !== addressDoctorOutcome && !expectedSubpremiseOverride) {
     mismatchReasons.push('outcome');
   }
 
@@ -525,6 +528,22 @@ test.describe('compareAddressValidationResults', () => {
       addressDoctorAction: 'FIX',
       googleOutcome: 'needs-subpremise',
       addressDoctorOutcome: 'block',
+    });
+  });
+
+  test('does not report expected Google subpremise override as mismatch', () => {
+    const result = compareAddressValidationResults(
+      { action: 'CONFIRM_ADD_SUBPREMISES' },
+      { action: 'CONFIRM' },
+    );
+
+    expect(result).toEqual({
+      mismatch: false,
+      mismatchReasons: [],
+      googleAction: 'CONFIRM_ADD_SUBPREMISES',
+      addressDoctorAction: 'CONFIRM',
+      googleOutcome: 'needs-subpremise',
+      addressDoctorOutcome: 'pass',
     });
   });
 });

--- a/tests/checkout/checkout-address.spec.js
+++ b/tests/checkout/checkout-address.spec.js
@@ -117,6 +117,10 @@ async function callDualValidateAddress(cfg, body, token, fetchFn = fetch, logFn 
         country: body.address?.regionCode || null,
       });
     }
+
+    if (google.action === 'CONFIRM_ADD_SUBPREMISES' && addressDoctor.action !== 'FIX') {
+      return google;
+    }
   }
 
   return addressDoctor || localAddressDoctorFix();
@@ -408,6 +412,49 @@ test.describe('callDualValidateAddress', () => {
 
     expect(result).toEqual(googleAccept);
     expect(logs).toHaveLength(0);
+  });
+
+  test('preserves Google add-subpremise action when AddressDoctor does not reject', async () => {
+    const googleSubpremise = {
+      ...googleAccept,
+      action: 'CONFIRM_ADD_SUBPREMISES',
+    };
+    const fetchFn = async (url) => ({
+      ok: true,
+      json: async () => {
+        if (url.startsWith(addressDoctorOrigin)) return addressDoctorConfirm;
+        return googleSubpremise;
+      },
+    });
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const result = await callDualValidateAddress(cfg, payload, null, fetchFn);
+
+    expect(result).toEqual(googleSubpremise);
+  });
+
+  test('keeps AddressDoctor FIX over Google add-subpremise action', async () => {
+    const googleSubpremise = {
+      ...googleAccept,
+      action: 'CONFIRM_ADD_SUBPREMISES',
+    };
+    const addressDoctorFix = {
+      ...addressDoctorConfirm,
+      action: 'FIX',
+      uspsDeliverable: false,
+    };
+    const fetchFn = async (url) => ({
+      ok: true,
+      json: async () => {
+        if (url.startsWith(addressDoctorOrigin)) return addressDoctorFix;
+        return googleSubpremise;
+      },
+    });
+
+    const cfg = { apiOrigin, addressDoctorOrigin };
+    const result = await callDualValidateAddress(cfg, payload, null, fetchFn);
+
+    expect(result).toEqual(addressDoctorFix);
   });
 
   test('uses AddressDoctor when Google validation fails', async () => {

--- a/tests/unit/checkout-address-autocomplete.test.js
+++ b/tests/unit/checkout-address-autocomplete.test.js
@@ -74,7 +74,7 @@ test('buildPlacesAutocompleteInput omits empty locality fields', () => {
   );
 });
 
-test('setAddressFieldValue clears stale field errors and notifies listeners', () => {
+test('setAddressFieldValue clears stale field errors without reopening autocomplete', () => {
   const events = [];
   let removed = false;
   const wrapper = {
@@ -107,5 +107,5 @@ test('setAddressFieldValue clears stale field errors and notifies listeners', ()
   assert.equal(inputEl.value, '28422-7728');
   assert.deepEqual(wrapper.classList.removed, ['has-error']);
   assert.equal(removed, true);
-  assert.deepEqual(events, ['remove:aria-invalid', 'remove:aria-describedby', 'input', 'change']);
+  assert.deepEqual(events, ['remove:aria-invalid', 'remove:aria-describedby', 'change']);
 });

--- a/tests/unit/checkout-address-autocomplete.test.js
+++ b/tests/unit/checkout-address-autocomplete.test.js
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildPlacesAutocompleteInput } from '../../blocks/checkout/checkout-address.js';
+
+function sectionWithFields(fields) {
+  return {
+    querySelector(selector) {
+      const match = selector.match(/^\[name="(.+)"\]$/);
+      if (!match) return null;
+      return fields[match[1]] || null;
+    },
+  };
+}
+
+function input(value) {
+  return { value };
+}
+
+function select(value, textContent = '') {
+  return {
+    value,
+    selectedOptions: textContent ? [{ textContent }] : [],
+  };
+}
+
+test('buildPlacesAutocompleteInput includes city and selected state label', () => {
+  const section = sectionWithFields({
+    'shipping-city': input('Bolivia'),
+    'shipping-state': select('NC', 'North Carolina'),
+    'shipping-zip': input(''),
+  });
+
+  assert.equal(
+    buildPlacesAutocompleteInput(section, '714 Lakeside Drive'),
+    '714 Lakeside Drive, Bolivia, North Carolina',
+  );
+});
+
+test('buildPlacesAutocompleteInput includes ZIP when present', () => {
+  const section = sectionWithFields({
+    'shipping-city': input('Springfield'),
+    'shipping-state': select('IL', 'Illinois'),
+    'shipping-zip': input('62701'),
+  });
+
+  assert.equal(
+    buildPlacesAutocompleteInput(section, '123 Main St'),
+    '123 Main St, Springfield, Illinois 62701',
+  );
+});
+
+test('buildPlacesAutocompleteInput falls back to state value', () => {
+  const section = sectionWithFields({
+    'billing-city': input('Toronto'),
+    'billing-state': select('ON'),
+    'billing-zip': input('M5E 1E5'),
+  });
+
+  assert.equal(
+    buildPlacesAutocompleteInput(section, '1 Yonge St', 'billing-'),
+    '1 Yonge St, Toronto, ON M5E 1E5',
+  );
+});
+
+test('buildPlacesAutocompleteInput omits empty locality fields', () => {
+  const section = sectionWithFields({});
+
+  assert.equal(
+    buildPlacesAutocompleteInput(section, '  714 Lakeside Drive  '),
+    '714 Lakeside Drive',
+  );
+});

--- a/tests/unit/checkout-address-autocomplete.test.js
+++ b/tests/unit/checkout-address-autocomplete.test.js
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildPlacesAutocompleteInput } from '../../blocks/checkout/checkout-address.js';
+import {
+  buildPlacesAutocompleteInput,
+  setAddressFieldValue,
+} from '../../blocks/checkout/checkout-address.js';
 
 function sectionWithFields(fields) {
   return {
@@ -69,4 +72,40 @@ test('buildPlacesAutocompleteInput omits empty locality fields', () => {
     buildPlacesAutocompleteInput(section, '  714 Lakeside Drive  '),
     '714 Lakeside Drive',
   );
+});
+
+test('setAddressFieldValue clears stale field errors and notifies listeners', () => {
+  const events = [];
+  let removed = false;
+  const wrapper = {
+    classList: {
+      removed: [],
+      remove(name) { this.removed.push(name); },
+    },
+    querySelector(selector) {
+      assert.equal(selector, '.field-error');
+      return { remove: () => { removed = true; } };
+    },
+  };
+  const inputEl = {
+    value: '',
+    closest(selector) {
+      assert.equal(selector, '.form-field');
+      return wrapper;
+    },
+    removeAttribute(name) {
+      events.push(`remove:${name}`);
+    },
+    dispatchEvent(event) {
+      events.push(event.type);
+      return true;
+    },
+  };
+
+  setAddressFieldValue(inputEl, '28422-7728');
+
+  assert.equal(inputEl.value, '28422-7728');
+  assert.deepEqual(wrapper.classList.removed, ['has-error']);
+  assert.equal(removed, true);
+  assert.deepEqual(events, ['remove:aria-invalid', 'remove:aria-describedby', 'input', 'change']);
 });

--- a/tests/unit/checkout-address-dual-validation.test.js
+++ b/tests/unit/checkout-address-dual-validation.test.js
@@ -1,0 +1,66 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { callDualValidateAddress } from '../../blocks/checkout/checkout-address.js';
+
+const apiOrigin = 'https://api.adobecommerce.live/org/sites/site';
+const addressDoctorOrigin = 'https://vitamix-address-doctor-proxy-worker.adobeaem.workers.dev';
+const payload = { address: { regionCode: 'US', addressLines: ['1450 Brickell Avenue', 'Miami, FL 33131'] } };
+
+const googleSubpremise = {
+  action: 'CONFIRM_ADD_SUBPREMISES',
+  formattedAddress: '1450 Brickell Ave, Miami, FL 33131, USA',
+  addressComponents: [
+    { longText: '1450', shortText: '1450', types: ['street_number'] },
+    { longText: 'Brickell Avenue', shortText: 'Brickell Avenue', types: ['route'] },
+    { longText: 'Miami', shortText: 'Miami', types: ['locality'] },
+    { longText: 'Florida', shortText: 'FL', types: ['administrative_area_level_1'] },
+    { longText: '33131', shortText: '33131', types: ['postal_code'] },
+  ],
+  uspsDeliverable: true,
+};
+
+const addressDoctorConfirm = {
+  provider: 'addressdoctor',
+  action: 'CONFIRM',
+  formattedAddress: '1450 Brickell Ave, Miami FL 33131',
+  addressComponents: [],
+  uspsDeliverable: true,
+};
+
+afterEach(() => {
+  window.IS_TEST_MODE = false;
+  globalThis.__resetTestState();
+});
+
+function mockFetch(google, addressDoctor) {
+  window.IS_TEST_MODE = true;
+  globalThis.__setFetchMock(async (url) => ({
+    ok: true,
+    json: async () => (url.startsWith(addressDoctorOrigin) ? addressDoctor : google),
+  }));
+}
+
+test('callDualValidateAddress preserves Google add-subpremise action when AddressDoctor does not reject', async () => {
+  mockFetch(googleSubpremise, addressDoctorConfirm);
+
+  const result = await callDualValidateAddress(
+    { apiOrigin, addressDoctorOrigin },
+    payload,
+    'tok-1',
+  );
+
+  assert.equal(result, googleSubpremise);
+});
+
+test('callDualValidateAddress keeps AddressDoctor FIX over Google add-subpremise action', async () => {
+  const addressDoctorFix = { ...addressDoctorConfirm, action: 'FIX', uspsDeliverable: false };
+  mockFetch(googleSubpremise, addressDoctorFix);
+
+  const result = await callDualValidateAddress(
+    { apiOrigin, addressDoctorOrigin },
+    payload,
+    'tok-1',
+  );
+
+  assert.equal(result, addressDoctorFix);
+});


### PR DESCRIPTION
Include locality details in Places autocomplete requests and preserve Google's missing-subpremise action so shoppers are prompted for apartment or suite numbers when AddressDoctor does not reject the address.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-checkout-autocomplete-context--vitamix--aemsites.aem.network/
