### PR TITLE
fix(commerce-admin): clarify pending journal entries

### DIFF
--- a/tools/commerce-admin/orders-page.js
+++ b/tools/commerce-admin/orders-page.js
@@ -1040,7 +1040,7 @@ function buildJournalHumanView(data) {
   if (entries.length === 0) {
     const p = document.createElement('p');
     p.className = 'orders-detail-empty';
-    p.textContent = 'No journal entries for this order.';
+    p.textContent = 'Journal entries are still being ingested. They can take up to five minutes after order creation to appear.';
     root.appendChild(p);
     return root;
   }


### PR DESCRIPTION
Replace the empty journal message with ingestion guidance so admins know new order journal entries may take up to five minutes to appear.

Test URLs:
- Before: https://product-admin--vitamix--aemsites.aem.network/
- After: https://fix-admin-journal-pending-message--vitamix--aemsites.aem.network/