### PR TITLE
Hero color overlay

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -42,6 +42,10 @@
   opacity: 0.8;
 }
 
+.hero.no-overlay::after {
+  content: none;
+}
+
 .hero:not(.split) {
   --image-color: var(--color-charcoal);
 }
@@ -80,10 +84,6 @@
 
 .hero .img-wrapper + h1 {
   margin-top: 0.6em;
-}
-
-.hero.no-overlay::after {
-  content: none;
 }
 
 @media (width >= 800px) {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -82,6 +82,10 @@
   margin-top: 0.6em;
 }
 
+.hero.no-overlay::after {
+  content: none;
+}
+
 @media (width >= 800px) {
   .hero h1 {
     font-size: var(--font-size-950);


### PR DESCRIPTION
No color overlay option for hero block. 


Test URLs:
Use first hero as an example. 

- Before: https://main--vitamix--aemsites.aem.page/drafts/ashleya/hero
- After: https://hero-color-overlay--vitamix--aemsites.aem.page/drafts/ashleya/hero
<img width="1776" height="573" alt="Screenshot 2026-06-16 at 11 56 46 AM" src="https://github.com/user-attachments/assets/e6e34db2-a4a0-40ea-a64d-d33e6e0826bf" />
