### PR TITLE
fix(commerce-admin): default orders grid to all states

### DIFF
--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -1242,7 +1242,7 @@ async function init() {
   }
 
   const initialQ = getUrlParam('q');
-  const initialState = getUrlParam('state') || 'payment_completed';
+  const initialState = getUrlParam('state') || '';
   const initialSort = getUrlParam('sort') === 'oldest' ? 'oldest' : 'newest';
 
   search.value = initialQ;


### PR DESCRIPTION
Fixes #640

The admin order grid defaulted its state filter to `payment_completed`, hiding orders in other states on load. Default to all states so every order is visible.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html
- After: https://fix-640-orders-default-state--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html