### PR TITLE
fix: horizontal scrollbar caused by video carousel

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -795,17 +795,18 @@
 /* Videos variant */
 
 .carousel-wrapper:has(.carousel.videos.block) {
-  margin-right: calc(-1 * var(--horizontal-spacing));
-}
-
-@media (width >= 600px) {
-  .carousel-wrapper:has(.carousel.videos.block) {
-    margin-right: 0;
-  }
+  overflow-x: hidden;
 }
 
 .carousel.videos.block {
   overflow: visible;
+  margin-right: calc(-1 * var(--horizontal-spacing));
+}
+
+@media (width >= 600px) {
+  .carousel.videos.block {
+    margin-right: 0;
+  }
 }
 
 /* Track */


### PR DESCRIPTION
Fixes a page-wide horizontal scrollbar on mobile widths caused by the videos carousel variant.

The wrapper previously applied a negative margin-right bleed to itself with nothing to clip it, so its box rendered wider than the viewport.

Moved the bleed margin down to the `.carousel.videos.block` child and added `overflow-x: hidden` on the `.carousel-wrapper` parent to correctly contain it, matching the existing pattern used by the expansion carousel variant.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/
- After: https://video-scollbar--vitamix--aemsites.aem.network/us/en_us/
