### PR TITLE
fix(auth): persist OTP session across tabs via localStorage

### DIFF
--- a/scripts/auth-api.js
+++ b/scripts/auth-api.js
@@ -1,7 +1,7 @@
 import { getConfig } from './commerce-config.js';
 import { mintRecaptchaToken, RECAPTCHA_ACTIONS, RECAPTCHA_HEADER } from './recaptcha.js';
 
-/** sessionStorage key for the JWT issued after OTP verification */
+/** localStorage key for the JWT issued after OTP verification */
 export const AUTH_TOKEN_KEY = 'auth_token';
 
 /** localStorage key for the serialised user object { email, roles } */
@@ -9,6 +9,32 @@ export const AUTH_USER_KEY = 'auth_user';
 
 /** CustomEvent name dispatched on document when auth state changes */
 export const AUTH_EVENT = 'commerce:auth-state-changed';
+
+/**
+ * Reads the current JWT, or null when not signed in.
+ * Backed by localStorage so the session is shared across all tabs of the
+ * origin (sessionStorage would isolate the token to a single tab).
+ *
+ * @returns {string|null}
+ */
+export function getToken() {
+  try { return localStorage.getItem(AUTH_TOKEN_KEY); } catch { return null; }
+}
+
+/**
+ * Persists the JWT so every tab on this origin sees the session.
+ * @param {string} token
+ */
+export function setToken(token) {
+  try { localStorage.setItem(AUTH_TOKEN_KEY, token); } catch { /* storage disabled */ }
+}
+
+/**
+ * Removes the JWT (logout / 401). Does not touch the cached user object.
+ */
+export function clearToken() {
+  try { localStorage.removeItem(AUTH_TOKEN_KEY); } catch { /* storage disabled */ }
+}
 
 /**
  * Dispatches a `commerce:auth-state-changed` CustomEvent on document.
@@ -53,9 +79,9 @@ export async function login(email, country, locale) {
 /**
  * Completes the OTP login flow by verifying the code the user received.
  * Sends a POST to /auth/callback with the code and the `hash`/`exp` values
- * returned by `login`. On success, stores the JWT in sessionStorage (cleared
- * when the browser tab closes) and the user object in localStorage (persists
- * across sessions for UI restoration), then dispatches an auth state event.
+ * returned by `login`. On success, stores the JWT and the user object in
+ * localStorage (shared across all tabs of the origin and persisted across
+ * browser sessions), then dispatches an auth state event.
  *
  * @param {string} email - The user's email address
  * @param {string} code - The 6-digit OTP code from the user's email
@@ -78,7 +104,7 @@ export async function verifyCode(email, code, hash, exp) {
   }
   const data = await resp.json();
   if (data.token) {
-    sessionStorage.setItem(AUTH_TOKEN_KEY, data.token);
+    setToken(data.token);
   }
   localStorage.setItem(AUTH_USER_KEY, JSON.stringify({
     email: data.email,
@@ -91,14 +117,14 @@ export async function verifyCode(email, code, hash, exp) {
 /**
  * Logs the current user out.
  * Makes a best-effort POST to /auth/logout to invalidate the token server-side,
- * then unconditionally clears the JWT from sessionStorage and the user object
- * from localStorage regardless of whether the server call succeeds.
+ * then unconditionally clears the JWT and the user object from localStorage
+ * regardless of whether the server call succeeds.
  * Dispatches an auth state event on completion.
  *
  * @returns {Promise<void>}
  */
 export async function logout() {
-  const token = sessionStorage.getItem(AUTH_TOKEN_KEY);
+  const token = getToken();
   try {
     await fetch(`${getConfig().apiOrigin}/auth/logout`, {
       method: 'POST',
@@ -108,27 +134,27 @@ export async function logout() {
       },
     });
   } catch { /* best-effort */ }
-  sessionStorage.removeItem(AUTH_TOKEN_KEY);
+  clearToken();
   localStorage.removeItem(AUTH_USER_KEY);
   dispatchAuthEvent(false, null);
 }
 
 /**
  * Returns whether the current user has an active session.
- * Checks for the presence of a JWT in sessionStorage. Note that this does not
+ * Checks for the presence of a JWT in localStorage. Note that this does not
  * validate the token with the server — it only checks local storage state.
  *
  * @returns {boolean}
  */
 export function isLoggedIn() {
-  return !!sessionStorage.getItem(AUTH_TOKEN_KEY);
+  return !!getToken();
 }
 
 /**
  * Returns the stored user object for the current session, or null if not
  * logged in. The object is written to localStorage by `verifyCode` and
  * persists across browser sessions for UI restoration purposes, but a missing
- * JWT in sessionStorage means the user is effectively logged out.
+ * JWT in localStorage means the user is effectively logged out.
  *
  * @returns {{ email: string, roles: string[] }|null}
  */
