### PR TITLE
Fix: Left-align wrapping button links on mobile in default content wrapper

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -573,6 +573,11 @@ button.button.link {
   text-transform: none;
 }
 
+.default-content-wrapper .button.link {
+  text-align: left;
+  line-height: var(--line-height-m);
+}
+
 a.button.link:hover,
 button.button.link:hover,
 button.button.link:focus {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -575,7 +575,7 @@ button.button.link {
 
 .default-content-wrapper .button.link {
   text-align: left;
-  line-height: var(--line-height-m);
+  line-height: var(--line-height-xl);
 }
 
 a.button.link:hover,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -573,11 +573,6 @@ button.button.link {
   text-transform: none;
 }
 
-.default-content-wrapper .button.link {
-  text-align: left;
-  line-height: var(--line-height-xl);
-}
-
 a.button.link:hover,
 button.button.link:hover,
 button.button.link:focus {
@@ -613,6 +608,11 @@ button.button.close {
 button.button.close:hover,
 button.button.close:focus {
   background-color: var(--color-shadow);
+}
+
+.default-content-wrapper .button.link {
+  text-align: left;
+  line-height: var(--line-height-xl);
 }
 
 @media (width >= 800px) {


### PR DESCRIPTION
On mobile, .button.link elements inside .default-content-wrapper that wrap to a second line appear centered and cramped due to inherited text-align: center and tight line-height from the base button styles.

Test URLs:
- Before: https://www.vitamix.com/us/en_us/owners-resources/product-support/owners-manuals
- After: https://content-wrapper-button-link--vitamix--aemsites.aem.live/us/en_us/owners-resources/product-support/owners-manuals
 
