### PR TITLE
fix(checkout): prevent order-total overlap on tablet (#621)

### DIFF
--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -861,6 +861,23 @@ button.checkout-submit-btn {
     padding-bottom: 8px;
   }
 
+  /* Single-column layout: the breakdown rows are shown, so stack the total
+     above a full-width button (matches the mobile experience). */
+  .order-total-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button.checkout-submit-btn {
+    justify-content: center;
+    width: 100%;
+  }
+}
+
+/* Two-column layout (viewport >= 1000px) where the checkout column itself is
+   narrow (e.g. tablet landscape): stack so the long submit button doesn't
+   overlap the total. */
+@container checkout-col (width < 600px) {
   .order-total-section {
     flex-direction: column;
     align-items: stretch;

--- a/blocks/order-summary/order-summary.css
+++ b/blocks/order-summary/order-summary.css
@@ -47,6 +47,10 @@
   min-width: 0;
 }
 
+.checkout-wrapper {
+  container: checkout-col / inline-size;
+}
+
 .order-summary-header-total {
   display: none;
   font-size: var(--commerce-font-size-base);
@@ -122,6 +126,13 @@
     width: 100%;
     position: static;
     order: -1;
+  }
+
+  /* The section uses align-items: flex-start, so flex items shrink-wrap on the
+     cross axis. Force full width here; otherwise inline-size containment on
+     .checkout-wrapper would collapse it to its min-content width. */
+  .checkout-wrapper {
+    width: 100%;
   }
 
   .order-summary-toggle {


### PR DESCRIPTION
Fixes #621

Stack the order total above a full-width submit button when the checkout column is narrow, using a container query for the narrow two-column tablet layout and restoring the single-column stacking. Make the checkout wrapper full-width on mobile so inline-size containment doesn't collapse it.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-621-checkout-overlap--vitamix--aemsites.aem.network/
