### PR TITLE
feat(checkout): defer preview until payment selection

### DIFF
--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -14,6 +14,29 @@ import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 export { validateLinkIntegrity };
 
 /**
+ * Builds checkout context fields for full-checkout order payloads.
+ * @param {string|null} paymentMethod
+ * @returns {Object|null}
+ */
+export function getCheckoutContext(paymentMethod) {
+  if (!paymentMethod) return null;
+  return {
+    paymentMethod,
+    checkoutFlow: paymentMethod === 'apple-pay' ? 'express' : 'standard',
+    entryPoint: 'checkout',
+  };
+}
+
+/**
+ * Returns the explicitly selected checkout payment method, if any.
+ * @param {HTMLFormElement} form
+ * @returns {string|null}
+ */
+export function getSelectedPaymentMethod(form) {
+  return form.querySelector('[name="paymentMethod"]:checked')?.value || null;
+}
+
+/**
  * Writes checkout state to sessionStorage before a payment redirect.
  * @param {string} email
  * @param {Object} cart
@@ -87,8 +110,8 @@ export function buildOrderJSON(formData, form, cart, state, config) {
   order.locale = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
   order.country = locale;
 
-  const paymentMethod = formData.get('paymentMethod');
-  if (paymentMethod) order.paymentMethod = paymentMethod;
+  const checkoutContext = getCheckoutContext(formData.get('paymentMethod'));
+  if (checkoutContext) Object.assign(order, checkoutContext);
 
   const customerTimezone = getCustomerTimezone();
   if (customerTimezone) order.customerTimezone = customerTimezone;
@@ -254,7 +277,11 @@ export function initOrder(form, cart, state, config, strings) {
       }
 
       // Delegate to the selected provider's own button if not credit-card
-      const selectedMethod = form.querySelector('[name="paymentMethod"]:checked')?.value;
+      const selectedMethod = getSelectedPaymentMethod(form);
+      if (!selectedMethod) {
+        showError(form, strings.errorSelectPayment);
+        return;
+      }
 
       if (selectedMethod === 'apple-pay') {
         submitBtn.disabled = true;

--- a/blocks/checkout/checkout-payment.js
+++ b/blocks/checkout/checkout-payment.js
@@ -95,13 +95,12 @@ export function renderPaymentSection(container, activeProviders, callbacks, stri
   // Credit card option
   if (chaseActive) {
     const cardLabel = document.createElement('label');
-    cardLabel.className = 'payment-option-card payment-option-active';
+    cardLabel.className = 'payment-option-card';
 
     const cardRadio = document.createElement('input');
     cardRadio.type = 'radio';
     cardRadio.name = 'paymentMethod';
     cardRadio.value = cardProviderId;
-    cardRadio.checked = true;
     cardRadio.id = 'payment-credit-card';
 
     const cardIcon = document.createElement('span');
@@ -178,20 +177,6 @@ export function renderPaymentSection(container, activeProviders, callbacks, stri
 
   container.appendChild(optionsWrapper);
   wireRadioTabNav(optionsWrapper, 'paymentMethod');
-
-  // When Chase is disabled, default-select the first available provider
-  if (!chaseActive) {
-    const firstRadio = optionsWrapper.querySelector('input[type="radio"]');
-    if (firstRadio) {
-      firstRadio.checked = true;
-      firstRadio.closest('.payment-option-card')?.classList.add('payment-option-active');
-      const firstProvider = activeProviders.find((p) => p.id !== cardProviderId);
-      const billingSection = container.closest('form')?.querySelector('.billing-section');
-      if (billingSection && firstProvider) {
-        billingSection.hidden = firstProvider.hidesBilling ?? false;
-      }
-    }
-  }
 
   // Wire radio changes
   container.addEventListener('change', (e) => {

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -80,6 +80,37 @@ export function findShippingMethodRadio(container, previousSelection = {}) {
 }
 
 /**
+ * Finds the estimated shipping method details for a selected radio.
+ * @param {Array<{id: string|number, type?: string, label?: string, rate?: string|number}>} rates
+ * @param {HTMLInputElement|null} radio
+ * @returns {Object|null}
+ */
+export function findShippingMethodRate(rates, radio) {
+  if (!radio) return null;
+  return rates.find((rate) => String(rate.id) === String(radio.value))
+    || rates.find((rate) => rate.type && rate.type === radio.dataset.shippingType)
+    || rates.find((rate) => rate.label && rate.label === radio.dataset.shippingLabel)
+    || null;
+}
+
+/**
+ * Dispatches the selected estimated shipping method for summary-only updates.
+ * @param {HTMLElement} shippingContainer
+ * @param {Object|null} shippingMethod
+ */
+function dispatchShippingSelected(shippingContainer, shippingMethod) {
+  shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', {
+    bubbles: true,
+    detail: {
+      shippingMethod: shippingMethod ? {
+        ...shippingMethod,
+        id: String(shippingMethod.id),
+      } : null,
+    },
+  }));
+}
+
+/**
  * Fetches a preview and dispatches checkout:preview event.
  * @param {HTMLFormElement} form
  * @param {Object} cart
@@ -157,6 +188,47 @@ export async function updatePreview(form, cart, state, config) {
 }
 
 /**
+ * Clears the currently signed preview state after order-affecting changes.
+ * @param {Object} state
+ */
+export function clearPreviewState(state) {
+  state.currentEstimateToken = null;
+  state.currentPreview = null;
+}
+
+/**
+ * Returns whether the shopper has explicitly selected a payment method.
+ * @param {Object} state
+ * @returns {boolean}
+ */
+export function hasExplicitPaymentSelection(state) {
+  return state.paymentMethodSelected === true;
+}
+
+/**
+ * Returns whether a preview should run after order-affecting changes.
+ * @param {Object} state
+ * @returns {boolean}
+ */
+export function shouldUpdatePreviewAfterPaymentSelection(state) {
+  return hasExplicitPaymentSelection(state) && Boolean(state.selectedShippingMethodId);
+}
+
+/**
+ * Refreshes the order preview only after explicit payment selection.
+ * @param {HTMLFormElement} form
+ * @param {Object} cart
+ * @param {Object} state
+ * @param {Object} config
+ * @returns {Promise<void>}
+ */
+export async function updatePreviewAfterPaymentSelection(form, cart, state, config) {
+  if (shouldUpdatePreviewAfterPaymentSelection(state)) {
+    await updatePreview(form, cart, state, config);
+  }
+}
+
+/**
  * Fetches shipping rates then triggers a preview.
  * @param {HTMLFormElement} form
  * @param {HTMLFieldSetElement} shippingContainer
@@ -192,18 +264,26 @@ async function fetchAndPreview(form, shippingContainer, cart, state, config, str
       couponCode,
       couponSource,
     );
-    renderShippingMethods(shippingContainer, result.rates || [], strings, currencyCode);
+    const rates = result.rates || [];
+    state.shippingMethods = rates;
+    renderShippingMethods(shippingContainer, rates, strings, currencyCode);
 
     // Preserve the user's previous selection; fall back to the first method.
     const targetRadio = findShippingMethodRadio(shippingContainer, previousSelection);
     if (targetRadio) {
+      const selectedRate = findShippingMethodRate(rates, targetRadio);
       targetRadio.checked = true;
       state.selectedShippingMethodId = targetRadio.value;
-      shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', { bubbles: true }));
-      await updatePreview(form, cart, state, config);
+      clearPreviewState(state);
+      dispatchShippingSelected(shippingContainer, selectedRate);
+      await updatePreviewAfterPaymentSelection(form, cart, state, config);
+    } else {
+      dispatchShippingSelected(shippingContainer, null);
     }
   } catch {
+    state.shippingMethods = [];
     renderShippingMethods(shippingContainer, [], strings, currencyCode);
+    dispatchShippingSelected(shippingContainer, null);
   }
 }
 
@@ -231,6 +311,7 @@ export function initShipping(form, shippingContainer, cart, state, config, strin
   if (stateSelect) {
     stateSelect.addEventListener('change', () => {
       state.selectedShippingMethodId = null;
+      dispatchShippingSelected(shippingContainer, null);
       fetchAndPreview(form, shippingContainer, cart, state, config, strings, currencyCode);
     });
   }
@@ -239,8 +320,12 @@ export function initShipping(form, shippingContainer, cart, state, config, strin
   shippingContainer.addEventListener('change', (e) => {
     if (e.target.name === 'shippingMethod') {
       state.selectedShippingMethodId = e.target.value;
-      shippingContainer.dispatchEvent(new CustomEvent('checkout:shipping-selected', { bubbles: true }));
-      updatePreview(form, cart, state, config);
+      clearPreviewState(state);
+      dispatchShippingSelected(
+        shippingContainer,
+        findShippingMethodRate(state.shippingMethods || [], e.target),
+      );
+      updatePreviewAfterPaymentSelection(form, cart, state, config);
     }
   });
 

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -7,7 +7,11 @@ import affirm from '../../scripts/payments/affirm.js';
 import chase from '../../scripts/payments/chase.js';
 import buildForm, { initCollapse } from './checkout-form.js';
 import { initAddress } from './checkout-address.js';
-import { initShipping, updatePreview } from './checkout-shipping.js';
+import {
+  clearPreviewState,
+  initShipping,
+  updatePreview,
+} from './checkout-shipping.js';
 import { initOrder } from './checkout-order.js';
 import { initPayment } from './checkout-payment.js';
 import { parsePreview } from '../../scripts/commerce-api.js';
@@ -66,6 +70,7 @@ const LOCAL_STRINGS = {
     noShippingMethods: 'No shipping methods available for this address.',
     shippingPlaceholder: 'Enter your shipping address to see available methods.',
     errorSelectShipping: 'Please select a shipping method.',
+    errorSelectPayment: 'Please select a payment method.',
     errorCalculateTotals: 'Unable to calculate totals. Please try again.',
     errorRecaptcha: 'Security verification failed. Please refresh the page and try again.',
     errorGeneric: 'An error occurred. Please try again.',
@@ -138,6 +143,7 @@ const LOCAL_STRINGS = {
     noShippingMethods: 'Aucune méthode de livraison disponible pour cette adresse.',
     shippingPlaceholder: 'Entrez votre adresse de livraison pour voir les méthodes disponibles.',
     errorSelectShipping: 'Veuillez sélectionner une méthode de livraison.',
+    errorSelectPayment: 'Veuillez sélectionner un mode de paiement.',
     errorCalculateTotals: 'Impossible de calculer les totaux. Veuillez réessayer.',
     errorRecaptcha: 'Échec de la vérification de sécurité. Veuillez actualiser la page et réessayer.',
     errorGeneric: 'Une erreur est survenue. Veuillez réessayer.',
@@ -443,7 +449,12 @@ export default async function decorate(block) {
     const input = form.querySelector(`[name="${name}"]`);
     if (!input) return;
     input.addEventListener('blur', () => {
-      if (input.value && state.selectedShippingMethodId && !state.currentPreview) {
+      if (
+        input.value
+        && state.selectedShippingMethodId
+        && !state.currentPreview
+        && state.paymentMethodSelected
+      ) {
         updatePreview(form, cart, state, config);
       }
     });
@@ -475,7 +486,10 @@ export default async function decorate(block) {
 
   // Re-run preview on payment method change — tax may vary by type (e.g. Avalara surcharge)
   paymentContainer.addEventListener('change', (e) => {
-    if (e.target.name === 'paymentMethod') updatePreview(form, cart, state, config);
+    if (e.target.name !== 'paymentMethod') return;
+    state.paymentMethodSelected = true;
+    clearPreviewState(state);
+    if (state.selectedShippingMethodId) updatePreview(form, cart, state, config);
   });
 
   // Inject order-summary block into this section if the author didn't add one

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -293,30 +293,49 @@ export default async function decorate(block) {
     discountsEl.appendChild(row);
   };
 
-  const updateTotals = () => {
-    const currency = getCurrencyCode();
-    const subtotal = formatPrice(cart.subtotal, currency);
-    subtotalEl.textContent = subtotal;
-    shippingEl.textContent = '--';
-    taxesEl.textContent = '--';
-    grandTotalEl.textContent = subtotal;
-    headerTotalEl.textContent = subtotal;
-  };
-
   let priceEstimateRequest = 0;
   let hasOrderPreview = false;
-  const renderPriceEstimate = (estimate) => {
+  let estimatedSubtotal = cart.subtotal;
+  let estimatedDiscountTotal = 0;
+  let estimatedShippingMethod = null;
+
+  const renderEstimatedTotals = () => {
     if (hasOrderPreview) return;
     const currency = getCurrencyCode();
-    const subtotal = parseFloat(estimate.subtotal) || cart.subtotal;
-    const discountTotal = parseFloat(estimate.orderDiscountTotal) || 0;
-    const total = Math.max(0, subtotal - discountTotal);
-    subtotalEl.textContent = formatPrice(subtotal, currency);
-    renderDiscountRows(estimate.discounts ?? [], currency);
-    shippingEl.textContent = '--';
+    const shippingRate = estimatedShippingMethod
+      ? parseFloat(estimatedShippingMethod.rate) || 0
+      : null;
+    const total = Math.max(
+      0,
+      estimatedSubtotal - estimatedDiscountTotal + (shippingRate ?? 0),
+    );
+
+    subtotalEl.textContent = formatPrice(estimatedSubtotal, currency);
+    if (shippingRate == null) {
+      shippingEl.textContent = '--';
+    } else {
+      shippingEl.textContent = shippingRate === 0 ? s.free : formatPrice(shippingRate, currency);
+    }
     taxesEl.textContent = '--';
     grandTotalEl.textContent = formatPrice(total, currency);
     headerTotalEl.textContent = formatPrice(total, currency);
+  };
+
+  const updateTotals = ({ resetShipping = false } = {}) => {
+    estimatedSubtotal = cart.subtotal;
+    estimatedDiscountTotal = 0;
+    if (resetShipping) estimatedShippingMethod = null;
+    renderEstimatedTotals();
+  };
+
+  const renderPriceEstimate = (estimate) => {
+    if (hasOrderPreview) return;
+    const currency = getCurrencyCode();
+    estimatedSubtotal = parseFloat(estimate.subtotal) || cart.subtotal;
+    estimatedDiscountTotal = parseFloat(estimate.orderDiscountTotal) || 0;
+    subtotalEl.textContent = formatPrice(estimatedSubtotal, currency);
+    renderDiscountRows(estimate.discounts ?? [], currency);
+    renderEstimatedTotals();
   };
 
   const updatePriceEstimate = async () => {
@@ -466,7 +485,7 @@ export default async function decorate(block) {
 
   const refreshSummary = () => {
     renderItems();
-    updateTotals();
+    updateTotals({ resetShipping: true });
     updatePriceEstimate();
     syncVisibility();
   };
@@ -480,6 +499,12 @@ export default async function decorate(block) {
     if (!couponCode || couponSource === 'auto') updatePriceEstimate();
   });
 
+  document.addEventListener('checkout:shipping-selected', (e) => {
+    if (hasOrderPreview) return;
+    estimatedShippingMethod = e.detail?.shippingMethod || null;
+    renderEstimatedTotals();
+  });
+
   const summaryContent = block.querySelector('.order-summary-content');
   document.addEventListener('checkout:preview-loading', () => {
     hasOrderPreview = true;
@@ -490,6 +515,7 @@ export default async function decorate(block) {
     summaryContent?.classList.remove('loading');
     const { preview, couponError } = e.detail || {};
     hasOrderPreview = Boolean(preview);
+    if (!preview) renderEstimatedTotals();
 
     if (couponError) {
       sessionStorage.removeItem('checkout_coupon_source');

--- a/scripts/commerce-api.js
+++ b/scripts/commerce-api.js
@@ -136,10 +136,11 @@ export async function estimatePrice(country, items, couponCode, couponSource) {
  * @param {string} state - State or province code (e.g. 'QC', 'CA')
  * @param {string} zip - Postal/ZIP code
  * @param {Array<{sku: string, path: string, quantity: number, price: Object}>} items
+ * @param {Object} [context={}] - Optional checkout context fields for tax rules
  * @returns {Promise<{ subtotal: number, shippingMethods: Array<Object> }>}
  * @throws {CommerceApiError}
  */
