### PR TITLE
fix(checkout): prefill default customer address

### DIFF
--- a/blocks/checkout/checkout-customer-address.js
+++ b/blocks/checkout/checkout-customer-address.js
@@ -67,7 +67,7 @@ export async function getDefaultCustomerAddress() {
 export function populateDefaultShippingAddress(form, address, locale) {
   if (!address || form.elements['shipping-street-0']?.value?.trim()) return false;
   const country = String(address.country || '').toLowerCase();
-  if (country && country !== String(locale).toLowerCase()) return false;
+  if (!country || country !== String(locale).toLowerCase()) return false;
 
   const fullName = String(address.name || '').trim().split(/\s+/);
   const values = {
@@ -79,7 +79,7 @@ export function populateDefaultShippingAddress(form, address, locale) {
     'shipping-city': address.city,
     'shipping-state': address.state,
     'shipping-zip': address.zip,
-    'shipping-phone': address.phone,
+    'shipping-telephone': address.phone,
   };
 
   Object.entries(values).forEach(([name, value]) => {
@@ -90,5 +90,33 @@ export function populateDefaultShippingAddress(form, address, locale) {
     'has-value',
     !!form.elements['shipping-state'].value,
   );
+  return true;
+}
+
+/**
+ * Loads, populates, validates, and activates a signed-in customer's default address.
+ * Dependencies are injectable so the checkout lifecycle can be tested without rendering the block.
+ * @param {Object} options
+ * @param {HTMLFormElement} options.form
+ * @param {string} options.locale
+ * @param {() => Promise<Record<string, unknown>|null>} [options.loadAddress]
+ * @param {(form: HTMLFormElement, locale: string) => void} options.save
+ * @param {() => Promise<boolean>} options.validate
+ * @param {() => void} options.refresh
+ * @returns {Promise<boolean>} whether a validated default address was activated
+ */
+export async function prefillDefaultShippingAddress({
+  form,
+  locale,
+  loadAddress = getDefaultCustomerAddress,
+  save,
+  validate,
+  refresh,
+}) {
+  const address = await loadAddress();
+  if (!populateDefaultShippingAddress(form, address, locale)) return false;
+  save(form, locale);
+  if (!await validate()) return false;
+  refresh();
   return true;
 }

--- a/blocks/checkout/checkout-customer-address.js
+++ b/blocks/checkout/checkout-customer-address.js
@@ -1,0 +1,94 @@
+import {
+  authFetch,
+  getUser,
+  isLoggedIn,
+} from '../../scripts/auth-api.js';
+import { getConfig } from '../../scripts/commerce-config.js';
+
+/** @param {unknown} payload */
+function unwrapPayload(payload) {
+  if (payload && typeof payload === 'object' && 'data' in payload) return payload.data;
+  return payload;
+}
+
+/** @param {Response} response */
+async function readResponse(response) {
+  if (!response.ok) throw new Error(`customer address request failed: ${response.status}`);
+  return response.json();
+}
+
+/** @param {unknown} payload */
+export function normalizeAddresses(payload) {
+  const value = unwrapPayload(payload);
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === 'object') {
+    if (Array.isArray(value.addresses)) return value.addresses;
+    if (Array.isArray(value.items)) return value.items;
+  }
+  return [];
+}
+
+/**
+ * Loads the signed-in customer's default address, hydrating list stubs when necessary.
+ * @returns {Promise<Record<string, unknown>|null>}
+ */
+export async function getDefaultCustomerAddress() {
+  if (!isLoggedIn()) return null;
+  const email = getUser()?.email;
+  if (!email) return null;
+
+  const base = `${getConfig().apiOrigin}/customers/${encodeURIComponent(email)}/addresses`;
+  const addresses = normalizeAddresses(await readResponse(await authFetch(base)));
+  const defaultAddress = addresses.find((address) => address?.isDefault === true);
+  if (!defaultAddress) return null;
+
+  const hasPostalFields = defaultAddress.address1 || defaultAddress.city || defaultAddress.zip;
+  if (hasPostalFields) return { ...defaultAddress, email: defaultAddress.email || email };
+
+  const id = defaultAddress.id || defaultAddress.addressId;
+  if (!id) return null;
+  const payload = unwrapPayload(await readResponse(
+    await authFetch(`${base}/${encodeURIComponent(String(id))}`),
+  ));
+  const detail = payload && typeof payload === 'object' && 'address' in payload
+    ? payload.address
+    : payload;
+  if (!detail || typeof detail !== 'object') return null;
+  return { ...defaultAddress, ...detail, email: detail.email || email };
+}
+
+/**
+ * Copies a customer address into an empty checkout shipping form.
+ * @param {HTMLFormElement} form
+ * @param {Record<string, unknown>} address
+ * @param {string} locale
+ * @returns {boolean} whether the form was populated
+ */
+export function populateDefaultShippingAddress(form, address, locale) {
+  if (!address || form.elements['shipping-street-0']?.value?.trim()) return false;
+  const country = String(address.country || '').toLowerCase();
+  if (country && country !== String(locale).toLowerCase()) return false;
+
+  const fullName = String(address.name || '').trim().split(/\s+/);
+  const values = {
+    email: address.email,
+    'shipping-firstname': address.firstName || fullName.shift(),
+    'shipping-lastname': address.lastName || fullName.join(' '),
+    'shipping-street-0': address.address1,
+    'shipping-street-1': address.address2,
+    'shipping-city': address.city,
+    'shipping-state': address.state,
+    'shipping-zip': address.zip,
+    'shipping-phone': address.phone,
+  };
+
+  Object.entries(values).forEach(([name, value]) => {
+    const field = form.elements[name];
+    if (field && value != null) field.value = String(value);
+  });
+  form.elements['shipping-state']?.classList.toggle(
+    'has-value',
+    !!form.elements['shipping-state'].value,
+  );
+  return true;
+}

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -20,10 +20,7 @@ import { validateField } from './checkout-validation.js';
 import { formStateKey, saveFormState, restoreFormState } from './checkout-session-state.js';
 import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
-import {
-  getDefaultCustomerAddress,
-  populateDefaultShippingAddress,
-} from './checkout-customer-address.js';
+import { prefillDefaultShippingAddress } from './checkout-customer-address.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -427,10 +424,12 @@ export default async function decorate(block) {
   // Start a signed-in customer's blank checkout with their default mailing address.
   // Treat saved addresses like manually entered ones: Address Doctor must accept or
   // correct the address before shipping rates are requested.
-  getDefaultCustomerAddress().then(async (address) => {
-    if (!populateDefaultShippingAddress(form, address, locale)) return;
-    saveFormState(form, locale);
-    if (await runShippingValidation()) refreshShipping();
+  prefillDefaultShippingAddress({
+    form,
+    locale,
+    save: saveFormState,
+    validate: runShippingValidation,
+    refresh: refreshShipping,
   }).catch(() => { /* signed-in address prefill is best-effort */ });
 
   // If the address was restored from sessionStorage on this page load, the

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -20,6 +20,10 @@ import { validateField } from './checkout-validation.js';
 import { formStateKey, saveFormState, restoreFormState } from './checkout-session-state.js';
 import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
+import {
+  getDefaultCustomerAddress,
+  populateDefaultShippingAddress,
+} from './checkout-customer-address.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -419,6 +423,15 @@ export default async function decorate(block) {
   // Wire shipping rate fetching and preview
   const shippingContainer = form.querySelector('.shipping-methods');
   const refreshShipping = initShipping(form, shippingContainer, cart, state, config, strings);
+
+  // Start a signed-in customer's blank checkout with their default mailing address.
+  // Treat saved addresses like manually entered ones: Address Doctor must accept or
+  // correct the address before shipping rates are requested.
+  getDefaultCustomerAddress().then(async (address) => {
+    if (!populateDefaultShippingAddress(form, address, locale)) return;
+    saveFormState(form, locale);
+    if (await runShippingValidation()) refreshShipping();
+  }).catch(() => { /* signed-in address prefill is best-effort */ });
 
   // If the address was restored from sessionStorage on this page load, the
   // state select has a value but no `change` event ever fired — so the

--- a/tests/unit/checkout-customer-address.test.js
+++ b/tests/unit/checkout-customer-address.test.js
@@ -1,0 +1,91 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { beforeEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeAddresses,
+  populateDefaultShippingAddress,
+} from '../../blocks/checkout/checkout-customer-address.js';
+
+function field(value = '') {
+  return {
+    value,
+    classList: { toggle() {} },
+  };
+}
+
+function checkoutForm(overrides = {}) {
+  return {
+    elements: {
+      email: field(),
+      'shipping-firstname': field(),
+      'shipping-lastname': field(),
+      'shipping-street-0': field(),
+      'shipping-street-1': field(),
+      'shipping-city': field(),
+      'shipping-state': field(),
+      'shipping-zip': field(),
+      'shipping-phone': field(),
+      ...overrides,
+    },
+  };
+}
+
+describe('default checkout customer address', () => {
+  beforeEach(() => globalThis.__resetTestState());
+
+  test('normalizes supported address-list response shapes', () => {
+    const address = { id: 'address-1', isDefault: true };
+    assert.deepEqual(normalizeAddresses([address]), [address]);
+    assert.deepEqual(normalizeAddresses({ data: { addresses: [address] } }), [address]);
+    assert.deepEqual(normalizeAddresses({ items: [address] }), [address]);
+    assert.deepEqual(normalizeAddresses(null), []);
+  });
+
+  test('populates all shipping fields from the default mailing address', () => {
+    const form = checkoutForm();
+    const populated = populateDefaultShippingAddress(form, {
+      email: 'jane@example.com',
+      name: 'Jane Mary Doe',
+      address1: '123 Main St',
+      address2: 'Apt 4',
+      city: 'Cleveland',
+      state: 'OH',
+      zip: '44114',
+      country: 'us',
+      phone: '2165550123',
+    }, 'us');
+
+    assert.equal(populated, true);
+    assert.equal(form.elements.email.value, 'jane@example.com');
+    assert.equal(form.elements['shipping-firstname'].value, 'Jane');
+    assert.equal(form.elements['shipping-lastname'].value, 'Mary Doe');
+    assert.equal(form.elements['shipping-street-0'].value, '123 Main St');
+    assert.equal(form.elements['shipping-street-1'].value, 'Apt 4');
+    assert.equal(form.elements['shipping-city'].value, 'Cleveland');
+    assert.equal(form.elements['shipping-state'].value, 'OH');
+    assert.equal(form.elements['shipping-zip'].value, '44114');
+    assert.equal(form.elements['shipping-phone'].value, '2165550123');
+  });
+
+  test('does not overwrite a restored or manually entered shipping address', () => {
+    const form = checkoutForm({ 'shipping-street-0': field('Existing address') });
+    const populated = populateDefaultShippingAddress(form, {
+      address1: 'Default address',
+      country: 'us',
+    }, 'us');
+
+    assert.equal(populated, false);
+    assert.equal(form.elements['shipping-street-0'].value, 'Existing address');
+  });
+
+  test('does not use an address from a different storefront country', () => {
+    const form = checkoutForm();
+    const populated = populateDefaultShippingAddress(form, {
+      address1: '1 Yonge St',
+      country: 'ca',
+    }, 'us');
+
+    assert.equal(populated, false);
+    assert.equal(form.elements['shipping-street-0'].value, '');
+  });
+});

--- a/tests/unit/checkout-customer-address.test.js
+++ b/tests/unit/checkout-customer-address.test.js
@@ -2,8 +2,10 @@
 import { beforeEach, describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  getDefaultCustomerAddress,
   normalizeAddresses,
   populateDefaultShippingAddress,
+  prefillDefaultShippingAddress,
 } from '../../blocks/checkout/checkout-customer-address.js';
 
 function field(value = '') {
@@ -24,10 +26,24 @@ function checkoutForm(overrides = {}) {
       'shipping-city': field(),
       'shipping-state': field(),
       'shipping-zip': field(),
-      'shipping-phone': field(),
+      'shipping-telephone': field(),
       ...overrides,
     },
   };
+}
+
+function signIn(email = 'jane@example.com') {
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }))
+    .toString('base64url');
+  localStorage.setItem('auth_token', `header.${payload}.signature`);
+  localStorage.setItem('auth_user', JSON.stringify({ email, roles: [] }));
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 describe('default checkout customer address', () => {
@@ -64,7 +80,7 @@ describe('default checkout customer address', () => {
     assert.equal(form.elements['shipping-city'].value, 'Cleveland');
     assert.equal(form.elements['shipping-state'].value, 'OH');
     assert.equal(form.elements['shipping-zip'].value, '44114');
-    assert.equal(form.elements['shipping-phone'].value, '2165550123');
+    assert.equal(form.elements['shipping-telephone'].value, '2165550123');
   });
 
   test('does not overwrite a restored or manually entered shipping address', () => {
@@ -87,5 +103,128 @@ describe('default checkout customer address', () => {
 
     assert.equal(populated, false);
     assert.equal(form.elements['shipping-street-0'].value, '');
+  });
+
+  test('does not use an address without a country', () => {
+    const form = checkoutForm();
+    const populated = populateDefaultShippingAddress(form, {
+      address1: '123 Main St',
+    }, 'us');
+
+    assert.equal(populated, false);
+  });
+
+  test('returns null without an authenticated customer', async () => {
+    assert.equal(await getDefaultCustomerAddress(), null);
+  });
+
+  test('returns a complete default address from the list response', async () => {
+    signIn();
+    let requests = 0;
+    globalThis.__setFetchMock(async (url, options) => {
+      requests += 1;
+      assert.match(String(url), /customers\/jane%40example\.com\/addresses$/);
+      assert.equal(new Headers(options.headers).get('Authorization')?.startsWith('Bearer '), true);
+      return jsonResponse({
+        addresses: [{
+          id: 'address-1',
+          isDefault: true,
+          address1: '123 Main St',
+          city: 'Cleveland',
+          zip: '44114',
+          country: 'us',
+        }],
+      });
+    });
+
+    const address = await getDefaultCustomerAddress();
+    assert.equal(address.address1, '123 Main St');
+    assert.equal(address.email, 'jane@example.com');
+    assert.equal(requests, 1);
+  });
+
+  test('hydrates a default address list stub from the detail endpoint', async () => {
+    signIn();
+    const urls = [];
+    globalThis.__setFetchMock(async (url) => {
+      urls.push(String(url));
+      if (urls.length === 1) {
+        return jsonResponse({ data: { addresses: [{ id: 'address-1', isDefault: true }] } });
+      }
+      return jsonResponse({
+        data: {
+          address: {
+            address1: '123 Main St',
+            city: 'Cleveland',
+            zip: '44114',
+            country: 'us',
+          },
+        },
+      });
+    });
+
+    const address = await getDefaultCustomerAddress();
+    assert.equal(address.address1, '123 Main St');
+    assert.match(urls[1], /\/addresses\/address-1$/);
+  });
+
+  test('returns null when no default or hydratable address exists', async () => {
+    signIn();
+    globalThis.__setFetchMock(async () => jsonResponse({ addresses: [{ id: 'address-1' }] }));
+    assert.equal(await getDefaultCustomerAddress(), null);
+
+    globalThis.__setFetchMock(async () => jsonResponse({
+      addresses: [{ isDefault: true }],
+    }));
+    assert.equal(await getDefaultCustomerAddress(), null);
+  });
+
+  test('rejects when the customer address API fails', async () => {
+    signIn();
+    globalThis.__setFetchMock(async () => jsonResponse({ message: 'failed' }, 500));
+    await assert.rejects(getDefaultCustomerAddress(), /customer address request failed: 500/);
+  });
+
+  test('runs the checkout prefill lifecycle in order', async () => {
+    const form = checkoutForm();
+    const calls = [];
+    const activated = await prefillDefaultShippingAddress({
+      form,
+      locale: 'us',
+      loadAddress: async () => ({ address1: '123 Main St', country: 'us' }),
+      save: () => calls.push('save'),
+      validate: async () => { calls.push('validate'); return true; },
+      refresh: () => calls.push('refresh'),
+    });
+
+    assert.equal(activated, true);
+    assert.deepEqual(calls, ['save', 'validate', 'refresh']);
+  });
+
+  test('does not refresh shipping when prefill is skipped or validation fails', async () => {
+    const existingForm = checkoutForm({ 'shipping-street-0': field('Existing address') });
+    const skippedCalls = [];
+    const skipped = await prefillDefaultShippingAddress({
+      form: existingForm,
+      locale: 'us',
+      loadAddress: async () => ({ address1: 'Default address', country: 'us' }),
+      save: () => skippedCalls.push('save'),
+      validate: async () => true,
+      refresh: () => skippedCalls.push('refresh'),
+    });
+    assert.equal(skipped, false);
+    assert.deepEqual(skippedCalls, []);
+
+    const invalidCalls = [];
+    const invalid = await prefillDefaultShippingAddress({
+      form: checkoutForm(),
+      locale: 'us',
+      loadAddress: async () => ({ address1: 'Bad address', country: 'us' }),
+      save: () => invalidCalls.push('save'),
+      validate: async () => { invalidCalls.push('validate'); return false; },
+      refresh: () => invalidCalls.push('refresh'),
+    });
+    assert.equal(invalid, false);
+    assert.deepEqual(invalidCalls, ['save', 'validate']);
   });
 });


### PR DESCRIPTION
Fixes #686

Populate blank checkouts from the signed-in customer's default mailing address and require the existing Address Doctor validation flow before shipping rates are accepted.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-686-default-checkout-address--vitamix--aemsites.aem.network/
