### PR TITLE
feat(checkout-progress): label final step Done instead of Confirmation

### DIFF
--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -38,7 +38,7 @@ const defaults = {
     'en-us': {
       stepCart: 'Cart',
       stepCheckout: 'Checkout',
-      stepConfirmation: 'Confirmation',
+      stepConfirmation: 'Done',
       checkoutStepsLabel: 'Checkout steps',
       remove: 'Remove',
       removeItem: 'Remove item',
@@ -81,7 +81,7 @@ const defaults = {
     'fr-ca': {
       stepCart: 'Panier',
       stepCheckout: 'Caisse',
-      stepConfirmation: 'Confirmation',
+      stepConfirmation: 'Terminé',
       checkoutStepsLabel: 'Étapes de la caisse',
       remove: 'Retirer',
       removeItem: "Retirer l'article",


### PR DESCRIPTION
Renames the third checkout progress step shown to shoppers (en-us Done, fr-ca Terminé).

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://checkout-progress-complete-to-done--vitamix--aemsites.aem.network/