### PR TITLE
fix(checkout): defer preview until payment selection

### DIFF
--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -14,6 +14,20 @@ import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 export { validateLinkIntegrity };
 
 /**
+ * Builds checkout context fields for full-checkout order payloads.
+ * @param {string|null} paymentMethod
+ * @returns {Object|null}
+ */
+export function getCheckoutContext(paymentMethod) {
+  if (!paymentMethod) return null;
+  return {
+    paymentMethod,
+    checkoutFlow: paymentMethod === 'apple-pay' ? 'express' : 'standard',
+    entryPoint: 'checkout',
+  };
+}
+
+/**
  * Writes checkout state to sessionStorage before a payment redirect.
  * @param {string} email
  * @param {Object} cart
@@ -87,8 +101,8 @@ export function buildOrderJSON(formData, form, cart, state, config) {
   order.locale = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
   order.country = locale;
 
-  const paymentMethod = formData.get('paymentMethod');
-  if (paymentMethod) order.paymentMethod = paymentMethod;
+  const checkoutContext = getCheckoutContext(formData.get('paymentMethod'));
+  if (checkoutContext) Object.assign(order, checkoutContext);
 
   const customerTimezone = getCustomerTimezone();
   if (customerTimezone) order.customerTimezone = customerTimezone;

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -157,6 +157,47 @@ export async function updatePreview(form, cart, state, config) {
 }
 
 /**
+ * Clears the currently signed preview state after order-affecting changes.
+ * @param {Object} state
+ */
+export function clearPreviewState(state) {
+  state.currentEstimateToken = null;
+  state.currentPreview = null;
+}
+
+/**
+ * Returns whether the shopper has explicitly selected a payment method.
+ * @param {Object} state
+ * @returns {boolean}
+ */
+export function hasExplicitPaymentSelection(state) {
+  return state.paymentMethodSelected === true;
+}
+
+/**
+ * Returns whether a preview should run after order-affecting changes.
+ * @param {Object} state
+ * @returns {boolean}
+ */
+export function shouldUpdatePreviewAfterPaymentSelection(state) {
+  return hasExplicitPaymentSelection(state) && Boolean(state.selectedShippingMethodId);
+}
+
+/**
+ * Refreshes the order preview only after explicit payment selection.
+ * @param {HTMLFormElement} form
+ * @param {Object} cart
+ * @param {Object} state
+ * @param {Object} config
+ * @returns {Promise<void>}
+ */
+export async function updatePreviewAfterPaymentSelection(form, cart, state, config) {
+  if (shouldUpdatePreviewAfterPaymentSelection(state)) {
+    await updatePreview(form, cart, state, config);
+  }
+}
+
+/**
  * Fetches shipping rates then triggers a preview.
  * @param {HTMLFormElement} form
  * @param {HTMLFieldSetElement} shippingContainer
@@ -199,8 +240,9 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
     if (targetRadio) {
       targetRadio.checked = true;
       state.selectedShippingMethodId = targetRadio.value;
+      clearPreviewState(state);
       shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', { bubbles: true }));
-      await updatePreview(form, cart, state, config);
+      await updatePreviewAfterPaymentSelection(form, cart, state, config);
     }
   } catch {
     renderShippingMethods(shippingContainer, [], strings, currencyCode);
@@ -239,8 +281,9 @@ export function initShipping(form, shippingContainer, cart, state, config, strin
   shippingContainer.addEventListener('change', (e) => {
     if (e.target.name === 'shippingMethod') {
       state.selectedShippingMethodId = e.target.value;
+      clearPreviewState(state);
       shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', { bubbles: true }));
-      updatePreview(form, cart, state, config);
+      updatePreviewAfterPaymentSelection(form, cart, state, config);
     }
   });
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -7,7 +7,11 @@ import affirm from '../../scripts/payments/affirm.js';
 import chase from '../../scripts/payments/chase.js';
 import buildForm, { initCollapse } from './checkout-form.js';
 import { initAddress } from './checkout-address.js';
-import { initShipping, updatePreview } from './checkout-shipping.js';
+import {
+  clearPreviewState,
+  initShipping,
+  updatePreview,
+} from './checkout-shipping.js';
 import { initOrder } from './checkout-order.js';
 import { initPayment } from './checkout-payment.js';
 import { parsePreview } from '../../scripts/commerce-api.js';
@@ -443,7 +447,12 @@ export default async function decorate(block) {
     const input = form.querySelector(`[name="${name}"]`);
     if (!input) return;
     input.addEventListener('blur', () => {
-      if (input.value && state.selectedShippingMethodId && !state.currentPreview) {
+      if (
+        input.value
+        && state.selectedShippingMethodId
+        && !state.currentPreview
+        && state.paymentMethodSelected
+      ) {
         updatePreview(form, cart, state, config);
       }
     });
@@ -475,7 +484,10 @@ export default async function decorate(block) {
 
   // Re-run preview on payment method change — tax may vary by type (e.g. Avalara surcharge)
   paymentContainer.addEventListener('change', (e) => {
-    if (e.target.name === 'paymentMethod') updatePreview(form, cart, state, config);
+    if (e.target.name !== 'paymentMethod') return;
+    state.paymentMethodSelected = true;
+    clearPreviewState(state);
+    if (state.selectedShippingMethodId) updatePreview(form, cart, state, config);
   });
 
   // Inject order-summary block into this section if the author didn't add one

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -136,10 +136,11 @@ export async function estimatePrice(country, items, couponCode, couponSource) {
  * @param {string} state - State or province code (e.g. 'QC', 'CA')
  * @param {string} zip - Postal/ZIP code
  * @param {Array<{sku: string, path: string, quantity: number, price: Object}>} items
+ * @param {Object} [context={}] - Optional checkout context fields for tax rules
  * @returns {Promise<{ subtotal: number, shippingMethods: Array<Object> }>}
  * @throws {CommerceApiError}
  */
