### PR TITLE
fix(commerce-admin): limit orders search placeholder to order id

### DIFF
--- a/tools/commerce-admin/orders.html
+++ b/tools/commerce-admin/orders.html
@@ -26,7 +26,7 @@
           type="search"
           id="orders-search"
           class="pim-search orders-search-wide"
-          placeholder="Search order id, email, state, billing or shipping name…"
+          placeholder="Search by order id…"
           aria-label="Search orders"
         />
         <div class="orders-toolbar-right">


### PR DESCRIPTION
Fixes #622

Search only matches by order id, so the placeholder no longer advertises email, state, or billing/shipping name.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html
- After: https://fix-622-orders-search-placeholder--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html