### PR TITLE
feat: send locale with shipping estimate requests

### DIFF
--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -81,8 +81,11 @@ async function post(path, body, recaptchaAction) {
  * @throws {CommerceApiError}
  */
 export async function estimateShipping(country, state, items, couponCode, couponSource) {
+  // BCP-47 store-view locale (e.g. 'fr-CA') so the API can localize method labels.
+  const { language: locale } = getLocaleAndLanguage(false, true);
   return post('/estimate/shipping', {
     country,
+    locale,
     shipping: { country, state },
     items,
     ...(couponCode ? { couponCode } : {}),
@@ -124,8 +127,11 @@ export async function estimatePrice(country, items, couponCode, couponSource) {
  * @throws {CommerceApiError}
  */
 export async function estimateExpressCheckout(country, state, zip, items) {
+  // BCP-47 store-view locale (e.g. 'fr-CA') so the API can localize method labels.
+  const { language: locale } = getLocaleAndLanguage(false, true);
   return post('/estimate/order', {
     country,
+    locale,
     shipping: { country, state, zip },
     items,
   });

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -6,7 +6,10 @@
  */
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { getOrder, estimateShipping, estimatePrice } from '../../scripts/commerce-api.js';
+import {
+  getOrder, estimateShipping, estimatePrice, estimateExpressCheckout,
+} from '../../scripts/commerce-api.js';
+import { __setLocale, __resetScripts } from './mocks/scripts.mjs';
 
 const API_ORIGIN = 'https://api.test.com/test-org/sites/test-site';
 
@@ -42,6 +45,7 @@ beforeEach(() => {
   lastUrl = undefined;
   lastInit = undefined;
   globalThis.__resetTestState();
+  __resetScripts();
 });
 
 // --- URL construction -------------------------------------------------------
@@ -180,6 +184,34 @@ test('estimateShipping: returns rates array from response', async () => {
   mockFetch(200, { rates });
   const result = await estimateShipping('us', 'NY', []);
   assert.deepEqual(result.rates, rates);
+});
+
+test('estimateShipping: sends BCP-47 locale from the store view', async () => {
+  __setLocale({ locale: 'ca', language: 'fr_ca' });
+  mockFetch(200, { rates: [] });
+  await estimateShipping('ca', 'QC', []);
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.locale, 'fr-CA');
+});
+
+test('estimateShipping: defaults locale to en-US', async () => {
+  mockFetch(200, { rates: [] });
+  await estimateShipping('us', 'CA', []);
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.locale, 'en-US');
+});
+
+test('estimateExpressCheckout: sends locale and order shape', async () => {
+  __setLocale({ locale: 'ca', language: 'fr_ca' });
+  const items = [{ sku: 'abc', quantity: 1, price: { final: '50.00' } }];
+  mockFetch(200, { subtotal: '50.00', shippingMethods: [] });
+  await estimateExpressCheckout('ca', 'QC', 'H2X 1Y4', items);
+  assert.equal(lastUrl, `${API_ORIGIN}/estimate/order`);
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.locale, 'fr-CA');
+  assert.equal(body.country, 'ca');
+  assert.deepEqual(body.shipping, { country: 'ca', state: 'QC', zip: 'H2X 1Y4' });
+  assert.deepEqual(body.items, items);
 });
 
 test('estimatePrice: includes couponSource when provided with couponCode', async () => {

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -26,8 +26,22 @@ export function checkVariantOutOfStock(sku) {
   return outOfStockSkus.has(sku);
 }
 
-export function getLocaleAndLanguage() {
-  return locale;
+/**
+ * Mirrors the real getLocaleAndLanguage(forceEnCA, bcp47) shape so callers that
+ * request the BCP-47 form (e.g. 'fr-CA') get the same conversion they would in
+ * production. The backing value set via __setLocale uses the URL/underscore form
+ * (e.g. { locale: 'ca', language: 'fr_ca' }).
+ */
+export function getLocaleAndLanguage(forceEnCA = false, bcp47 = false) {
+  const { locale: loc } = locale;
+  let { language } = locale;
+  if (forceEnCA && loc === 'ca' && language === 'en_us') {
+    language = 'en_ca';
+  }
+  if (bcp47) {
+    language = language.replace('_', '-').replace(/-([a-z]{2})$/, (_, r) => `-${r.toUpperCase()}`);
+  }
+  return { locale: loc, language };
 }
 
 export async function loggedFetch(...args) {


### PR DESCRIPTION
estimateShipping and estimateExpressCheckout now include the store-view locale (BCP-47, e.g. fr-CA) in their request bodies so the Commerce API can return translated shipping method labels. The locale is sourced the same way as the PayPal session call, keeping a single canonical locale across all commerce requests.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://shipping-label-locale--vitamix--aemsites.aem.network/