### PR TITLE
Add styles for split hero without overlay

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -46,6 +46,16 @@
   content: none;
 }
 
+.hero.split.no-overlay::after {
+  content: none;
+}
+
+@media (width >= 800px) {
+  .hero.split.no-overlay::after {
+    content: none;
+  }
+}
+
 .hero:not(.split) {
   --image-color: var(--color-charcoal);
 }


### PR DESCRIPTION
Create a version of the split hero with no overlay. 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/drafts/ashleya/hero
- After: https://hero-overlay--vitamix--aemsites.aem.page/drafts/ashleya/hero
