### PR TITLE
feat(commerce-admin): show customer email in orders list

### DIFF
--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -116,6 +116,7 @@ function filterByQuery(orders, q) {
     if (nNeedle && normalizeOrderIdKey(o.id).includes(nNeedle)) return true;
     if (nNeedle && normalizeOrderIdKey(String(o.friendlyId || '')).includes(nNeedle)) return true;
     if (nNeedle && normalizeOrderIdKey(orderIdForDisplay(o)).includes(nNeedle)) return true;
+    if ((o.email || '').toLowerCase().includes(needle)) return true;
     if ((o.customer?.email || '').toLowerCase().includes(needle)) return true;
     if ((o.customMetadata?.customerEmail || '').toLowerCase().includes(needle)) return true;
     if ((o.state || '').toLowerCase().includes(needle)) return true;
@@ -1269,6 +1270,7 @@ function renderTable(wrap, orders, query, onEditSaved) {
       <thead>
         <tr>
           <th>Order ID</th>
+          <th>Email</th>
           <th>State</th>
           <th>Items</th>
           <th>Subtotal</th>
@@ -1307,9 +1309,15 @@ function renderTable(wrap, orders, query, onEditSaved) {
       ? String(o.paymentMethod).trim()
       : '—';
     const marketHtml = o.country ? commerceMarketEmojiHtml(o.country) : '—';
+    const emailRaw = o.email || o.customer?.email || '';
+    const emailStr = String(emailRaw).trim();
+    const emailHtml = emailStr
+      ? `<span class="orders-email">${highlightMatch(emailStr, query)}</span>`
+      : '—';
     return `
           <tr class="orders-row-open" data-id="${escapeHtml(id)}" tabindex="0" role="button" aria-label="Open order ${escapeHtml(formattedId)}">
             <td><code class="orders-id"${titleAttr}>${highlightOrderIdCell(formattedId, compactId, query)}</code></td>
+            <td>${emailHtml}</td>
             <td><span class="orders-badge ${orderStateBadgeClass(o.state)}">${highlightMatch(String(o.state || 'pending'), query)}</span></td>
             <td>${highlightMatch(itemCount, query)}</td>
             <td>${highlightMatch(subtotalStr, query)}</td>

--- a/tools/commerce-admin/orders.css
+++ b/tools/commerce-admin/orders.css
@@ -189,6 +189,16 @@
   color: #202223;
 }
 
+.orders-email {
+  display: inline-block;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+  color: #202223;
+}
+
 .orders-detail-rich .coupons-modal-idline code.orders-detail-id-code {
   font-size: 1.05rem;
   font-weight: 600;

--- a/tools/commerce-admin/orders.html
+++ b/tools/commerce-admin/orders.html
@@ -26,7 +26,7 @@
           type="search"
           id="orders-search"
           class="pim-search orders-search-wide"
-          placeholder="Search by order id…"
+          placeholder="Search by order id or email…"
           aria-label="Search orders"
         />
         <div class="orders-toolbar-right">


### PR DESCRIPTION
Fixes #641

Adds an Email column to the admin orders grid and lets the search box match on email, using the email now returned in the order list metadata. Updates the search placeholder to reflect what is searchable.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/
- After: https://orders-list-email--vitamix--aemsites.aem.network/