### PR TITLE
feat(checkout): send customer timezone with orders

### DIFF
--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -1,4 +1,9 @@
-import { createOrder, initiatePayment, previewOrder } from '../../scripts/commerce-api.js';
+import {
+  createOrder,
+  getCustomerTimezone,
+  initiatePayment,
+  previewOrder,
+} from '../../scripts/commerce-api.js';
 import { collectAddress } from './checkout-address.js';
 import { updatePreview } from './checkout-shipping.js';
 import { FORMS_ENDPOINT, getLocaleAndLanguage } from '../../scripts/scripts.js';
@@ -84,6 +89,9 @@ export function buildOrderJSON(formData, form, cart, state, config) {
 
   const paymentMethod = formData.get('paymentMethod');
   if (paymentMethod) order.paymentMethod = paymentMethod;
+
+  const customerTimezone = getCustomerTimezone();
+  if (customerTimezone) order.customerTimezone = customerTimezone;
 
   return order;
 }

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -19,6 +19,19 @@ class CommerceApiError extends Error {
 }
 
 /**
+ * Read the shopper browser timezone for Commerce API order payloads, when available.
+ *
+ * @returns {string|undefined}
+ */
+export function getCustomerTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Makes an authenticated POST request to the Commerce API.
  * Attaches a Bearer token from localStorage if one is present, so orders
  * created while a user is logged in are associated with their account.

--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -1,4 +1,8 @@
-import { validateApplePayMerchant, estimateExpressCheckout } from '../commerce-api.js';
+import {
+  estimateExpressCheckout,
+  getCustomerTimezone,
+  validateApplePayMerchant,
+} from '../commerce-api.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
 
@@ -163,6 +167,7 @@ function startExpressSession(btn, config, callbacks) {
         // to the right account. The Apple Pay contact email may differ from the
         // commerce account email, which causes assertEmail to reject the request.
         const customerEmail = (isLoggedIn() && getUser()?.email) || contact.emailAddress || '';
+        const customerTimezone = getCustomerTimezone();
         const orderBody = {
           customer: {
             firstName: contact.givenName || '',
@@ -177,6 +182,7 @@ function startExpressSession(btn, config, callbacks) {
           estimateToken: callbacks.getState().currentEstimateToken,
           country: locale,
           locale: bcp47,
+          ...(customerTimezone ? { customerTimezone } : {}),
         };
 
         const createdOrder = await callbacks.createOrder(orderBody);

--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -1,5 +1,6 @@
 import {
   createPayPalSession,
+  getCustomerTimezone,
   patchPayPalSession,
   getPayPalSession,
 } from '../commerce-api.js';
@@ -259,6 +260,7 @@ export default {
             config.getLocale(),
             getLocaleAndLanguage(false, true).language,
           );
+          const customerTimezone = getCustomerTimezone();
           const orderBody = {
             customer: {
               firstName: session.payer.firstName,
@@ -281,6 +283,7 @@ export default {
             estimateToken: state.currentEstimateToken,
             country: session.shippingAddress.country,
             locale: getLocaleAndLanguage(false, true).language,
+            ...(customerTimezone ? { customerTimezone } : {}),
           };
           const createdOrder = await callbacks.createOrder(orderBody);
           const fraudToken = (() => {

--- a/tests/unit/checkout-order-timezone.test.js
+++ b/tests/unit/checkout-order-timezone.test.js
@@ -1,0 +1,84 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOrderJSON } from '../../blocks/checkout/checkout-order.js';
+
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
+afterEach(() => {
+  Intl.DateTimeFormat = originalDateTimeFormat;
+});
+
+function mockTimeZone(timeZone) {
+  Intl.DateTimeFormat = () => ({
+    resolvedOptions: () => ({ timeZone }),
+  });
+}
+
+function formData(values) {
+  return {
+    get(name) {
+      return values[name] ?? '';
+    },
+  };
+}
+
+function formWithBillingChoice(value = 'same') {
+  return {
+    querySelector(selector) {
+      if (selector === '[name="billing-choice"]:checked') return { value };
+      return null;
+    },
+  };
+}
+
+const config = {
+  getLocale: () => 'us',
+  getLanguage: () => 'en_us',
+};
+
+const cart = {
+  getItemsForAPI: () => [{ sku: 'sku-1', path: '/products/sku-1', quantity: 1, price: { currency: 'USD', regular: '10.00' } }],
+};
+
+const baseValues = {
+  email: 'jane@example.com',
+  'shipping-firstname': 'Jane',
+  'shipping-lastname': 'Doe',
+  'shipping-street-0': '123 Main St',
+  'shipping-street-1': '',
+  'shipping-city': 'Cleveland',
+  'shipping-state': 'OH',
+  'shipping-zip': '44101',
+  'shipping-telephone': '(555) 123-4567',
+  paymentMethod: 'chase',
+};
+
+test('buildOrderJSON includes customerTimezone when browser reports one', () => {
+  mockTimeZone('America/New_York');
+
+  const order = buildOrderJSON(
+    formData(baseValues),
+    formWithBillingChoice('same'),
+    cart,
+    {},
+    config,
+  );
+
+  assert.equal(order.customerTimezone, 'America/New_York');
+});
+
+test('buildOrderJSON omits customerTimezone when timezone capture fails', () => {
+  Intl.DateTimeFormat = () => {
+    throw new Error('unsupported');
+  };
+
+  const order = buildOrderJSON(
+    formData(baseValues),
+    formWithBillingChoice('same'),
+    cart,
+    {},
+    config,
+  );
+
+  assert.equal(order.customerTimezone, undefined);
+});

--- a/tests/unit/customer-timezone.test.js
+++ b/tests/unit/customer-timezone.test.js
@@ -1,0 +1,35 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { getCustomerTimezone } from '../../scripts/commerce-api.js';
+
+const originalDateTimeFormat = Intl.DateTimeFormat;
+
+afterEach(() => {
+  Intl.DateTimeFormat = originalDateTimeFormat;
+});
+
+function mockTimeZone(timeZone) {
+  Intl.DateTimeFormat = () => ({
+    resolvedOptions: () => ({ timeZone }),
+  });
+}
+
+test('getCustomerTimezone returns the browser timezone', () => {
+  mockTimeZone('America/New_York');
+
+  assert.equal(getCustomerTimezone(), 'America/New_York');
+});
+
+test('getCustomerTimezone returns undefined when Intl throws', () => {
+  Intl.DateTimeFormat = () => {
+    throw new Error('unsupported');
+  };
+
+  assert.equal(getCustomerTimezone(), undefined);
+});
+
+test('getCustomerTimezone returns undefined when no timezone is reported', () => {
+  mockTimeZone(undefined);
+
+  assert.equal(getCustomerTimezone(), undefined);
+});


### PR DESCRIPTION
Fixes #627

Captures the shopper browser timezone during checkout and adds it to order creation payloads. Standard checkout and direct express checkout flows now send customerTimezone so confirmation emails can render order timestamps in the customer's local time.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://customer-timezone-checkout--vitamix--aemsites.aem.network/