@@ -146,10 +172,10 @@ export function getUser() {
  * @param {string} url - The URL to fetch
  * @param {RequestInit} [options={}] - Standard fetch options (method, body, etc.)
  * @returns {Promise<Response>}
- * @throws {Error} If the user is not authenticated (no token in sessionStorage)
+ * @throws {Error} If the user is not authenticated (no token in localStorage)
  */
 export async function authFetch(url, options = {}) {
-  const token = sessionStorage.getItem(AUTH_TOKEN_KEY);
+  const token = getToken();
   if (!token) throw new Error('Not authenticated');
 
   const headers = new Headers(options.headers || {});
@@ -157,9 +183,23 @@ export async function authFetch(url, options = {}) {
 
   const resp = await fetch(url, { ...options, headers });
   if (resp.status === 401) {
-    sessionStorage.removeItem(AUTH_TOKEN_KEY);
+    clearToken();
     localStorage.removeItem(AUTH_USER_KEY);
     dispatchAuthEvent(false, null);
   }
   return resp;
+}
+
+/**
+ * Keeps tabs in sync. The browser fires a `storage` event on *other* tabs of
+ * the same origin whenever localStorage changes, so when one tab logs in or
+ * out we re-dispatch the local auth state event in the others. A null `key`
+ * means storage was cleared wholesale; treat that as an auth change too.
+ */
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('storage', (e) => {
+    if (e.key !== AUTH_TOKEN_KEY && e.key !== AUTH_USER_KEY && e.key !== null) return;
+    const loggedIn = isLoggedIn();
+    dispatchAuthEvent(loggedIn, loggedIn ? getUser()?.email ?? null : null);
+  });
 }

--- a/scripts/auth-api.js
+++ b/scripts/auth-api.js
@@ -10,30 +10,106 @@ export const AUTH_USER_KEY = 'auth_user';
 /** CustomEvent name dispatched on document when auth state changes */
 export const AUTH_EVENT = 'commerce:auth-state-changed';
 
+/** Seconds before JWT `exp` to treat the token as expired (clock skew). */
+const AUTH_EXPIRY_SKEW_SEC = 30;
+
+/** id of the one-shot expiry timer, so it can be rescheduled or cleared. */
+let authExpiryTimerId = null;
+
+/**
+ * Decodes the payload segment of a JWT without verifying its signature.
+ * Verification happens server-side; this is only used to read `exp`/`iat`
+ * so the client can stop presenting a token it knows the server will reject.
+ *
+ * @param {string} token
+ * @returns {Record<string, unknown>|null}
+ */
+function decodeJwtPayload(token) {
+  if (!token || typeof token !== 'string') return null;
+  const part = token.split('.')[1];
+  if (!part) return null;
+  try {
+    const b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    return JSON.parse(atob(padded));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * JWT expiry in Unix seconds. Falls back to `iat + 24h` when `exp` is absent,
+ * matching the 24h lifetime the API issues.
+ *
+ * @param {string} token
+ * @returns {number|null}
+ */
+export function getTokenExpirySec(token) {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  if (typeof payload.exp === 'number') return payload.exp;
+  if (typeof payload.iat === 'number') return payload.iat + 86400;
+  return null;
+}
+
+/**
+ * Whether the token is expired (or undecodable). A token whose expiry can't be
+ * read is treated as expired so a malformed/garbage value never counts as a
+ * live session.
+ *
+ * @param {string} token
+ * @param {number} [skewSec]
+ * @returns {boolean}
+ */
+export function isAuthTokenExpired(token, skewSec = AUTH_EXPIRY_SKEW_SEC) {
+  const exp = getTokenExpirySec(token);
+  if (!exp) return true;
+  return Date.now() / 1000 >= exp - skewSec;
+}
+
 /**
  * Reads the current JWT, or null when not signed in.
  * Backed by localStorage so the session is shared across all tabs of the
- * origin (sessionStorage would isolate the token to a single tab).
+ * origin (sessionStorage would isolate the token to a single tab). An expired
+ * token is cleared on read and reported as absent, so the UI never trusts a
+ * token the server would reject.
  *
  * @returns {string|null}
  */
 export function getToken() {
-  try { return localStorage.getItem(AUTH_TOKEN_KEY); } catch { return null; }
+  let token;
+  try { token = localStorage.getItem(AUTH_TOKEN_KEY); } catch { return null; }
+  if (!token) return null;
+  if (isAuthTokenExpired(token)) {
+    // eslint-disable-next-line no-use-before-define
+    clearToken();
+    try { localStorage.removeItem(AUTH_USER_KEY); } catch { /* storage disabled */ }
+    return null;
+  }
+  return token;
 }
 
 /**
- * Persists the JWT so every tab on this origin sees the session.
+ * Persists the JWT so every tab on this origin sees the session, and schedules
+ * the auto-expiry timer for one day of acquisition (the token's `exp`).
  * @param {string} token
  */
 export function setToken(token) {
   try { localStorage.setItem(AUTH_TOKEN_KEY, token); } catch { /* storage disabled */ }
+  // eslint-disable-next-line no-use-before-define
+  scheduleAuthExpiry();
 }
 
 /**
- * Removes the JWT (logout / 401). Does not touch the cached user object.
+ * Removes the JWT (logout / 401 / expiry). Does not touch the cached user
+ * object. Cancels any pending expiry timer.
  */
 export function clearToken() {
   try { localStorage.removeItem(AUTH_TOKEN_KEY); } catch { /* storage disabled */ }
+  if (authExpiryTimerId != null) {
+    clearTimeout(authExpiryTimerId);
+    authExpiryTimerId = null;
+  }
 }
 
 /**
@@ -43,6 +119,38 @@ export function clearToken() {
  */
 function dispatchAuthEvent(loggedIn, email) {
   document.dispatchEvent(new CustomEvent(AUTH_EVENT, { detail: { loggedIn, email } }));
+}
+
+/**
+ * Schedules a one-shot timer that logs the user out when the current token's
+ * `exp` lapses, so the UI flips to signed-out without waiting for the next API
+ * call. Reschedules on each call and fires immediately if already expired.
+ * No-op when there is no (live) token.
+ */
+export function scheduleAuthExpiry() {
+  if (authExpiryTimerId != null) {
+    clearTimeout(authExpiryTimerId);
+    authExpiryTimerId = null;
+  }
+  let token;
+  try { token = localStorage.getItem(AUTH_TOKEN_KEY); } catch { return; }
+  if (!token) return;
+  const expSec = getTokenExpirySec(token);
+  if (!expSec) return;
+  const fire = () => {
+    clearToken();
+    try { localStorage.removeItem(AUTH_USER_KEY); } catch { /* storage disabled */ }
+    dispatchAuthEvent(false, null);
+  };
+  const delayMs = expSec * 1000 - Date.now() - AUTH_EXPIRY_SKEW_SEC * 1000;
+  if (delayMs <= 0) {
+    fire();
+    return;
+  }
+  authExpiryTimerId = setTimeout(fire, delayMs);
+  // In Node (tests) a pending timer keeps the event loop alive; unref so the
+  // process can exit. No-op in browsers, where setTimeout returns a number.
+  if (typeof authExpiryTimerId?.unref === 'function') authExpiryTimerId.unref();
 }
 
 /**
@@ -193,13 +301,20 @@ export async function authFetch(url, options = {}) {
 /**
  * Keeps tabs in sync. The browser fires a `storage` event on *other* tabs of
  * the same origin whenever localStorage changes, so when one tab logs in or
- * out we re-dispatch the local auth state event in the others. A null `key`
- * means storage was cleared wholesale; treat that as an auth change too.
+ * out we re-dispatch the local auth state event in the others and (re)arm this
+ * tab's own expiry timer. A null `key` means storage was cleared wholesale;
+ * treat that as an auth change too.
+ *
+ * On load we also schedule the expiry timer for any session restored from a
+ * prior visit, so a token that lapsed while the tab was closed is cleaned up
+ * (and an active session still flips to signed-out the moment it expires).
  */
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('storage', (e) => {
     if (e.key !== AUTH_TOKEN_KEY && e.key !== AUTH_USER_KEY && e.key !== null) return;
+    scheduleAuthExpiry();
     const loggedIn = isLoggedIn();
     dispatchAuthEvent(loggedIn, loggedIn ? getUser()?.email ?? null : null);
   });
+  scheduleAuthExpiry();
 }

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -1,5 +1,5 @@
 import { getConfig } from './commerce-config.js';
-import { AUTH_TOKEN_KEY } from './auth-api.js';
+import { getToken } from './auth-api.js';
 import { mintRecaptchaToken, RECAPTCHA_ACTIONS, RECAPTCHA_HEADER } from './recaptcha.js';
 import { getLocaleAndLanguage, loggedFetch } from './scripts.js';
 import { logApiError, logNetworkError } from './operations-log.js';
@@ -20,7 +20,7 @@ class CommerceApiError extends Error {
 
 /**
  * Makes an authenticated POST request to the Commerce API.
- * Attaches a Bearer token from sessionStorage if one is present, so orders
+ * Attaches a Bearer token from localStorage if one is present, so orders
  * created while a user is logged in are associated with their account.
  * When `recaptchaAction` is provided AND no Bearer token is available,
  * mints a reCAPTCHA Enterprise token and attaches it as `X-Recaptcha-Token`.
@@ -34,7 +34,7 @@ class CommerceApiError extends Error {
  */
 async function post(path, body, recaptchaAction) {
   const headers = { 'Content-Type': 'application/json' };
-  const token = sessionStorage.getItem(AUTH_TOKEN_KEY);
+  const token = getToken();
   if (token) headers.Authorization = `Bearer ${token}`;
 
   if (recaptchaAction && !token) {
@@ -187,7 +187,7 @@ export async function initiatePayment(orderId, idempotencyKey, fraudToken, provi
 
 /**
  * Makes an authenticated HTTP request to the Commerce API.
- * Attaches a Bearer token from sessionStorage when present.
+ * Attaches a Bearer token from localStorage when present.
  * No reCAPTCHA support — PayPal session endpoints are Cloudflare-rate-limited.
  *
  * @param {string} path - API path relative to config.apiOrigin
@@ -199,7 +199,7 @@ export async function initiatePayment(orderId, idempotencyKey, fraudToken, provi
 async function request(path, body, method) {
   const headers = {};
   if (body !== null) headers['Content-Type'] = 'application/json';
-  const token = sessionStorage.getItem(AUTH_TOKEN_KEY);
+  const token = getToken();
   if (token) headers.Authorization = `Bearer ${token}`;
 
   let resp;

--- a/tests/unit/auth-api.test.js
+++ b/tests/unit/auth-api.test.js
@@ -18,11 +18,23 @@ import {
   getUser,
   verifyCode,
   logout,
+  getTokenExpirySec,
+  isAuthTokenExpired,
+  scheduleAuthExpiry,
 } from '../../scripts/auth-api.js';
 
 beforeEach(() => {
   globalThis.__resetTestState();
 });
+
+/** Build a JWT-shaped token whose payload carries the given claims. */
+function makeJwt(claims) {
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url');
+  return `eyJhbGciOiJIUzI1NiJ9.${payload}.sig`;
+}
+const nowSec = () => Math.floor(Date.now() / 1000);
+const FUTURE_JWT = makeJwt({ exp: nowSec() + 3600 });
+const EXPIRED_JWT = makeJwt({ exp: nowSec() - 3600 });
 
 /** Returns the most recently dispatched AUTH_EVENT, or undefined. */
 function lastAuthEvent() {
@@ -32,9 +44,9 @@ function lastAuthEvent() {
 // --- Storage helpers --------------------------------------------------------
 
 test('setToken writes the JWT to localStorage (shared across tabs)', () => {
-  setToken('jwt-123');
-  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), 'jwt-123');
-  assert.equal(getToken(), 'jwt-123');
+  setToken(FUTURE_JWT);
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), FUTURE_JWT);
+  assert.equal(getToken(), FUTURE_JWT);
 });
 
 test('getToken returns null when no token is stored', () => {
@@ -42,24 +54,62 @@ test('getToken returns null when no token is stored', () => {
 });
 
 test('clearToken removes the JWT but leaves the cached user object', () => {
-  setToken('jwt-123');
+  setToken(FUTURE_JWT);
   localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'a@b.com', roles: ['user'] }));
   clearToken();
   assert.equal(getToken(), null);
   assert.ok(localStorage.getItem(AUTH_USER_KEY), 'user object should remain');
 });
 
-test('isLoggedIn reflects the presence of a token in localStorage', () => {
+test('isLoggedIn reflects the presence of a live token in localStorage', () => {
   assert.equal(isLoggedIn(), false);
-  setToken('jwt-123');
+  setToken(FUTURE_JWT);
   assert.equal(isLoggedIn(), true);
   clearToken();
   assert.equal(isLoggedIn(), false);
 });
 
 test('the token is not written to sessionStorage', () => {
-  setToken('jwt-123');
+  setToken(FUTURE_JWT);
   assert.equal(sessionStorage.getItem(AUTH_TOKEN_KEY), null);
+});
+
+// --- Expiry -----------------------------------------------------------------
+
+test('getTokenExpirySec reads exp, falling back to iat + 24h', () => {
+  assert.equal(getTokenExpirySec(makeJwt({ exp: 1000 })), 1000);
+  assert.equal(getTokenExpirySec(makeJwt({ iat: 2000 })), 2000 + 86400);
+  assert.equal(getTokenExpirySec('not-a-jwt'), null);
+});
+
+test('isAuthTokenExpired is true for expired and undecodable tokens', () => {
+  assert.equal(isAuthTokenExpired(FUTURE_JWT), false);
+  assert.equal(isAuthTokenExpired(EXPIRED_JWT), true);
+  assert.equal(isAuthTokenExpired('garbage'), true);
+});
+
+test('getToken clears and reports an expired token as absent', () => {
+  localStorage.setItem(AUTH_TOKEN_KEY, EXPIRED_JWT);
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'a@b.com', roles: ['user'] }));
+  assert.equal(getToken(), null);
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), null, 'expired token should be removed');
+  assert.equal(localStorage.getItem(AUTH_USER_KEY), null, 'cached user should be removed');
+  assert.equal(isLoggedIn(), false);
+});
+
+test('scheduleAuthExpiry logs out immediately when the token is already expired', () => {
+  localStorage.setItem(AUTH_TOKEN_KEY, EXPIRED_JWT);
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'a@b.com', roles: ['user'] }));
+  scheduleAuthExpiry();
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), null);
+  const evt = lastAuthEvent();
+  assert.ok(evt, 'an AUTH_EVENT should be dispatched');
+  assert.deepEqual(evt.detail, { loggedIn: false, email: null });
+});
+
+test('scheduleAuthExpiry is a no-op when no token is stored', () => {
+  scheduleAuthExpiry();
+  assert.equal(lastAuthEvent(), undefined);
 });
 
 // --- verifyCode -------------------------------------------------------------
