### PR TITLE
fix(commerce-admin): show customer orders from customer endpoint

### DIFF
--- a/tools/commerce-admin/customers-page.js
+++ b/tools/commerce-admin/customers-page.js
@@ -10,9 +10,9 @@ import { wireDialogEscapeDismiss } from './commerce-dialog-dismiss.js';
 import { createDetailModalHeaderCloseAndJson } from './commerce-detail-modal-json.js';
 import { openJsonEditDialog } from './commerce-json-edit-dialog.js';
 import { PB_ORG, PB_SITE } from './commerce-pbus-config.js';
-import { escapeHtml, showToast } from './commerce-otp-ui.js';
+import { escapeHtml, showToast, commerceMarketEmojiHtml } from './commerce-otp-ui.js';
 import { highlightMatch } from './search-highlight.js';
-import { openOrderById } from './orders-page.js';
+import { openOrderById, orderStateBadgeClass } from './orders-page.js';
 
 function getUrlParam(key) {
   return new URLSearchParams(window.location.search).get(key) || '';
@@ -80,13 +80,14 @@ function formatOrderNumberLabel(orderOrRawId) {
 }
 
 /**
- * Order entries (clickable: `{ id, label }`) from `GET customers/{email}/orders`.
- * The endpoint already scopes to the customer, so no email matching is needed;
- * each summary carries the full `id` used to open the order detail dialog.
+ * Order summaries from `GET customers/{email}/orders`, sorted newest-first and
+ * deduped by id. The endpoint already scopes to the customer, so no email
+ * matching is needed; each summary carries the full `id` used to open the order
+ * detail dialog plus list metadata (state, itemCount, total, country, createdAt).
  * @param {object[]} orders
- * @returns {{ id: string, label: string }[]}
+ * @returns {object[]}
  */
-function orderEntriesFromCustomerOrders(orders) {
+function orderSummariesFromCustomerOrders(orders) {
   if (!Array.isArray(orders)) return [];
   const sorted = [...orders].sort((a, b) => {
     const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
@@ -96,13 +97,12 @@ function orderEntriesFromCustomerOrders(orders) {
   const seen = new Set();
   const out = [];
   sorted.forEach((o) => {
-    const id = o && o.id != null ? String(o.id).trim() : '';
-    const label = formatOrderNumberLabel(o);
-    if (!label || label === '—') return;
-    const k = id ? `id:${id}` : `lbl:${normalizeOrderIdKey(label)}`;
-    if (seen.has(k)) return;
-    seen.add(k);
-    out.push({ id, label });
+    if (!o || typeof o !== 'object') return;
+    const id = o.id != null ? String(o.id).trim() : '';
+    if (!id) return;
+    if (seen.has(id)) return;
+    seen.add(id);
+    out.push(o);
   });
   return out;
 }
@@ -137,27 +137,6 @@ function embeddedOrderDisplayNumbers(data) {
     if (!k || seen.has(k)) return;
     seen.add(k);
     out.push(lbl);
-  });
-  return out;
-}
-
-/** Embedded labels (non-clickable: no order id) from the customer JSON record. */
-function embeddedOrderEntries(data) {
-  return embeddedOrderDisplayNumbers(data).map((label) => ({ id: '', label }));
-}
-
-/** Merge clickable + embedded entries, deduped by id and by normalized label. */
-function mergeOrderEntries(primary, secondary) {
-  const seen = new Set();
-  const out = [];
-  [...primary, ...secondary].forEach((e) => {
-    if (!e || !e.label) return;
-    const lblKey = `lbl:${normalizeOrderIdKey(e.label)}`;
-    const idKey = e.id ? `id:${e.id}` : lblKey;
-    if (seen.has(idKey) || seen.has(lblKey)) return;
-    seen.add(idKey);
-    seen.add(lblKey);
-    out.push(e);
   });
   return out;
 }
@@ -435,7 +414,87 @@ function buildCustomerRichHeader(data) {
   return wrap;
 }
 
-function buildCustomerDetailHumanView(data, orderEntries, onOpenOrder) {
+/** Money cell like the orders admin: `$<value>` or em dash. */
+function formatMoneyCell(value) {
+  if (value == null || String(value).trim() === '') return '—';
+  return `$${String(value).trim()}`;
+}
+
+/** Localized created date for an order summary. */
+function orderCreatedCell(o) {
+  if (!o || o.createdAt == null || o.createdAt === '') return '—';
+  const d = new Date(o.createdAt);
+  return Number.isNaN(d.getTime()) ? String(o.createdAt) : d.toLocaleString();
+}
+
+/**
+ * Orders table for the customer modal, mirroring the Orders admin look (badge,
+ * market flag) but trimmed to a single-customer context. Rows open the shared
+ * order detail dialog.
+ * @param {object[]} orders
+ * @param {(id: string) => void} onOpenOrder
+ */
+function buildCustomerOrdersTable(orders, onOpenOrder) {
+  const table = document.createElement('table');
+  table.className = 'customers-orders-table orders-data-table';
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>Order</th>
+        <th>State</th>
+        <th>Items</th>
+        <th>Total</th>
+        <th>Market</th>
+        <th>Created</th>
+      </tr>
+    </thead>`;
+  const tbody = document.createElement('tbody');
+
+  orders.forEach((o) => {
+    const id = o.id != null ? String(o.id).trim() : '';
+    const shortId = orderIdForDisplay(o) || id;
+    const formattedId = formatOrderIdChunks(shortId);
+    const state = String(o.state || 'pending');
+    let itemCount = '—';
+    if (o.itemCount != null && String(o.itemCount).trim() !== '') itemCount = String(o.itemCount);
+    const total = formatMoneyCell(o.total != null && String(o.total).trim() !== '' ? o.total : o.subtotal);
+    const marketHtml = o.country ? commerceMarketEmojiHtml(o.country) : '—';
+
+    const tr = document.createElement('tr');
+    const clickable = Boolean(id) && typeof onOpenOrder === 'function';
+    if (clickable) {
+      tr.className = 'customers-orders-row-open';
+      tr.setAttribute('role', 'button');
+      tr.setAttribute('tabindex', '0');
+      tr.setAttribute('aria-label', `Open order ${formattedId}`);
+    }
+    const titleAttr = id && normalizeOrderIdKey(shortId) !== normalizeOrderIdKey(id)
+      ? ` title="${escapeHtml(id)}"`
+      : '';
+    tr.innerHTML = `
+      <td><code class="orders-id"${titleAttr}>${escapeHtml(formattedId)}</code></td>
+      <td><span class="orders-badge ${orderStateBadgeClass(state)}">${escapeHtml(state)}</span></td>
+      <td>${escapeHtml(itemCount)}</td>
+      <td>${escapeHtml(total)}</td>
+      <td>${marketHtml}</td>
+      <td>${escapeHtml(orderCreatedCell(o))}</td>`;
+    if (clickable) {
+      tr.addEventListener('click', () => onOpenOrder(id));
+      tr.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpenOrder(id);
+        }
+      });
+    }
+    tbody.appendChild(tr);
+  });
+
+  table.appendChild(tbody);
+  return table;
+}
+
+function buildCustomerDetailHumanView(data, orderData, onOpenOrder) {
   const root = document.createElement('div');
   root.className = 'customers-detail-human';
   root.appendChild(buildCustomerRichHeader(data));
@@ -470,37 +529,38 @@ function buildCustomerDetailHumanView(data, orderEntries, onOpenOrder) {
     root.appendChild(sec);
   }
 
-  const orders = Array.isArray(orderEntries) ? orderEntries : [];
+  const orders = orderData && Array.isArray(orderData.orders) ? orderData.orders : [];
+  const embeddedLabels = orderData && Array.isArray(orderData.embeddedLabels)
+    ? orderData.embeddedLabels : [];
   const ordSec = detailSection('Orders');
-  if (!orders.length) {
+  if (orders.length) {
+    const count = document.createElement('p');
+    count.className = 'customers-orders-count';
+    count.textContent = `${orders.length} order${orders.length === 1 ? '' : 's'}`;
+    ordSec.appendChild(count);
+    const wrapEl = document.createElement('div');
+    wrapEl.className = 'customers-orders-table-wrap';
+    wrapEl.appendChild(buildCustomerOrdersTable(orders, onOpenOrder));
+    ordSec.appendChild(wrapEl);
+  } else if (embeddedLabels.length) {
+    /* Fallback: order numbers present on the customer record but not returned by
+       the customer orders endpoint (no metadata for a full table row). */
+    const ul = document.createElement('ul');
+    ul.className = 'customers-order-number-list';
+    embeddedLabels.forEach((label) => {
+      const li = document.createElement('li');
+      const code = document.createElement('code');
+      code.className = 'customers-order-number-code';
+      code.textContent = label;
+      li.appendChild(code);
+      ul.appendChild(li);
+    });
+    ordSec.appendChild(ul);
+  } else {
     const p = document.createElement('p');
     p.className = 'orders-detail-empty';
     p.textContent = 'No orders found for this customer.';
     ordSec.appendChild(p);
-  } else {
-    const ul = document.createElement('ul');
-    ul.className = 'customers-order-number-list';
-    orders.forEach((entry) => {
-      const li = document.createElement('li');
-      const code = document.createElement('code');
-      code.className = 'customers-order-number-code';
-      code.textContent = entry.label;
-      if (entry.id && typeof onOpenOrder === 'function') {
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'customers-order-open-btn';
-        btn.setAttribute('aria-label', `Open order ${entry.label}`);
-        btn.appendChild(code);
-        btn.addEventListener('click', () => {
-          onOpenOrder(entry.id);
-        });
-        li.appendChild(btn);
-      } else {
-        li.appendChild(code);
-      }
-      ul.appendChild(li);
-    });
-    ordSec.appendChild(ul);
   }
   root.appendChild(ordSec);
 
@@ -509,7 +569,9 @@ function buildCustomerDetailHumanView(data, orderEntries, onOpenOrder) {
 
 function openCustomerDetailModal(
   customerData,
-  { email, onRefresh, orderEntries = [] } = {},
+  {
+    email, onRefresh, orders = [], embeddedLabels = [],
+  } = {},
 ) {
   const dialog = document.createElement('dialog');
   dialog.className = 'customers-detail-dialog coupons-detail-dialog';
@@ -545,7 +607,11 @@ function openCustomerDetailModal(
 
   const header = createDetailModalHeaderCloseAndJson({
     bodyHost,
-    getHumanNode: () => buildCustomerDetailHumanView(customerData, orderEntries, openOrder),
+    getHumanNode: () => buildCustomerDetailHumanView(
+      customerData,
+      { orders, embeddedLabels },
+      openOrder,
+    ),
     getJsonValue: () => customerData,
     onClose: shut,
   });
@@ -608,11 +674,13 @@ async function viewCustomer(email, rowFallback, onRefresh) {
     /* use fallback */
   }
 
-  const fromOrders = orderEntriesFromCustomerOrders(customerOrders);
-  const embedded = embeddedOrderEntries(data);
-  const merged = mergeOrderEntries(fromOrders, embedded);
+  const orders = orderSummariesFromCustomerOrders(customerOrders);
+  /* Only used when the endpoint returns nothing — order numbers on the record. */
+  const embeddedLabels = orders.length ? [] : embeddedOrderDisplayNumbers(data);
 
-  openCustomerDetailModal(data, { email, onRefresh, orderEntries: merged });
+  openCustomerDetailModal(data, {
+    email, onRefresh, orders, embeddedLabels,
+  });
 }
 
 function renderTable(wrap, displayed, query, onEditSaved) {

--- a/tools/commerce-admin/customers-page.js
+++ b/tools/commerce-admin/customers-page.js
@@ -12,6 +12,7 @@ import { openJsonEditDialog } from './commerce-json-edit-dialog.js';
 import { PB_ORG, PB_SITE } from './commerce-pbus-config.js';
 import { escapeHtml, showToast } from './commerce-otp-ui.js';
 import { highlightMatch } from './search-highlight.js';
+import { openOrderById } from './orders-page.js';
 
 function getUrlParam(key) {
   return new URLSearchParams(window.location.search).get(key) || '';
@@ -78,38 +79,30 @@ function formatOrderNumberLabel(orderOrRawId) {
   return short ? formatOrderIdChunks(short) : formatOrderIdChunks(raw);
 }
 
-function orderEmailNorm(o) {
-  const e = o?.customer?.email
-    || o?.customMetadata?.customerEmail
-    || o?.email;
-  return e != null ? String(e).trim().toLowerCase() : '';
-}
-
 /**
- * Order numbers for a customer email from `GET orders` (same list payload as the Orders admin).
+ * Order entries (clickable: `{ id, label }`) from `GET customers/{email}/orders`.
+ * The endpoint already scopes to the customer, so no email matching is needed;
+ * each summary carries the full `id` used to open the order detail dialog.
  * @param {object[]} orders
- * @param {string} email
+ * @returns {{ id: string, label: string }[]}
  */
-function orderDisplayNumbersFromOrdersList(orders, email) {
-  const want = String(email || '').trim().toLowerCase();
-  if (!want || !Array.isArray(orders)) return [];
-  const matches = orders.filter((o) => {
-    const e = orderEmailNorm(o);
-    return e && e === want;
-  });
-  matches.sort((a, b) => {
+function orderEntriesFromCustomerOrders(orders) {
+  if (!Array.isArray(orders)) return [];
+  const sorted = [...orders].sort((a, b) => {
     const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
     const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
     return tb - ta;
   });
-  const labels = matches.map((o) => formatOrderNumberLabel(o)).filter(Boolean);
   const seen = new Set();
   const out = [];
-  labels.forEach((lbl) => {
-    const k = normalizeOrderIdKey(lbl);
-    if (!k || seen.has(k)) return;
+  sorted.forEach((o) => {
+    const id = o && o.id != null ? String(o.id).trim() : '';
+    const label = formatOrderNumberLabel(o);
+    if (!label || label === '—') return;
+    const k = id ? `id:${id}` : `lbl:${normalizeOrderIdKey(label)}`;
+    if (seen.has(k)) return;
     seen.add(k);
-    out.push(lbl);
+    out.push({ id, label });
   });
   return out;
 }
@@ -148,14 +141,23 @@ function embeddedOrderDisplayNumbers(data) {
   return out;
 }
 
-function mergeOrderNumberLists(primary, secondary) {
+/** Embedded labels (non-clickable: no order id) from the customer JSON record. */
+function embeddedOrderEntries(data) {
+  return embeddedOrderDisplayNumbers(data).map((label) => ({ id: '', label }));
+}
+
+/** Merge clickable + embedded entries, deduped by id and by normalized label. */
+function mergeOrderEntries(primary, secondary) {
   const seen = new Set();
   const out = [];
-  [...primary, ...secondary].forEach((lbl) => {
-    const k = normalizeOrderIdKey(lbl);
-    if (!k || seen.has(k)) return;
-    seen.add(k);
-    out.push(lbl);
+  [...primary, ...secondary].forEach((e) => {
+    if (!e || !e.label) return;
+    const lblKey = `lbl:${normalizeOrderIdKey(e.label)}`;
+    const idKey = e.id ? `id:${e.id}` : lblKey;
+    if (seen.has(idKey) || seen.has(lblKey)) return;
+    seen.add(idKey);
+    seen.add(lblKey);
+    out.push(e);
   });
   return out;
 }
@@ -433,7 +435,7 @@ function buildCustomerRichHeader(data) {
   return wrap;
 }
 
-function buildCustomerDetailHumanView(data, orderDisplayNumbers) {
+function buildCustomerDetailHumanView(data, orderEntries, onOpenOrder) {
   const root = document.createElement('div');
   root.className = 'customers-detail-human';
   root.appendChild(buildCustomerRichHeader(data));
@@ -468,22 +470,34 @@ function buildCustomerDetailHumanView(data, orderDisplayNumbers) {
     root.appendChild(sec);
   }
 
-  const orderNums = Array.isArray(orderDisplayNumbers) ? orderDisplayNumbers : [];
+  const orders = Array.isArray(orderEntries) ? orderEntries : [];
   const ordSec = detailSection('Orders');
-  if (!orderNums.length) {
+  if (!orders.length) {
     const p = document.createElement('p');
     p.className = 'orders-detail-empty';
-    p.textContent = 'No orders found for this email in the loaded orders list, and none on the customer record.';
+    p.textContent = 'No orders found for this customer.';
     ordSec.appendChild(p);
   } else {
     const ul = document.createElement('ul');
     ul.className = 'customers-order-number-list';
-    orderNums.forEach((label) => {
+    orders.forEach((entry) => {
       const li = document.createElement('li');
       const code = document.createElement('code');
       code.className = 'customers-order-number-code';
-      code.textContent = label;
-      li.appendChild(code);
+      code.textContent = entry.label;
+      if (entry.id && typeof onOpenOrder === 'function') {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'customers-order-open-btn';
+        btn.setAttribute('aria-label', `Open order ${entry.label}`);
+        btn.appendChild(code);
+        btn.addEventListener('click', () => {
+          onOpenOrder(entry.id);
+        });
+        li.appendChild(btn);
+      } else {
+        li.appendChild(code);
+      }
       ul.appendChild(li);
     });
     ordSec.appendChild(ul);
@@ -495,10 +509,17 @@ function buildCustomerDetailHumanView(data, orderDisplayNumbers) {
 
 function openCustomerDetailModal(
   customerData,
-  { email, onRefresh, orderDisplayNumbers = [] } = {},
+  { email, onRefresh, orderEntries = [] } = {},
 ) {
   const dialog = document.createElement('dialog');
   dialog.className = 'customers-detail-dialog coupons-detail-dialog';
+
+  const openOrder = (orderId) => {
+    if (!orderId) return;
+    openOrderById(orderId, { onEditSaved: onRefresh }).catch((err) => {
+      showToast(err.message || 'Failed to load order', 'error');
+    });
+  };
 
   const toolbar = document.createElement('div');
   toolbar.className = 'commerce-detail-modal-toolbar';
@@ -524,7 +545,7 @@ function openCustomerDetailModal(
 
   const header = createDetailModalHeaderCloseAndJson({
     bodyHost,
-    getHumanNode: () => buildCustomerDetailHumanView(customerData, orderDisplayNumbers),
+    getHumanNode: () => buildCustomerDetailHumanView(customerData, orderEntries, openOrder),
     getJsonValue: () => customerData,
     onClose: shut,
   });
@@ -568,11 +589,11 @@ function openCustomerDetailModal(
 
 async function viewCustomer(email, rowFallback, onRefresh) {
   let data = rowFallback;
-  let ordersList = [];
+  let customerOrders = [];
   try {
     const [custResp, ordResp] = await Promise.all([
       apiFetch(PB_ORG, PB_SITE, `customers/${encodeURIComponent(email)}`, { method: 'GET' }),
-      apiFetch(PB_ORG, PB_SITE, 'orders', { method: 'GET' }),
+      apiFetch(PB_ORG, PB_SITE, `customers/${encodeURIComponent(email)}/orders`, { method: 'GET' }),
     ]);
     if (custResp.ok) {
       const raw = await custResp.json();
@@ -581,17 +602,17 @@ async function viewCustomer(email, rowFallback, onRefresh) {
     if (ordResp.ok) {
       const ordJson = await ordResp.json();
       const list = ordJson.orders || ordJson || [];
-      if (Array.isArray(list)) ordersList = list;
+      if (Array.isArray(list)) customerOrders = list;
     }
   } catch {
     /* use fallback */
   }
 
-  const fromOrders = orderDisplayNumbersFromOrdersList(ordersList, email);
-  const embedded = embeddedOrderDisplayNumbers(data);
-  const merged = mergeOrderNumberLists(fromOrders, embedded);
+  const fromOrders = orderEntriesFromCustomerOrders(customerOrders);
+  const embedded = embeddedOrderEntries(data);
+  const merged = mergeOrderEntries(fromOrders, embedded);
 
-  openCustomerDetailModal(data, { email, onRefresh, orderDisplayNumbers: merged });
+  openCustomerDetailModal(data, { email, onRefresh, orderEntries: merged });
 }
 
 function renderTable(wrap, displayed, query, onEditSaved) {

--- a/tools/commerce-admin/customers.css
+++ b/tools/commerce-admin/customers.css
@@ -195,3 +195,28 @@
   font-size: 13px;
   word-break: break-all;
 }
+
+.customers-order-open-btn {
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: #2c6ecb;
+  cursor: pointer;
+  text-align: left;
+}
+
+.customers-order-open-btn:hover .customers-order-number-code,
+.customers-order-open-btn:focus-visible .customers-order-number-code {
+  text-decoration: underline;
+}
+
+.customers-order-open-btn .customers-order-number-code {
+  color: inherit;
+}
+
+.customers-order-open-btn:focus-visible {
+  outline: 2px solid #2c6ecb;
+  outline-offset: 2px;
+  border-radius: 3px;
+}

--- a/tools/commerce-admin/customers.css
+++ b/tools/commerce-admin/customers.css
@@ -196,27 +196,31 @@
   word-break: break-all;
 }
 
-.customers-order-open-btn {
-  padding: 0;
-  border: 0;
-  background: none;
-  font: inherit;
-  color: #2c6ecb;
+.customers-orders-count {
+  margin: 0 0 0.5rem;
+  font-size: 13px;
+  color: #6d7175;
+}
+
+.customers-orders-table-wrap {
+  overflow-x: auto;
+}
+
+/* Compact the shared orders table for the narrower customer modal. */
+.customers-orders-table.orders-data-table {
+  font-size: 13px;
+}
+
+.customers-orders-table.orders-data-table th:first-child,
+.customers-orders-table.orders-data-table td:first-child {
+  min-width: 0;
+}
+
+.customers-orders-table tbody tr.customers-orders-row-open {
   cursor: pointer;
-  text-align: left;
 }
 
-.customers-order-open-btn:hover .customers-order-number-code,
-.customers-order-open-btn:focus-visible .customers-order-number-code {
-  text-decoration: underline;
-}
-
-.customers-order-open-btn .customers-order-number-code {
-  color: inherit;
-}
-
-.customers-order-open-btn:focus-visible {
-  outline: 2px solid #2c6ecb;
-  outline-offset: 2px;
-  border-radius: 3px;
+.customers-orders-table tbody tr.customers-orders-row-open:focus-visible {
+  outline: 2px solid #1a56b0;
+  outline-offset: -2px;
 }

--- a/tools/commerce-admin/customers.css
+++ b/tools/commerce-admin/customers.css
@@ -138,6 +138,11 @@
   font-size: 14px;
 }
 
+/* Wider than the shared coupons dialog to give the orders table room to breathe. */
+.customers-detail-dialog.coupons-detail-dialog {
+  max-width: min(96vw, 940px);
+}
+
 .customers-detail-scroll {
   padding-top: 12px;
 }

--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -962,7 +962,7 @@ function buildJournalHumanView(data) {
   return root;
 }
 
-function showOrderDialog(order, { onEditSaved } = {}) {
+export function showOrderDialog(order, { onEditSaved } = {}) {
   let orderPayload = order;
   const orderId = resolveOrderId(orderPayload);
   let isJournalView = false;
@@ -1095,6 +1095,20 @@ function showOrderDialog(order, { onEditSaved } = {}) {
   dialog.showModal();
 }
 
+/**
+ * Fetch a full order by id and open the shared order detail dialog. Reused by
+ * the customers admin so a customer's order opens the same pop-up as the
+ * orders list.
+ * @param {string} orderId
+ * @param {{ onEditSaved?: () => (void | Promise<void>) }} [opts]
+ */
+export async function openOrderById(orderId, { onEditSaved } = {}) {
+  const resp = await apiFetch(PB_ORG, PB_SITE, `orders/${encodeURIComponent(orderId)}`, { method: 'GET' });
+  if (!resp.ok) throw new Error(await readRespError(resp));
+  const orderData = await resp.json();
+  showOrderDialog(orderData, { onEditSaved });
+}
+
 function fillStateSelect(select, states, current) {
   select.innerHTML = '';
   const all = document.createElement('option');
@@ -1190,10 +1204,7 @@ function renderTable(wrap, orders, query, onEditSaved) {
       const id = row.getAttribute('data-id');
       if (!id) return;
       try {
-        const resp = await apiFetch(PB_ORG, PB_SITE, `orders/${encodeURIComponent(id)}`, { method: 'GET' });
-        if (!resp.ok) throw new Error(await readRespError(resp));
-        const orderData = await resp.json();
-        showOrderDialog(orderData, { onEditSaved });
+        await openOrderById(id, { onEditSaved });
       } catch (err) {
         showToast(`Failed to load order: ${err.message}`, 'error');
       }

--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -201,7 +201,7 @@ function formatDateTime(iso) {
 }
 
 /** Distinct badge colors for list + detail (not only success vs default). */
-function orderStateBadgeClass(state) {
+export function orderStateBadgeClass(state) {
   const s = String(state || 'pending').toLowerCase().replace(/\s+/g, '_');
   if (s === 'completed' || s === 'payment_completed' || s === 'fulfilled') return 'orders-badge-success';
   if (s === 'payment_cancelled' || s === 'cancelled' || s === 'canceled' || s === 'abandoned') return 'orders-badge-danger';


### PR DESCRIPTION
The Customers tab matched orders by email against the admin orders list, whose summaries carry no email field, so it always showed no orders. Fetch the customer-scoped GET customers/{email}/orders endpoint instead and make each order open the shared order detail dialog reused from the Orders tab.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/
- After: https://fix-customer-orders-list--vitamix--aemsites.aem.network/