-export async function estimateExpressCheckout(country, state, zip, items) {
+export async function estimateExpressCheckout(country, state, zip, items, context = {}) {
   // BCP-47 store-view locale (e.g. 'fr-CA') so the API can localize method labels.
   const { language: locale } = getLocaleAndLanguage(false, true);
   return post('/estimate/order', {
@@ -147,6 +148,7 @@ export async function estimateExpressCheckout(country, state, zip, items) {
     locale,
     shipping: { country, state, zip },
     items,
+    ...context,
   });
 }
 

--- a/scripts/payments/apple-pay-context.js
+++ b/scripts/payments/apple-pay-context.js
@@ -1,0 +1,87 @@
+export const APPLE_PAY_CART_CONTEXT = {
+  paymentMethod: 'apple-pay',
+  checkoutFlow: 'express',
+  entryPoint: 'cart',
+};
+
+/**
+ * Builds the Apple Pay cart preview payload for a selected shipping method.
+ * @param {Object} cart
+ * @param {string} shippingMethodId
+ * @param {string} locale
+ * @param {Object|null} contact
+ * @returns {Object}
+ */
+export function buildApplePayCartPreviewPayload(cart, shippingMethodId, locale, contact) {
+  const countryCode = contact?.countryCode?.toLowerCase();
+  return {
+    ...APPLE_PAY_CART_CONTEXT,
+    items: cart.getItemsForAPI(),
+    shippingMethod: { id: shippingMethodId },
+    locale,
+    ...(countryCode ? {
+      country: countryCode,
+      shipping: {
+        country: countryCode,
+        state: contact.administrativeArea,
+        zip: contact.postalCode || '',
+      },
+    } : {}),
+  };
+}
+
+/**
+ * Builds the Apple Pay cart order payload from the authorized payment contact.
+ * @param {Object} params
+ * @param {Object} params.payment
+ * @param {Object} params.cart
+ * @param {string} params.shippingMethodId
+ * @param {string} params.estimateToken
+ * @param {string} params.country
+ * @param {string} params.locale
+ * @param {string} params.customerEmail
+ * @param {string} [params.customerTimezone]
+ * @returns {Object}
+ */
+export function buildApplePayCartOrderPayload(params) {
+  const {
+    payment,
+    cart,
+    shippingMethodId,
+    estimateToken,
+    country,
+    locale,
+    customerEmail,
+    customerTimezone,
+  } = params;
+  const contact = payment.shippingContact;
+  const shippingAddr = {
+    name: `${contact.givenName} ${contact.familyName}`.trim(),
+    address1: (contact.addressLines || [])[0] || '',
+    address2: (contact.addressLines || [])[1] || '',
+    city: contact.locality,
+    state: contact.administrativeArea,
+    zip: contact.postalCode,
+    country: contact.countryCode?.toLowerCase() || country,
+    phone: contact.phoneNumber || '',
+    email: contact.emailAddress || '',
+  };
+
+  return {
+    ...APPLE_PAY_CART_CONTEXT,
+    customer: {
+      firstName: contact.givenName || '',
+      lastName: contact.familyName || '',
+      email: customerEmail,
+      phone: contact.phoneNumber || '',
+    },
+    shipping: shippingAddr,
+    billing: shippingAddr,
+    items: cart.getItemsForAPI(),
+    shippingMethod: { id: shippingMethodId },
+    estimateToken,
+    country,
+    locale,
+    ...(customerTimezone ? { customerTimezone } : {}),
+  };
+}

--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -5,6 +5,11 @@ import {
 } from '../commerce-api.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
+import {
+  APPLE_PAY_CART_CONTEXT,
+  buildApplePayCartOrderPayload,
+  buildApplePayCartPreviewPayload,
+} from './apple-pay-context.js';
 
 const APPLE_PAY_SDK_URL = 'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js';
 
@@ -78,6 +83,7 @@ function startExpressSession(btn, config, callbacks) {
           contact.administrativeArea,
           contact.postalCode,
           cart.getItemsForAPI(),
+          APPLE_PAY_CART_CONTEXT,
         );
         const methods = result.shippingMethods || [];
         if (!methods.length) {
@@ -116,21 +122,14 @@ function startExpressSession(btn, config, callbacks) {
 
     session.onshippingmethodselected = async (e) => {
       try {
-        const contact = lastShippingContact;
-        const countryCode = contact?.countryCode?.toLowerCase();
-        const previewResult = await callbacks.previewOrderDirect({
-          items: cart.getItemsForAPI(),
-          shippingMethod: { id: e.shippingMethod.identifier },
-          locale: bcp47,
-          ...(countryCode ? {
-            country: countryCode,
-            shipping: {
-              country: countryCode,
-              state: contact.administrativeArea,
-              zip: contact.postalCode || '',
-            },
-          } : {}),
-        });
+        const previewResult = await callbacks.previewOrderDirect(
+          buildApplePayCartPreviewPayload(
+            cart,
+            e.shippingMethod.identifier,
+            bcp47,
+            lastShippingContact,
+          ),
+        );
         lastShippingMethodId = e.shippingMethod.identifier;
         callbacks.getState().currentEstimateToken = previewResult.estimateToken;
         session.completeShippingMethodSelection({
@@ -151,39 +150,21 @@ function startExpressSession(btn, config, callbacks) {
       const { payment } = e;
       const contact = payment.shippingContact;
       try {
-        const shippingAddr = {
-          name: `${contact.givenName} ${contact.familyName}`.trim(),
-          address1: (contact.addressLines || [])[0] || '',
-          address2: (contact.addressLines || [])[1] || '',
-          city: contact.locality,
-          state: contact.administrativeArea,
-          zip: contact.postalCode,
-          country: contact.countryCode?.toLowerCase() || locale,
-          phone: contact.phoneNumber || '',
-          email: contact.emailAddress || '',
-        };
-
         // When the user is signed in, use their account email so the order is linked
         // to the right account. The Apple Pay contact email may differ from the
         // commerce account email, which causes assertEmail to reject the request.
         const customerEmail = (isLoggedIn() && getUser()?.email) || contact.emailAddress || '';
         const customerTimezone = getCustomerTimezone();
-        const orderBody = {
-          customer: {
-            firstName: contact.givenName || '',
-            lastName: contact.familyName || '',
-            email: customerEmail,
-            phone: contact.phoneNumber || '',
-          },
-          shipping: shippingAddr,
-          billing: shippingAddr,
-          items: cart.getItemsForAPI(),
-          shippingMethod: { id: lastShippingMethodId || e.payment.shippingMethod?.identifier || '' },
+        const orderBody = buildApplePayCartOrderPayload({
+          payment,
+          cart,
+          shippingMethodId: lastShippingMethodId || e.payment.shippingMethod?.identifier || '',
           estimateToken: callbacks.getState().currentEstimateToken,
           country: locale,
           locale: bcp47,
-          ...(customerTimezone ? { customerTimezone } : {}),
-        };
+          customerEmail,
+          customerTimezone,
+        });
 
         const createdOrder = await callbacks.createOrder(orderBody);
         const fraudToken = (() => {

--- a/scripts/payments/paypal-context.js
+++ b/scripts/payments/paypal-context.js
@@ -1,0 +1,10 @@
+/**
+ * Ensures checkout PayPal has a signed estimate token before order creation.
+ * @param {Object} callbacks
+ * @returns {Promise<boolean>}
+ */
+export default async function ensureCheckoutPreviewToken(callbacks) {
+  if (callbacks.getState().currentEstimateToken) return true;
+  await callbacks.updatePreview();
+  return Boolean(callbacks.getState().currentEstimateToken);
+}

--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -7,6 +7,7 @@ import {
 import { getLocaleAndLanguage } from '../scripts.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
+import ensureCheckoutPreviewToken from './paypal-context.js';
 
 let sdkLoadPromise = null;
 
@@ -360,14 +361,10 @@ export default {
       callbacks.clearError();
       btn.disabled = true;
 
-      const state = callbacks.getState();
-      if (!state.currentEstimateToken) {
-        await callbacks.updatePreview();
-        if (!callbacks.getState().currentEstimateToken) {
-          callbacks.showError('Unable to calculate totals. Please try again.');
-          btn.disabled = false;
-          return;
-        }
+      if (!await ensureCheckoutPreviewToken(callbacks)) {
+        callbacks.showError('Unable to calculate totals. Please try again.');
+        btn.disabled = false;
+        return;
       }
 
       const formData = callbacks.getFormData();

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -298,6 +298,15 @@ async function fillBilling(page, address = VALID_ADDRESS) {
   await field(page, 'billing-state').selectOption(address.state);
 }
 
+async function selectCreditCardAndWaitForPreview(page) {
+  const previewResponse = page.waitForResponse(
+    (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
+    { timeout: 15000 },
+  );
+  await page.locator('.checkout-form [name="paymentMethod"][value="chase"]').check();
+  await previewResponse;
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 test.describe('Edge Checkout Page', () => {
@@ -550,12 +559,14 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await expandOrderSummary(page);
 
-      // Start from quantity 2, then select a shipping address. The first
-      // estimate/preview should use the qty-2 standard id.
+      // Start from quantity 2, then select a shipping address. Shipping alone
+      // must not create a signed preview; selecting a payment method should.
       await page.locator('.order-summary-items .qty-inc').first().click();
       await fillShipping(page);
       await expect(page.locator('.checkout-form [name="shippingMethod"][value="797"]')).toBeChecked({ timeout: 10000 });
-      await expect.poll(() => previewRequests.some(
+      expect(previewRequests).toHaveLength(0);
+      await selectCreditCardAndWaitForPreview(page);
+      expect(previewRequests.some(
         (body) => body.items?.[0]?.quantity === 2 && body.shippingMethod?.id === '797',
       )).toBe(true);
 
@@ -619,13 +630,12 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillShipping(page);
 
-      // Wait for the preview call triggered by state-change → shipping-selected
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
-
       const total = page.locator('.order-summary-grand-total');
+      await expect(page.locator('.order-summary-shipping')).toContainText('5.99', { timeout: 10000 });
+      await expect(total).toContainText('555.98', { timeout: 10000 });
+
+      await selectCreditCardAndWaitForPreview(page);
+
       // MOCK_PREVIEW.total = 604.10 — formatted as $604.10
       await expect(total).toContainText('604.10', { timeout: 10000 });
       console.log('✓ Order summary total reflects mocked preview response');
@@ -728,10 +738,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
 
@@ -766,10 +773,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
       await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
       await fillBilling(page, BILLING_ADDRESS);
 
@@ -824,10 +828,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
       await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
       await fillBilling(page, BILLING_ADDRESS);
 
@@ -874,10 +875,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
       previewCount = 0;
 
       await page.locator('.checkout-form [name="billing-choice"][value="different"]').check();
@@ -921,13 +919,10 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
-      await page.locator('.checkout-submit-btn').click();
-
+      // Selecting payment moves focus out of the address fields and can open
+      // the validation dialog before submit. Exercise that existing dialog.
       const dialog = page.locator('.address-validation-dialog');
       await expect(dialog).toBeVisible({ timeout: 10000 });
       await expect(dialog.locator('button', { hasText: 'Use this address' })).toBeVisible();
@@ -987,10 +982,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
       const dialog = page.locator('.address-validation-dialog');
@@ -1060,11 +1052,8 @@ test.describe('Edge Checkout Page', () => {
       await fillContact(page);
       await fillShipping(page);
 
-      // Wait for shipping rates + first preview to land
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      // Shipping rates land first; explicit payment selection creates the preview.
+      await selectCreditCardAndWaitForPreview(page);
 
       // Submit
       await page.locator('.checkout-submit-btn').click();
@@ -1100,10 +1089,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
       await expect.poll(
@@ -1134,10 +1120,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
       await expect.poll(
@@ -1181,10 +1164,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
       await page.waitForURL(redirectUrl, { timeout: 15000 });
@@ -1237,10 +1217,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
 
@@ -1270,10 +1247,7 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form')).toBeVisible({ timeout: 15000 });
       await fillContact(page);
       await fillShipping(page);
-      await page.waitForResponse(
-        (res) => res.url().includes('/orders/preview') && res.request().method() === 'POST',
-        { timeout: 15000 },
-      );
+      await selectCreditCardAndWaitForPreview(page);
 
       await page.locator('.checkout-submit-btn').click();
 

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -936,7 +936,12 @@ test.describe('Edge Checkout Page', () => {
 
       await dialog.locator('button', { hasText: 'Edit address' }).click();
       await expect(dialog).toHaveCount(0);
-      await expect(page.locator('.checkout-form > .checkout-error')).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('.checkout-form > .checkout-error')).toBeHidden();
+
+      // Editing does not approve the address. A submit attempt must validate
+      // again and reopen the confirmation dialog instead of creating an order.
+      await page.locator('.checkout-submit-btn').click();
+      await expect(dialog).toBeVisible({ timeout: 10000 });
       expect(orderCreateCalled).toBe(false);
       expect(page.url()).toContain('/order/checkout');
       console.log('✓ Suggestion dialog only allows approved address or edit');
@@ -984,10 +989,13 @@ test.describe('Edge Checkout Page', () => {
       await fillShipping(page);
       await selectCreditCardAndWaitForPreview(page);
 
-      await page.locator('.checkout-submit-btn').click();
+      // Payment selection can open validation before submit. Approve that
+      // suggestion, then submit the validated address to continue checkout.
       const dialog = page.locator('.address-validation-dialog');
       await expect(dialog).toBeVisible({ timeout: 10000 });
       await dialog.locator('button', { hasText: 'Use this address' }).click();
+      await expect(dialog).toHaveCount(0);
+      await page.locator('.checkout-submit-btn').click();
 
       await expect.poll(
         () => page.url(),

--- a/tests/unit/apple-pay-context.test.js
+++ b/tests/unit/apple-pay-context.test.js
@@ -1,0 +1,147 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  APPLE_PAY_CART_CONTEXT,
+  buildApplePayCartOrderPayload,
+  buildApplePayCartPreviewPayload,
+} from '../../scripts/payments/apple-pay-context.js';
+
+const ITEMS = [{
+  sku: 'sku-1',
+  path: '/products/sku-1',
+  quantity: 1,
+  price: { currency: 'USD', regular: '10.00' },
+}];
+
+const cart = {
+  getItemsForAPI: () => ITEMS,
+};
+
+const shippingContact = {
+  countryCode: 'US',
+  administrativeArea: 'MN',
+  postalCode: '55441',
+};
+
+const paymentContact = {
+  givenName: 'Jane',
+  familyName: 'Doe',
+  addressLines: ['123 Main St', 'Suite 4'],
+  locality: 'Cleveland',
+  administrativeArea: 'OH',
+  postalCode: '44101',
+  countryCode: 'US',
+  phoneNumber: '(555) 123-4567',
+  emailAddress: 'apple@example.com',
+};
+
+test('APPLE_PAY_CART_CONTEXT identifies cart-origin Apple Pay express checkout', () => {
+  assert.deepEqual(APPLE_PAY_CART_CONTEXT, {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+  });
+});
+
+test('buildApplePayCartPreviewPayload includes cart context and partial shipping', () => {
+  const payload = buildApplePayCartPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    shippingContact,
+  );
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.checkoutFlow, 'express');
+  assert.equal(payload.entryPoint, 'cart');
+  assert.deepEqual(payload.items, ITEMS);
+  assert.deepEqual(payload.shippingMethod, { id: 'standard' });
+  assert.equal(payload.locale, 'en-US');
+  assert.equal(payload.country, 'us');
+  assert.deepEqual(payload.shipping, {
+    country: 'us',
+    state: 'MN',
+    zip: '55441',
+  });
+});
+
+test('buildApplePayCartPreviewPayload omits shipping when contact has no country', () => {
+  const payload = buildApplePayCartPreviewPayload(cart, 'standard', 'en-US', null);
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.country, undefined);
+  assert.equal(payload.shipping, undefined);
+});
+
+test('buildApplePayCartOrderPayload includes cart context and full address data', () => {
+  const payload = buildApplePayCartOrderPayload({
+    payment: { shippingContact: paymentContact },
+    cart,
+    shippingMethodId: 'standard',
+    estimateToken: 'estimate-token',
+    country: 'us',
+    locale: 'en-US',
+    customerEmail: 'account@example.com',
+    customerTimezone: 'America/New_York',
+  });
+
+  assert.equal(payload.paymentMethod, 'apple-pay');
+  assert.equal(payload.checkoutFlow, 'express');
+  assert.equal(payload.entryPoint, 'cart');
+  assert.equal(payload.customer.email, 'account@example.com');
+  assert.equal(payload.customer.firstName, 'Jane');
+  assert.equal(payload.customer.lastName, 'Doe');
+  assert.deepEqual(payload.shippingMethod, { id: 'standard' });
+  assert.equal(payload.estimateToken, 'estimate-token');
+  assert.equal(payload.country, 'us');
+  assert.equal(payload.locale, 'en-US');
+  assert.equal(payload.customerTimezone, 'America/New_York');
+  assert.deepEqual(payload.items, ITEMS);
+  assert.deepEqual(payload.shipping, {
+    name: 'Jane Doe',
+    address1: '123 Main St',
+    address2: 'Suite 4',
+    city: 'Cleveland',
+    state: 'OH',
+    zip: '44101',
+    country: 'us',
+    phone: '(555) 123-4567',
+    email: 'apple@example.com',
+  });
+  assert.deepEqual(payload.billing, payload.shipping);
+});
+
+test('Apple Pay cart preview and order payloads use matching context facts', () => {
+  const preview = buildApplePayCartPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    shippingContact,
+  );
+  const order = buildApplePayCartOrderPayload({
+    payment: { shippingContact: paymentContact },
+    cart,
+    shippingMethodId: 'standard',
+    estimateToken: 'estimate-token',
+    country: 'us',
+    locale: 'en-US',
+    customerEmail: 'account@example.com',
+  });
+
+  assert.deepEqual(
+    {
+      paymentMethod: preview.paymentMethod,
+      checkoutFlow: preview.checkoutFlow,
+      entryPoint: preview.entryPoint,
+    },
+    APPLE_PAY_CART_CONTEXT,
+  );
+  assert.deepEqual(
+    {
+      paymentMethod: order.paymentMethod,
+      checkoutFlow: order.checkoutFlow,
+      entryPoint: order.entryPoint,
+    },
+    APPLE_PAY_CART_CONTEXT,
+  );
+});

--- a/tests/unit/checkout-order-context.test.js
+++ b/tests/unit/checkout-order-context.test.js
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOrderJSON, getCheckoutContext } from '../../blocks/checkout/checkout-order.js';
+import { APPLE_PAY_CART_CONTEXT } from '../../scripts/payments/apple-pay-context.js';
+
+function formData(values) {
+  return {
+    get(name) {
+      return values[name] ?? '';
+    },
+  };
+}
+
+function formWithBillingChoice(value = 'same') {
+  return {
+    querySelector(selector) {
+      if (selector === '[name="billing-choice"]:checked') return { value };
+      return null;
+    },
+  };
+}
+
+const config = {
+  getLocale: () => 'us',
+  getLanguage: () => 'en_us',
+};
+
+const cart = {
+  getItemsForAPI: () => [{
+    sku: 'sku-1',
+    path: '/products/sku-1',
+    quantity: 1,
+    price: { currency: 'USD', regular: '10.00' },
+  }],
+};
+
+const baseValues = {
+  email: 'jane@example.com',
+  'shipping-firstname': 'Jane',
+  'shipping-lastname': 'Doe',
+  'shipping-street-0': '123 Main St',
+  'shipping-street-1': '',
+  'shipping-city': 'Cleveland',
+  'shipping-state': 'OH',
+  'shipping-zip': '44101',
+  'shipping-telephone': '(555) 123-4567',
+};
+
+function buildOrder(values) {
+  return buildOrderJSON(
+    formData({ ...baseValues, ...values }),
+    formWithBillingChoice('same'),
+    cart,
+    {},
+    config,
+  );
+}
+
+test('getCheckoutContext returns null when payment method is absent', () => {
+  assert.equal(getCheckoutContext(''), null);
+  assert.equal(getCheckoutContext(null), null);
+});
+
+test('getCheckoutContext returns standard checkout context for card payments', () => {
+  assert.deepEqual(getCheckoutContext('chase'), {
+    paymentMethod: 'chase',
+    checkoutFlow: 'standard',
+    entryPoint: 'checkout',
+  });
+});
+
+test('getCheckoutContext returns express checkout context for checkout-page Apple Pay', () => {
+  assert.deepEqual(getCheckoutContext('apple-pay'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'checkout',
+  });
+});
+
+test('buildOrderJSON includes checkout context for card checkout', () => {
+  const order = buildOrder({ paymentMethod: 'chase' });
+
+  assert.equal(order.paymentMethod, 'chase');
+  assert.equal(order.checkoutFlow, 'standard');
+  assert.equal(order.entryPoint, 'checkout');
+});
+
+test('buildOrderJSON includes checkout entry point for checkout-page Apple Pay', () => {
+  const order = buildOrder({ paymentMethod: 'apple-pay' });
+
+  assert.equal(order.paymentMethod, 'apple-pay');
+  assert.equal(order.checkoutFlow, 'express');
+  assert.equal(order.entryPoint, 'checkout');
+});
+
+test('checkout-page Apple Pay context does not reuse cart entry point', () => {
+  const order = buildOrder({ paymentMethod: 'apple-pay' });
+
+  assert.equal(APPLE_PAY_CART_CONTEXT.entryPoint, 'cart');
+  assert.equal(order.entryPoint, 'checkout');
+  assert.notEqual(order.entryPoint, APPLE_PAY_CART_CONTEXT.entryPoint);
+});
+
+test('buildOrderJSON omits checkout context when payment method is absent', () => {
+  const order = buildOrder({ paymentMethod: '' });
+
+  assert.equal(order.paymentMethod, undefined);
+  assert.equal(order.checkoutFlow, undefined);
+  assert.equal(order.entryPoint, undefined);
+});

--- a/tests/unit/checkout-payment-selection.test.js
+++ b/tests/unit/checkout-payment-selection.test.js
@@ -1,0 +1,175 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderPaymentSection } from '../../blocks/checkout/checkout-payment.js';
+import { getSelectedPaymentMethod } from '../../blocks/checkout/checkout-order.js';
+
+function createClassList(element) {
+  return {
+    add(...classes) {
+      const existing = element.className ? element.className.split(/\s+/) : [];
+      element.className = [...new Set([...existing, ...classes])].join(' ');
+    },
+    remove(...classes) {
+      const remove = new Set(classes);
+      element.className = (element.className || '')
+        .split(/\s+/)
+        .filter((name) => name && !remove.has(name))
+        .join(' ');
+    },
+    contains(className) {
+      return (element.className || '').split(/\s+/).includes(className);
+    },
+    toggle(className, force) {
+      if (force) this.add(className);
+      else this.remove(className);
+    },
+  };
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.dataset = {};
+    this.attributes = {};
+    this.eventListeners = {};
+    this.className = '';
+    this.classList = createClassList(this);
+  }
+
+  append(...children) {
+    children.forEach((child) => this.appendChild(child));
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+
+  addEventListener(type, handler) {
+    this.eventListeners[type] = handler;
+  }
+
+  closest(selector) {
+    if (selector === 'form') {
+      return this.tagName === 'FORM' ? this : this.parentElement?.closest(selector) || null;
+    }
+    if (selector.startsWith('.')) {
+      return this.classList.contains(selector.slice(1))
+        ? this
+        : this.parentElement?.closest(selector) || null;
+    }
+    return null;
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  querySelectorAll(selector) {
+    const results = [];
+    const matches = (element) => {
+      if (selector === 'input[type="radio"]') {
+        return element.tagName === 'INPUT' && element.type === 'radio';
+      }
+      if (selector === 'input[type="radio"][name="paymentMethod"]') {
+        return element.tagName === 'INPUT' && element.type === 'radio' && element.name === 'paymentMethod';
+      }
+      if (selector === '[name="paymentMethod"]:checked') {
+        return element.name === 'paymentMethod' && element.checked === true;
+      }
+      if (selector === '.payment-option-card') {
+        return element.classList.contains('payment-option-card');
+      }
+      if (selector === '.billing-section') {
+        return element.classList.contains('billing-section');
+      }
+      return false;
+    };
+    const visit = (element) => {
+      if (matches(element)) results.push(element);
+      element.children.forEach(visit);
+    };
+    visit(this);
+    return results;
+  }
+}
+
+const strings = {
+  paymentSecureTitle: 'Secure payment',
+  paymentSecureSub: 'Pay securely',
+  paymentHow: 'How would you like to pay?',
+  creditCard: 'Credit card',
+  creditCardSub: 'Pay by card',
+  paypalLabel: 'PayPal',
+  paypalSub: 'Continue with PayPal',
+  applePayLabel: 'Apple Pay',
+  applePaySub: 'Continue with Apple Pay',
+  affirmLabel: 'Affirm',
+  affirmSub: 'Pay over time',
+};
+
+function withFakeDocument(fn) {
+  const originalDocument = globalThis.document;
+  const originalInput = globalThis.HTMLInputElement;
+  globalThis.document = {
+    createElement: (tagName) => new FakeElement(tagName),
+  };
+  globalThis.HTMLInputElement = FakeElement;
+  try {
+    fn();
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.HTMLInputElement = originalInput;
+  }
+}
+
+test('renderPaymentSection does not select card by default', () => {
+  withFakeDocument(() => {
+    const container = new FakeElement('fieldset');
+
+    renderPaymentSection(container, [{ id: 'chase' }], {}, strings, { cardProvider: 'chase' });
+
+    const radios = container.querySelectorAll('input[type="radio"][name="paymentMethod"]');
+    assert.equal(radios.length, 1);
+    assert.equal(radios[0].value, 'chase');
+    assert.equal(radios[0].checked, undefined);
+    assert.equal(container.querySelector('.payment-option-card').classList.contains('payment-option-active'), false);
+  });
+});
+
+test('renderPaymentSection does not select first wallet provider when card is unavailable', () => {
+  withFakeDocument(() => {
+    const container = new FakeElement('fieldset');
+    const paypal = {
+      id: 'paypal',
+      renderCheckoutButton: () => {},
+    };
+
+    renderPaymentSection(container, [paypal], {}, strings, { cardProvider: 'chase' });
+
+    const radios = container.querySelectorAll('input[type="radio"][name="paymentMethod"]');
+    assert.equal(radios.length, 1);
+    assert.equal(radios[0].value, 'paypal');
+    assert.equal(radios[0].checked, undefined);
+    assert.equal(container.querySelector('.payment-option-card').classList.contains('payment-option-active'), false);
+  });
+});
+
+test('getSelectedPaymentMethod returns null until the shopper selects a method', () => {
+  const form = new FakeElement('form');
+  const radio = new FakeElement('input');
+  radio.name = 'paymentMethod';
+  radio.value = 'chase';
+  radio.type = 'radio';
+  form.appendChild(radio);
+
+  assert.equal(getSelectedPaymentMethod(form), null);
+  radio.checked = true;
+  assert.equal(getSelectedPaymentMethod(form), 'chase');
+});

--- a/tests/unit/checkout-shipping.test.js
+++ b/tests/unit/checkout-shipping.test.js
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { findShippingMethodRadio } from '../../blocks/checkout/checkout-shipping.js';
+import {
+  clearPreviewState,
+  findShippingMethodRadio,
+  findShippingMethodRate,
+  hasExplicitPaymentSelection,
+  shouldUpdatePreviewAfterPaymentSelection,
+} from '../../blocks/checkout/checkout-shipping.js';
 
 function radio(value, type, label) {
   return {
@@ -60,4 +66,45 @@ test('findShippingMethodRadio falls back to label, then first method', () => {
     standard,
   );
   assert.equal(findShippingMethodRadio(container([]), { id: '218' }), null);
+});
+
+test('findShippingMethodRate returns selected estimated shipping method details', () => {
+  const rates = [
+    { id: '220', type: 'standard', label: 'Standard Shipping', rate: '0.00' },
+    { id: '2276', type: 'priority', label: 'Priority Shipping', rate: '9.95' },
+  ];
+
+  assert.equal(findShippingMethodRate(rates, radio('2276')), rates[1]);
+  assert.equal(findShippingMethodRate(rates, radio('missing', 'standard')), rates[0]);
+  assert.equal(findShippingMethodRate(rates, radio('missing', null, 'Priority Shipping')), rates[1]);
+  assert.equal(findShippingMethodRate(rates, null), null);
+});
+
+test('clearPreviewState clears signed estimate state', () => {
+  const state = { currentEstimateToken: 'token', currentPreview: { total: 10 } };
+
+  clearPreviewState(state);
+
+  assert.equal(state.currentEstimateToken, null);
+  assert.equal(state.currentPreview, null);
+});
+
+test('hasExplicitPaymentSelection is true only after explicit payment selection', () => {
+  assert.equal(hasExplicitPaymentSelection({}), false);
+  assert.equal(hasExplicitPaymentSelection({ paymentMethodSelected: false }), false);
+  assert.equal(hasExplicitPaymentSelection({ paymentMethodSelected: true }), true);
+});
+
+test('shouldUpdatePreviewAfterPaymentSelection requires payment and shipping selection', () => {
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({}), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    paymentMethodSelected: true,
+  }), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    selectedShippingMethodId: 'standard',
+  }), false);
+  assert.equal(shouldUpdatePreviewAfterPaymentSelection({
+    paymentMethodSelected: true,
+    selectedShippingMethodId: 'standard',
+  }), true);
 });

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -214,6 +214,21 @@ test('estimateExpressCheckout: sends locale and order shape', async () => {
   assert.deepEqual(body.items, items);
 });
 
+test('estimateExpressCheckout: includes optional checkout context fields', async () => {
+  const items = [{ sku: 'abc', quantity: 1, price: { final: '50.00' } }];
+  mockFetch(200, { subtotal: '50.00', shippingMethods: [] });
+  await estimateExpressCheckout('us', 'MN', '55441', items, {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+  });
+
+  const body = JSON.parse(lastInit.body);
+  assert.equal(body.paymentMethod, 'apple-pay');
+  assert.equal(body.checkoutFlow, 'express');
+  assert.equal(body.entryPoint, 'cart');
+});
+
 test('estimatePrice: includes couponSource when provided with couponCode', async () => {
   mockFetch(200, { discounts: [], orderDiscountTotal: 0 });
   await estimatePrice('us', [], 'IDME10', 'auto');

--- a/tests/unit/paypal-checkout-preview.test.js
+++ b/tests/unit/paypal-checkout-preview.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import ensureCheckoutPreviewToken from '../../scripts/payments/paypal-context.js';
+
+function callbacksForState(state) {
+  let updatePreviewCalls = 0;
+  return {
+    callbacks: {
+      getState: () => state,
+      updatePreview: async () => {
+        updatePreviewCalls += 1;
+        state.currentEstimateToken = 'generated-token';
+      },
+    },
+    getUpdatePreviewCalls: () => updatePreviewCalls,
+  };
+}
+
+test('ensureCheckoutPreviewToken reuses an existing PayPal checkout estimate token', async () => {
+  const state = { currentEstimateToken: 'existing-token' };
+  const { callbacks, getUpdatePreviewCalls } = callbacksForState(state);
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), true);
+  assert.equal(getUpdatePreviewCalls(), 0);
+  assert.equal(state.currentEstimateToken, 'existing-token');
+});
+
+test('ensureCheckoutPreviewToken creates a PayPal checkout estimate token when missing', async () => {
+  const state = {};
+  const { callbacks, getUpdatePreviewCalls } = callbacksForState(state);
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), true);
+  assert.equal(getUpdatePreviewCalls(), 1);
+  assert.equal(state.currentEstimateToken, 'generated-token');
+});
+
+test('ensureCheckoutPreviewToken reports failure when preview does not return a token', async () => {
+  let updatePreviewCalls = 0;
+  const callbacks = {
+    getState: () => ({}),
+    updatePreview: async () => { updatePreviewCalls += 1; },
+  };
+
+  assert.equal(await ensureCheckoutPreviewToken(callbacks), false);
+  assert.equal(updatePreviewCalls, 1);
+});


### PR DESCRIPTION
Adds explicit checkout context for wallet flows, requires shopper payment selection, and updates the order summary from selected shipping estimate data before signed payment previews.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://checkout-shipping-summary-estimate--vitamix--aemsites.aem.network/
