### PR TITLE
fix(checkout): preserve house number when Place Details omits street_number

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -140,7 +140,7 @@ export function setAddressFieldValue(input, value) {
   input.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
-function fillAddressFields(section, addressInput, addressComponents) {
+export function fillAddressFields(section, addressInput, addressComponents) {
   const c = {};
   addressComponents.forEach((comp) => {
     comp.types.forEach((type) => { c[type] = comp; });
@@ -149,8 +149,17 @@ function fillAddressFields(section, addressInput, addressComponents) {
   // Only overwrite a field when Google actually returned the corresponding component.
   // Clearing an existing user-typed value can blank a required field and make the
   // section fail validation, which silently prevents collapse() from collapsing.
+  //
+  // Place Details responses occasionally come back with a `route` but no
+  // `street_number` (Google resolved the place to a route/geocode rather than a
+  // precise premise). Rebuilding the street from components alone would then drop
+  // the house number the user already entered (e.g. "32501 Dufferin Street" ->
+  // "Dufferin Street"). Only overwrite when we have a street_number, or when the
+  // field is currently empty (nothing to lose).
   const street = [c.street_number?.longText, c.route?.longText].filter(Boolean).join(' ');
-  if (street) setAddressFieldValue(addressInput, street);
+  if (street && (c.street_number?.longText || !addressInput.value.trim())) {
+    setAddressFieldValue(addressInput, street);
+  }
 
   const address2Input = section.querySelector('[autocomplete="address-line2"]');
   if (address2Input && c.subpremise) {

--- a/tests/unit/checkout-address-autocomplete.test.js
+++ b/tests/unit/checkout-address-autocomplete.test.js
@@ -3,7 +3,35 @@ import assert from 'node:assert/strict';
 import {
   buildPlacesAutocompleteInput,
   setAddressFieldValue,
+  fillAddressFields,
 } from '../../blocks/checkout/checkout-address.js';
+
+// Minimal field mock compatible with setAddressFieldValue/clearFieldError:
+// closest() returns null so clearFieldError early-returns, and dispatchEvent
+// is a no-op recorder.
+function fieldMock(value = '') {
+  return {
+    value,
+    closest() { return null; },
+    removeAttribute() {},
+    dispatchEvent() { return true; },
+    classList: { toggle() {} },
+  };
+}
+
+// Section mock for fillAddressFields, which queries by [autocomplete="..."]
+// for line2/city/zip and select[name$="-state"] for the state dropdown.
+function sectionForFill(fields) {
+  return {
+    querySelector(selector) {
+      return fields[selector] || null;
+    },
+  };
+}
+
+function component(types, longText, shortText = longText) {
+  return { types, longText, shortText };
+}
 
 function sectionWithFields(fields) {
   return {
@@ -108,4 +136,42 @@ test('setAddressFieldValue clears stale field errors without reopening autocompl
   assert.deepEqual(wrapper.classList.removed, ['has-error']);
   assert.equal(removed, true);
   assert.deepEqual(events, ['remove:aria-invalid', 'remove:aria-describedby', 'change']);
+});
+
+test('fillAddressFields keeps the house number when Place Details omits street_number', () => {
+  // Regression: Google occasionally returns a `route` with no `street_number`.
+  // Rebuilding from components alone dropped the number the user already had,
+  // turning "32501 Dufferin Street" into "Dufferin Street".
+  const addressInput = fieldMock('32501 Dufferin Street');
+  const section = sectionForFill({});
+
+  fillAddressFields(section, addressInput, [
+    component(['route'], 'Dufferin Street'),
+    component(['locality'], 'Toronto'),
+  ]);
+
+  assert.equal(addressInput.value, '32501 Dufferin Street');
+});
+
+test('fillAddressFields rebuilds street from components when street_number is present', () => {
+  const addressInput = fieldMock('32501 Dufferin');
+  const section = sectionForFill({});
+
+  fillAddressFields(section, addressInput, [
+    component(['street_number'], '32501'),
+    component(['route'], 'Dufferin Street'),
+  ]);
+
+  assert.equal(addressInput.value, '32501 Dufferin Street');
+});
+
+test('fillAddressFields populates an empty street from a route-only result', () => {
+  const addressInput = fieldMock('');
+  const section = sectionForFill({});
+
+  fillAddressFields(section, addressInput, [
+    component(['route'], 'Dufferin Street'),
+  ]);
+
+  assert.equal(addressInput.value, 'Dufferin Street');
 });

--- a/widgets/search-results/search-results.js
+++ b/widgets/search-results/search-results.js
@@ -263,7 +263,10 @@ function filterBySearch(index, searchTerm) {
   }).map((item) => ({ ...item, searchTerm: term }));
 }
 
-/** Type order for tie-break: product > manual > recipe > article > query (lower = higher priority). */
+/**
+ * Type order for tie-break: product > manual > recipe > article > query
+ * (lower = higher priority).
+ */
 const TYPE_ORDER = {
   product: 0,
   manual: 1,


### PR DESCRIPTION
Autocomplete selection rebuilt the street from `street_number + route` and wrote it back whenever non-empty, so a route-only Place Details response dropped the house number the user had (e.g. "32501 Dufferin Street" became "Dufferin Street"). The street is now only overwritten when a `street_number` is present or the field is empty.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-checkout-autocomplete-street-number--vitamix--aemsites.aem.network/