@@ -69,15 +119,15 @@ test('verifyCode stores the JWT in localStorage and dispatches a logged-in event
     ok: true,
     status: 200,
     json: async () => ({
-      success: true, token: 'jwt-abc', email: 'user@example.com', roles: ['user'],
+      success: true, token: FUTURE_JWT, email: 'user@example.com', roles: ['user'],
     }),
     headers: { get: () => null },
   }));
 
   const data = await verifyCode('user@example.com', '123456', 'hash', Date.now() + 60000);
 
-  assert.equal(data.token, 'jwt-abc');
-  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), 'jwt-abc');
+  assert.equal(data.token, FUTURE_JWT);
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), FUTURE_JWT);
   assert.deepEqual(getUser(), { email: 'user@example.com', roles: ['user'] });
   assert.equal(isLoggedIn(), true);
 
@@ -89,7 +139,7 @@ test('verifyCode stores the JWT in localStorage and dispatches a logged-in event
 // --- logout -----------------------------------------------------------------
 
 test('logout clears token and user from localStorage and dispatches a logged-out event', async () => {
-  setToken('jwt-abc');
+  setToken(FUTURE_JWT);
   localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'user@example.com', roles: ['user'] }));
   globalThis.__setFetchMock(async () => ({ ok: true, status: 204, json: async () => ({}) }));
 
