### PR TITLE
feat(commerce-admin): show customer type on orders

### DIFF
--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -306,6 +306,13 @@ function paymentSummaryLine(payment) {
   return bits.length ? bits.join(' · ') : '—';
 }
 
+function customerTypeLabel(customerType) {
+  const type = customerType != null ? String(customerType).trim().toLowerCase() : '';
+  if (type === 'registered') return 'Registered User';
+  if (type === 'guest') return 'Guest';
+  return '';
+}
+
 function formatAddressLines(addr) {
   if (!addr || typeof addr !== 'object') return '';
   const lines = [];
@@ -484,6 +491,8 @@ function buildOrderRichHeader(o) {
     summarizeOrderMonetaryTotal(o),
   ));
   stats.appendChild(statBlock('Payment', paymentSummaryLine(o.payment)));
+  const customerType = customerTypeLabel(o.customerType);
+  if (customerType) stats.appendChild(statBlock('Customer type', customerType));
   wrap.appendChild(stats);
 
   const pills = document.createElement('div');


### PR DESCRIPTION
Adds an optional Customer type summary card to order details so admins can distinguish registered users from guests when the API provides customerType, while omitting the card for older orders without the field.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html
- After: https://order-customer-type-admin--vitamix--aemsites.aem.network/tools/commerce-admin/orders.html