-export async function estimateExpressCheckout(country, state, zip, items) {
+export async function estimateExpressCheckout(country, state, zip, items, context = {}) {
   // BCP-47 store-view locale (e.g. 'fr-CA') so the API can localize method labels.
   const { language: locale } = getLocaleAndLanguage(false, true);
   return post('/estimate/order', {
@@ -147,6 +148,7 @@ export async function estimateExpressCheckout(country, state, zip, items) {
     locale,
     shipping: { country, state, zip },
     items,
+    ...context,
   });
 }
 

--- a/scripts/payments/apple-pay-context.js
+++ b/scripts/payments/apple-pay-context.js
@@ -1,0 +1,87 @@
+export const APPLE_PAY_CART_CONTEXT = {
+  paymentMethod: 'apple-pay',
+  checkoutFlow: 'express',
+  entryPoint: 'cart',
+};
+
+/**
+ * Builds the Apple Pay cart preview payload for a selected shipping method.
+ * @param {Object} cart
+ * @param {string} shippingMethodId
+ * @param {string} locale
+ * @param {Object|null} contact
+ * @returns {Object}
+ */
+export function buildApplePayCartPreviewPayload(cart, shippingMethodId, locale, contact) {
+  const countryCode = contact?.countryCode?.toLowerCase();
+  return {
+    ...APPLE_PAY_CART_CONTEXT,
+    items: cart.getItemsForAPI(),
+    shippingMethod: { id: shippingMethodId },
+    locale,
+    ...(countryCode ? {
+      country: countryCode,
+      shipping: {
+        country: countryCode,
+        state: contact.administrativeArea,
+        zip: contact.postalCode || '',
+      },
+    } : {}),
+  };
+}
+
+/**
+ * Builds the Apple Pay cart order payload from the authorized payment contact.
+ * @param {Object} params
+ * @param {Object} params.payment
+ * @param {Object} params.cart
+ * @param {string} params.shippingMethodId
+ * @param {string} params.estimateToken
+ * @param {string} params.country
+ * @param {string} params.locale
+ * @param {string} params.customerEmail
+ * @param {string} [params.customerTimezone]
+ * @returns {Object}
+ */
+export function buildApplePayCartOrderPayload(params) {
+  const {
+    payment,
+    cart,
+    shippingMethodId,
+    estimateToken,
+    country,
+    locale,
+    customerEmail,
+    customerTimezone,
+  } = params;
+  const contact = payment.shippingContact;
+  const shippingAddr = {
+    name: `${contact.givenName} ${contact.familyName}`.trim(),
+    address1: (contact.addressLines || [])[0] || '',
+    address2: (contact.addressLines || [])[1] || '',
+    city: contact.locality,
+    state: contact.administrativeArea,
+    zip: contact.postalCode,
+    country: contact.countryCode?.toLowerCase() || country,
+    phone: contact.phoneNumber || '',
+    email: contact.emailAddress || '',
+  };
+
+  return {
+    ...APPLE_PAY_CART_CONTEXT,
+    customer: {
+      firstName: contact.givenName || '',
+      lastName: contact.familyName || '',
+      email: customerEmail,
+      phone: contact.phoneNumber || '',
+    },
+    shipping: shippingAddr,
+    billing: shippingAddr,
+    items: cart.getItemsForAPI(),
+    shippingMethod: { id: shippingMethodId },
+    estimateToken,
+    country,
+    locale,
+    ...(customerTimezone ? { customerTimezone } : {}),
+  };
+}

--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -5,6 +5,11 @@ import {
 } from '../commerce-api.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
+import {
+  APPLE_PAY_CART_CONTEXT,
+  buildApplePayCartOrderPayload,
+  buildApplePayCartPreviewPayload,
+} from './apple-pay-context.js';
 
 const APPLE_PAY_SDK_URL = 'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js';
 
@@ -78,6 +83,7 @@ function startExpressSession(btn, config, callbacks) {
           contact.administrativeArea,
           contact.postalCode,
           cart.getItemsForAPI(),
+          APPLE_PAY_CART_CONTEXT,
         );
         const methods = result.shippingMethods || [];
         if (!methods.length) {
@@ -116,21 +122,14 @@ function startExpressSession(btn, config, callbacks) {
 
     session.onshippingmethodselected = async (e) => {
       try {
-        const contact = lastShippingContact;
-        const countryCode = contact?.countryCode?.toLowerCase();
-        const previewResult = await callbacks.previewOrderDirect({
-          items: cart.getItemsForAPI(),
-          shippingMethod: { id: e.shippingMethod.identifier },
-          locale: bcp47,
-          ...(countryCode ? {
-            country: countryCode,
-            shipping: {
-              country: countryCode,
-              state: contact.administrativeArea,
-              zip: contact.postalCode || '',
-            },
-          } : {}),
-        });
+        const previewResult = await callbacks.previewOrderDirect(
+          buildApplePayCartPreviewPayload(
+            cart,
+            e.shippingMethod.identifier,
+            bcp47,
+            lastShippingContact,
+          ),
+        );
         lastShippingMethodId = e.shippingMethod.identifier;
         callbacks.getState().currentEstimateToken = previewResult.estimateToken;
         session.completeShippingMethodSelection({
@@ -151,39 +150,21 @@ function startExpressSession(btn, config, callbacks) {
       const { payment } = e;
       const contact = payment.shippingContact;
       try {
-        const shippingAddr = {
-          name: `${contact.givenName} ${contact.familyName}`.trim(),
-          address1: (contact.addressLines || [])[0] || '',
-          address2: (contact.addressLines || [])[1] || '',
-          city: contact.locality,
-          state: contact.administrativeArea,
-          zip: contact.postalCode,
-          country: contact.countryCode?.toLowerCase() || locale,
-          phone: contact.phoneNumber || '',
-          email: contact.emailAddress || '',
-        };
-
         // When the user is signed in, use their account email so the order is linked
         // to the right account. The Apple Pay contact email may differ from the
         // commerce account email, which causes assertEmail to reject the request.
         const customerEmail = (isLoggedIn() && getUser()?.email) || contact.emailAddress || '';
         const customerTimezone = getCustomerTimezone();
-        const orderBody = {
-          customer: {
-            firstName: contact.givenName || '',
-            lastName: contact.familyName || '',
-            email: customerEmail,
-            phone: contact.phoneNumber || '',
-          },
-          shipping: shippingAddr,
-          billing: shippingAddr,
-          items: cart.getItemsForAPI(),
-          shippingMethod: { id: lastShippingMethodId || e.payment.shippingMethod?.identifier || '' },
+        const orderBody = buildApplePayCartOrderPayload({
+          payment,
+          cart,
+          shippingMethodId: lastShippingMethodId || e.payment.shippingMethod?.identifier || '',
           estimateToken: callbacks.getState().currentEstimateToken,
           country: locale,
           locale: bcp47,
-          ...(customerTimezone ? { customerTimezone } : {}),
-        };
+          customerEmail,
+          customerTimezone,
+        });
 
         const createdOrder = await callbacks.createOrder(orderBody);
         const fraudToken = (() => {

--- a/scripts/payments/paypal-context.js
+++ b/scripts/payments/paypal-context.js
@@ -1,0 +1,10 @@
+/**
+ * Ensures checkout PayPal has a signed estimate token before order creation.
+ * @param {Object} callbacks
+ * @returns {Promise<boolean>}
+ */
+export default async function ensureCheckoutPreviewToken(callbacks) {
+  if (callbacks.getState().currentEstimateToken) return true;
+  await callbacks.updatePreview();
+  return Boolean(callbacks.getState().currentEstimateToken);
+}

--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -7,6 +7,7 @@ import {
 import { getLocaleAndLanguage } from '../scripts.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
+import ensureCheckoutPreviewToken from './paypal-context.js';
 
 let sdkLoadPromise = null;
 
@@ -360,14 +361,10 @@ export default {
       callbacks.clearError();
       btn.disabled = true;
 
-      const state = callbacks.getState();
-      if (!state.currentEstimateToken) {
-        await callbacks.updatePreview();
-        if (!callbacks.getState().currentEstimateToken) {
-          callbacks.showError('Unable to calculate totals. Please try again.');
-          btn.disabled = false;
-          return;
-        }
+      if (!await ensureCheckoutPreviewToken(callbacks)) {
+        callbacks.showError('Unable to calculate totals. Please try again.');
+        btn.disabled = false;
+        return;
       }
 
       const formData = callbacks.getFormData();

--- a/tests/unit/apple-pay-context.test.js
+++ b/tests/unit/apple-pay-context.test.js
@@ -110,3 +110,38 @@ test('buildApplePayCartOrderPayload includes cart context and full address data'
   });
   assert.deepEqual(payload.billing, payload.shipping);
 });
+
+test('Apple Pay cart preview and order payloads use matching context facts', () => {
+  const preview = buildApplePayCartPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    shippingContact,
+  );
+  const order = buildApplePayCartOrderPayload({
+    payment: { shippingContact: paymentContact },
+    cart,
+    shippingMethodId: 'standard',
+    estimateToken: 'estimate-token',
+    country: 'us',
+    locale: 'en-US',
+    customerEmail: 'account@example.com',
+  });
+
+  assert.deepEqual(
+    {
+      paymentMethod: preview.paymentMethod,
+      checkoutFlow: preview.checkoutFlow,
+      entryPoint: preview.entryPoint,
+    },
+    APPLE_PAY_CART_CONTEXT,
+  );
+  assert.deepEqual(
+    {
+      paymentMethod: order.paymentMethod,
+      checkoutFlow: order.checkoutFlow,
+      entryPoint: order.entryPoint,
+    },
+    APPLE_PAY_CART_CONTEXT,
+  );
+});

--- a/tests/unit/apple-pay-context.test.js
+++ b/tests/unit/apple-pay-context.test.js
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  APPLE_PAY_CART_CONTEXT,
+  buildApplePayCartOrderPayload,
+  buildApplePayCartPreviewPayload,
+} from '../../scripts/payments/apple-pay-context.js';
+
+const ITEMS = [{
+  sku: 'sku-1',
+  path: '/products/sku-1',
+  quantity: 1,
+  price: { currency: 'USD', regular: '10.00' },
+}];
+
+const cart = {
+  getItemsForAPI: () => ITEMS,
+};
+
+const shippingContact = {
+  countryCode: 'US',
+  administrativeArea: 'MN',
+  postalCode: '55441',
+};
+
+const paymentContact = {
+  givenName: 'Jane',
+  familyName: 'Doe',
+  addressLines: ['123 Main St', 'Suite 4'],
+  locality: 'Cleveland',
+  administrativeArea: 'OH',
+  postalCode: '44101',
+  countryCode: 'US',
+  phoneNumber: '(555) 123-4567',
+  emailAddress: 'apple@example.com',
+};
+
+test('APPLE_PAY_CART_CONTEXT identifies cart-origin Apple Pay express checkout', () => {
+  assert.deepEqual(APPLE_PAY_CART_CONTEXT, {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+  });
+});
+
+test('buildApplePayCartPreviewPayload includes cart context and partial shipping', () => {
+  const payload = buildApplePayCartPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    shippingContact,
+  );
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.checkoutFlow, 'express');
+  assert.equal(payload.entryPoint, 'cart');
+  assert.deepEqual(payload.items, ITEMS);
+  assert.deepEqual(payload.shippingMethod, { id: 'standard' });
+  assert.equal(payload.locale, 'en-US');
+  assert.equal(payload.country, 'us');
+  assert.deepEqual(payload.shipping, {
+    country: 'us',
+    state: 'MN',
+    zip: '55441',
+  });
+});
+
+test('buildApplePayCartPreviewPayload omits shipping when contact has no country', () => {
+  const payload = buildApplePayCartPreviewPayload(cart, 'standard', 'en-US', null);
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.country, undefined);
+  assert.equal(payload.shipping, undefined);
+});
+
+test('buildApplePayCartOrderPayload includes cart context and full address data', () => {
+  const payload = buildApplePayCartOrderPayload({
+    payment: { shippingContact: paymentContact },
+    cart,
+    shippingMethodId: 'standard',
+    estimateToken: 'estimate-token',
+    country: 'us',
+    locale: 'en-US',
+    customerEmail: 'account@example.com',
+    customerTimezone: 'America/New_York',
+  });
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.checkoutFlow, 'express');
+  assert.equal(payload.entryPoint, 'cart');
+  assert.equal(payload.customer.email, 'account@example.com');
+  assert.equal(payload.customer.firstName, 'Jane');
+  assert.equal(payload.customer.lastName, 'Doe');
+  assert.deepEqual(payload.shippingMethod, { id: 'standard' });
+  assert.equal(payload.estimateToken, 'estimate-token');
+  assert.equal(payload.country, 'us');
+  assert.equal(payload.locale, 'en-US');
+  assert.equal(payload.customerTimezone, 'America/New_York');
+  assert.deepEqual(payload.items, ITEMS);
+  assert.deepEqual(payload.shipping, {
+    name: 'Jane Doe',
+    address1: '123 Main St',
+    address2: 'Suite 4',
+    city: 'Cleveland',
+    state: 'OH',
+    zip: '44101',
+    country: 'us',
+    phone: '(555) 123-4567',
+    email: 'apple@example.com',
+  });
+  assert.deepEqual(payload.billing, payload.shipping);
+});

--- a/tests/unit/checkout-order-context.test.js
+++ b/tests/unit/checkout-order-context.test.js
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOrderJSON, getCheckoutContext } from '../../blocks/checkout/checkout-order.js';
+
+function formData(values) {
+  return {
+    get(name) {
+      return values[name] ?? '';
+    },
+  };
+}
+
+function formWithBillingChoice(value = 'same') {
+  return {
+    querySelector(selector) {
+      if (selector === '[name="billing-choice"]:checked') return { value };
+      return null;
+    },
+  };
+}
+
+const config = {
+  getLocale: () => 'us',
+  getLanguage: () => 'en_us',
+};
+
+const cart = {
+  getItemsForAPI: () => [{
+    sku: 'sku-1',
+    path: '/products/sku-1',
+    quantity: 1,
+    price: { currency: 'USD', regular: '10.00' },
+  }],
+};
+
+const baseValues = {
+  email: 'jane@example.com',
+  'shipping-firstname': 'Jane',
+  'shipping-lastname': 'Doe',
+  'shipping-street-0': '123 Main St',
+  'shipping-street-1': '',
+  'shipping-city': 'Cleveland',
+  'shipping-state': 'OH',
+  'shipping-zip': '44101',
+  'shipping-telephone': '(555) 123-4567',
+};
+
+function buildOrder(values) {
+  return buildOrderJSON(
+    formData({ ...baseValues, ...values }),
+    formWithBillingChoice('same'),
+    cart,
+    {},
+    config,
+  );
+}
+
+test('getCheckoutContext returns null when payment method is absent', () => {
+  assert.equal(getCheckoutContext(''), null);
+  assert.equal(getCheckoutContext(null), null);
+});
+
+test('getCheckoutContext returns standard checkout context for card payments', () => {
+  assert.deepEqual(getCheckoutContext('chase'), {
+    paymentMethod: 'chase',
+    checkoutFlow: 'standard',
+    entryPoint: 'checkout',
+  });
+});
+
+test('getCheckoutContext returns express checkout context for checkout-page Apple Pay', () => {
+  assert.deepEqual(getCheckoutContext('apple-pay'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'checkout',
+  });
+});
+
+test('buildOrderJSON includes checkout context for card checkout', () => {
+  const order = buildOrder({ paymentMethod: 'chase' });
+
+  assert.equal(order.paymentMethod, 'chase');
+  assert.equal(order.checkoutFlow, 'standard');
+  assert.equal(order.entryPoint, 'checkout');
+});
+
+test('buildOrderJSON includes checkout entry point for checkout-page Apple Pay', () => {
+  const order = buildOrder({ paymentMethod: 'apple-pay' });
+
+  assert.equal(order.paymentMethod, 'apple-pay');
+  assert.equal(order.checkoutFlow, 'express');
+  assert.equal(order.entryPoint, 'checkout');
+});
+
+test('buildOrderJSON omits checkout context when payment method is absent', () => {
+  const order = buildOrder({ paymentMethod: '' });
+
+  assert.equal(order.paymentMethod, undefined);
+  assert.equal(order.checkoutFlow, undefined);
+  assert.equal(order.entryPoint, undefined);
+});

--- a/tests/unit/checkout-order-context.test.js
+++ b/tests/unit/checkout-order-context.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildOrderJSON, getCheckoutContext } from '../../blocks/checkout/checkout-order.js';
+import { APPLE_PAY_CART_CONTEXT } from '../../scripts/payments/apple-pay-context.js';
 
 function formData(values) {
   return {
@@ -90,6 +91,14 @@ test('buildOrderJSON includes checkout entry point for checkout-page Apple Pay',
   assert.equal(order.paymentMethod, 'apple-pay');
   assert.equal(order.checkoutFlow, 'express');
   assert.equal(order.entryPoint, 'checkout');
+});
+
+test('checkout-page Apple Pay context does not reuse cart entry point', () => {
+  const order = buildOrder({ paymentMethod: 'apple-pay' });
+
+  assert.equal(APPLE_PAY_CART_CONTEXT.entryPoint, 'cart');
+  assert.equal(order.entryPoint, 'checkout');
+  assert.notEqual(order.entryPoint, APPLE_PAY_CART_CONTEXT.entryPoint);
 });
 
 test('buildOrderJSON omits checkout context when payment method is absent', () => {

--- a/tests/unit/checkout-shipping.test.js
+++ b/tests/unit/checkout-shipping.test.js
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { findShippingMethodRadio } from '../../blocks/checkout/checkout-shipping.js';
+import {
+  clearPreviewState,
+  findShippingMethodRadio,
+  hasExplicitPaymentSelection,
+  shouldUpdatePreviewAfterPaymentSelection,
+} from '../../blocks/checkout/checkout-shipping.js';
 
 function radio(value, type, label) {
   return {
@@ -60,4 +65,33 @@ test('findShippingMethodRadio falls back to label, then first method', () => {
     standard,
   );
   assert.equal(findShippingMethodRadio(container([]), { id: '218' }), null);
+});
+
+test('clearPreviewState clears signed estimate state', () => {
+  const state = { currentEstimateToken: 'token', currentPreview: { total: 10 } };
+
+  clearPreviewState(state);
+
+  assert.equal(state.currentEstimateToken, null);
+  assert.equal(state.currentPreview, null);
+});
+
+test('hasExplicitPaymentSelection is true only after explicit payment selection', () => {
+  assert.equal(hasExplicitPaymentSelection({}), false);
+  assert.equal(hasExplicitPaymentSelection({ paymentMethodSelected: false }), false);
+  assert.equal(hasExplicitPaymentSelection({ paymentMethodSelected: true }), true);
+});
+
+test('shouldUpdatePreviewAfterPaymentSelection requires payment and shipping selection', () => {
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({}), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    paymentMethodSelected: true,
+  }), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    selectedShippingMethodId: 'standard',
+  }), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    paymentMethodSelected: true,
+    selectedShippingMethodId: 'standard',
+  }), true);
 });

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -214,6 +214,21 @@ test('estimateExpressCheckout: sends locale and order shape', async () => {
   assert.deepEqual(body.items, items);
 });
 
+test('estimateExpressCheckout: includes optional checkout context fields', async () => {
+  const items = [{ sku: 'abc', quantity: 1, price: { final: '50.00' } }];
+  mockFetch(200, { subtotal: '50.00', shippingMethods: [] });
+  await estimateExpressCheckout('us', 'MN', '55441', items, {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+  });
+
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.paymentMethod, 'apple-pay');
+  assert.equal(body.checkoutFlow, 'express');
+  assert.equal(body.entryPoint, 'cart');
+});
+
 test('estimatePrice: includes couponSource when provided with couponCode', async () => {
   mockFetch(200, { discounts: [], orderDiscountTotal: 0 });
   await estimatePrice('us', [], 'IDME10', 'auto');

--- a/tests/unit/paypal-checkout-preview.test.js
+++ b/tests/unit/paypal-checkout-preview.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import ensureCheckoutPreviewToken from '../../scripts/payments/paypal-context.js';
+
+function callbacksForState(state) {
+  let updatePreviewCalls = 0;
+  return {
+    callbacks: {
+      getState: () => state,
+      updatePreview: async () => {
+        updatePreviewCalls += 1;
+        state.currentEstimateToken = 'generated-token';
+      },
+    },
+    getUpdatePreviewCalls: () => updatePreviewCalls,
+  };
+}
+
+test('ensureCheckoutPreviewToken reuses an existing PayPal checkout estimate token', async () => {
+  const state = { currentEstimateToken: 'existing-token' };
+  const { callbacks, getUpdatePreviewCalls } = callbacksForState(state);
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), true);
+  assert.equal(getUpdatePreviewCalls(), 0);
+  assert.equal(state.currentEstimateToken, 'existing-token');
+});
+
+test('ensureCheckoutPreviewToken creates a PayPal checkout estimate token when missing', async () => {
+  const state = {};
+  const { callbacks, getUpdatePreviewCalls } = callbacksForState(state);
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), true);
+  assert.equal(getUpdatePreviewCalls(), 1);
+  assert.equal(state.currentEstimateToken, 'generated-token');
+});
+
+test('ensureCheckoutPreviewToken reports failure when preview does not return a token', async () => {
+  let updatePreviewCalls = 0;
+  const callbacks = {
+    getState: () => ({}),
+    updatePreview: async () => { updatePreviewCalls += 1; },
+  };
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), false);
+  assert.equal(updatePreviewCalls, 1);
+});


### PR DESCRIPTION
## Problem

Vitamix cart-origin Apple Pay did not send the explicit checkout context required by Commerce API tax rules, and standard checkout preview could run before the shopper explicitly selected a payment method.

## Solution

This branch sends Apple Pay cart context through estimate, preview, and order creation payloads; keeps checkout-page Apple Pay on the checkout entry point; and defers final preview generation until payment selection while clearing stale estimate state after order-affecting shipping changes.

## Tests

- `npm run lint`
- Focused unit tests for commerce API context, Apple Pay cart payloads, checkout order context, and checkout shipping preview timing

Note: `npm test` currently fails on an existing unrelated unit mock issue in `tests/unit/add-to-cart.test.js` where the mock `scripts.js` does not export `getPdpOverride`.

## Review notes

- Commit 4 changes checkout preview timing and should get careful review.
- Impl plan still has Commit 5 unchecked; push/PR creation was not blocked because the requested branch currently contains the reviewed implementation commits.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://apple-pay-tax-context--vitamix--aemsites.aem.network/