@@ -105,7 +155,7 @@ test('logout clears token and user from localStorage and dispatches a logged-out
 });
 
 test('logout still clears local state when the server call fails', async () => {
-  setToken('jwt-abc');
+  setToken(FUTURE_JWT);
   globalThis.__setFetchMock(async () => { throw new Error('network down'); });
 
   await logout();

--- a/tests/unit/auth-api.test.js
+++ b/tests/unit/auth-api.test.js
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for scripts/auth-api.js — token storage helpers and the
+ * localStorage-backed session that is shared across browser tabs.
+ *
+ * Run with `npm run test:unit`. The setup file installs the fetch mock and
+ * browser globals (localStorage, document) that auth-api.js depends on.
+ */
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AUTH_TOKEN_KEY,
+  AUTH_USER_KEY,
+  AUTH_EVENT,
+  getToken,
+  setToken,
+  clearToken,
+  isLoggedIn,
+  getUser,
+  verifyCode,
+  logout,
+} from '../../scripts/auth-api.js';
+
+beforeEach(() => {
+  globalThis.__resetTestState();
+});
+
+/** Returns the most recently dispatched AUTH_EVENT, or undefined. */
+function lastAuthEvent() {
+  return [...globalThis.__events].reverse().find((e) => e.type === AUTH_EVENT);
+}
+
+// --- Storage helpers --------------------------------------------------------
+
+test('setToken writes the JWT to localStorage (shared across tabs)', () => {
+  setToken('jwt-123');
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), 'jwt-123');
+  assert.equal(getToken(), 'jwt-123');
+});
+
+test('getToken returns null when no token is stored', () => {
+  assert.equal(getToken(), null);
+});
+
+test('clearToken removes the JWT but leaves the cached user object', () => {
+  setToken('jwt-123');
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'a@b.com', roles: ['user'] }));
+  clearToken();
+  assert.equal(getToken(), null);
+  assert.ok(localStorage.getItem(AUTH_USER_KEY), 'user object should remain');
+});
+
+test('isLoggedIn reflects the presence of a token in localStorage', () => {
+  assert.equal(isLoggedIn(), false);
+  setToken('jwt-123');
+  assert.equal(isLoggedIn(), true);
+  clearToken();
+  assert.equal(isLoggedIn(), false);
+});
+
+test('the token is not written to sessionStorage', () => {
+  setToken('jwt-123');
+  assert.equal(sessionStorage.getItem(AUTH_TOKEN_KEY), null);
+});
+
+// --- verifyCode -------------------------------------------------------------
+
+test('verifyCode stores the JWT in localStorage and dispatches a logged-in event', async () => {
+  globalThis.__setFetchMock(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      success: true, token: 'jwt-abc', email: 'user@example.com', roles: ['user'],
+    }),
+    headers: { get: () => null },
+  }));
+
+  const data = await verifyCode('user@example.com', '123456', 'hash', Date.now() + 60000);
+
+  assert.equal(data.token, 'jwt-abc');
+  assert.equal(localStorage.getItem(AUTH_TOKEN_KEY), 'jwt-abc');
+  assert.deepEqual(getUser(), { email: 'user@example.com', roles: ['user'] });
+  assert.equal(isLoggedIn(), true);
+
+  const evt = lastAuthEvent();
+  assert.ok(evt, 'an AUTH_EVENT should be dispatched');
+  assert.deepEqual(evt.detail, { loggedIn: true, email: 'user@example.com' });
+});
+
+// --- logout -----------------------------------------------------------------
+
+test('logout clears token and user from localStorage and dispatches a logged-out event', async () => {
+  setToken('jwt-abc');
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email: 'user@example.com', roles: ['user'] }));
+  globalThis.__setFetchMock(async () => ({ ok: true, status: 204, json: async () => ({}) }));
+
+  await logout();
+
+  assert.equal(getToken(), null);
+  assert.equal(localStorage.getItem(AUTH_USER_KEY), null);
+  assert.equal(isLoggedIn(), false);
+
+  const evt = lastAuthEvent();
+  assert.ok(evt, 'an AUTH_EVENT should be dispatched');
+  assert.deepEqual(evt.detail, { loggedIn: false, email: null });
+});
+
+test('logout still clears local state when the server call fails', async () => {
+  setToken('jwt-abc');
+  globalThis.__setFetchMock(async () => { throw new Error('network down'); });
+
+  await logout();
+
+  assert.equal(getToken(), null);
+  assert.equal(isLoggedIn(), false);
+});

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -2,7 +2,7 @@
  * Unit tests for scripts/commerce-api.js — getOrder and estimateShipping functions.
  *
  * Run with `npm run test:unit`. The setup file installs the fetch mock and
