### PR TITLE
fix(checkout): keep account email for PayPal orders

### DIFF
--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -5,6 +5,7 @@ import {
   getPayPalSession,
 } from '../commerce-api.js';
 import { getLocaleAndLanguage } from '../scripts.js';
+import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
 
 let sdkLoadPromise = null;
@@ -261,11 +262,15 @@ export default {
             getLocaleAndLanguage(false, true).language,
           );
           const customerTimezone = getCustomerTimezone();
+          // When signed in, the order owner is the commerce account. PayPal may
+          // return a different payer email, which remains on billing/shipping.
+          const accountEmail = isLoggedIn() ? getUser()?.email : '';
+          const customerEmail = accountEmail || session.payer.email || '';
           const orderBody = {
             customer: {
               firstName: session.payer.firstName,
               lastName: session.payer.lastName,
-              email: session.payer.email,
+              email: customerEmail,
               phone: '',
             },
             shipping: {

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -92,18 +92,23 @@ async function handleShippingOptionsChange(data, actions, closureState, callback
   return undefined;
 }
 
-/** @param {object} callbacks @param {{ getPayPalSessionFn: Function }} deps */
+/**
+ * @param {object} callbacks
+ * @param {{ getPayPalSessionFn: Function, isLoggedInFn?: Function, getUserFn?: Function }} deps
+ */
 async function handleApprove(callbacks, deps) {
   try {
     const state = callbacks.getState();
     const session = await deps.getPayPalSessionFn(state.paypalSessionId);
     const cart = callbacks.getCart();
     const config = callbacks.getConfig();
+    const accountEmail = deps.isLoggedInFn?.() ? deps.getUserFn?.()?.email : '';
+    const customerEmail = accountEmail || session.payer.email || '';
     const orderBody = {
       customer: {
         firstName: session.payer.firstName,
         lastName: session.payer.lastName,
-        email: session.payer.email,
+        email: customerEmail,
         phone: '',
       },
       shipping: {
@@ -461,6 +466,23 @@ test.describe('onApprove callback', () => {
     expect(orderBody.shippingMethod.id).toBe('std');
     expect(orderBody.estimateToken).toBe('est-tok');
     expect(orderBody.country).toBe('us');
+  });
+
+  test('uses authenticated account email for order customer when signed in', async () => {
+    const state = makeState({ paypalSessionId: 'PP-TEST-001', currentEstimateToken: 'est-tok' });
+    let orderBody;
+    const callbacks = makeCallbacks(state, {
+      createOrder: async (body) => { orderBody = body; return { order: { id: 'ORD-001' } }; },
+    });
+    const deps = {
+      getPayPalSessionFn: async () => SESSION,
+      isLoggedInFn: () => true,
+      getUserFn: () => ({ email: 'account@example.com' }),
+    };
+    await handleApprove(callbacks, deps);
+    expect(orderBody.customer.email).toBe('account@example.com');
+    expect(orderBody.shipping.email).toBe('john@example.com');
+    expect(orderBody.billing.email).toBe('john@example.com');
   });
 
   test('calls initiatePayment with provider=paypal-express, paymentMethod=paypal, paypalOrderId', async () => {


### PR DESCRIPTION
PayPal Express can return a payer email that differs from the signed-in commerce account. Use the account email as the order owner for authenticated checkout while retaining the PayPal payer email on billing and shipping contact data.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-wallet-email-auth--vitamix--aemsites.aem.network/