- * browser globals (sessionStorage) that commerce-api.js depends on.
+ * browser globals (localStorage) that commerce-api.js depends on.
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
@@ -76,14 +76,14 @@ test('getOrder: returns the full { order } payload on success', async () => {
 
 // --- Authentication ---------------------------------------------------------
 
-test('getOrder: attaches Bearer token from sessionStorage when present', async () => {
-  sessionStorage.setItem('auth_token', 'test-jwt');
+test('getOrder: attaches Bearer token from localStorage when present', async () => {
+  localStorage.setItem('auth_token', 'test-jwt');
   mockFetch(200, { order: {} });
   await getOrder('user@example.com', 'ord-4');
   assert.equal(lastInit.headers.Authorization, 'Bearer test-jwt');
 });
 
-test('getOrder: omits Authorization header when no token in sessionStorage', async () => {
+test('getOrder: omits Authorization header when no token in localStorage', async () => {
   mockFetch(200, { order: {} });
   await getOrder('user@example.com', 'ord-5');
   assert.equal(lastInit.headers.Authorization, undefined);

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -10,6 +10,13 @@ import { getOrder, estimateShipping, estimatePrice } from '../../scripts/commerc
 
 const API_ORIGIN = 'https://api.test.com/test-org/sites/test-site';
 
+/** Build a JWT-shaped token whose payload carries the given `exp` (Unix secs). */
+function makeJwt(expSec) {
+  const payload = Buffer.from(JSON.stringify({ exp: expSec })).toString('base64url');
+  return `eyJhbGciOiJIUzI1NiJ9.${payload}.sig`;
+}
+const FUTURE_JWT = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+
 /** Captured details from the most recent fetch() call. */
 let lastUrl;
 let lastInit;
@@ -77,10 +84,17 @@ test('getOrder: returns the full { order } payload on success', async () => {
 // --- Authentication ---------------------------------------------------------
 
 test('getOrder: attaches Bearer token from localStorage when present', async () => {
-  localStorage.setItem('auth_token', 'test-jwt');
+  localStorage.setItem('auth_token', FUTURE_JWT);
   mockFetch(200, { order: {} });
   await getOrder('user@example.com', 'ord-4');
-  assert.equal(lastInit.headers.Authorization, 'Bearer test-jwt');
+  assert.equal(lastInit.headers.Authorization, `Bearer ${FUTURE_JWT}`);
+});
+
+test('getOrder: omits Authorization header when the stored token is expired', async () => {
+  localStorage.setItem('auth_token', makeJwt(Math.floor(Date.now() / 1000) - 3600));
+  mockFetch(200, { order: {} });
+  await getOrder('user@example.com', 'ord-4b');
+  assert.equal(lastInit.headers.Authorization, undefined);
 });
 
 test('getOrder: omits Authorization header when no token in localStorage', async () => {


### PR DESCRIPTION
Fixes #619

The JWT was stored in per-tab sessionStorage, so a session created in one tab was not visible in others. This moves token storage to localStorage behind getToken/setToken/clearToken helpers and syncs auth state across tabs with a storage event.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://auth-localstorage-cross-tab--vitamix--aemsites.aem.network/