### PR TITLE
fix(apple-pay): show effective shipping rate

### DIFF
--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -1,6 +1,7 @@
 import {
   estimateExpressCheckout,
   getCustomerTimezone,
+  parsePreview,
   validateApplePayMerchant,
 } from '../commerce-api.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
@@ -132,12 +133,13 @@ function startExpressSession(btn, config, callbacks) {
         );
         lastShippingMethodId = e.shippingMethod.identifier;
         callbacks.getState().currentEstimateToken = previewResult.estimateToken;
+        const { shippingRate } = parsePreview(previewResult, cart.subtotal);
         session.completeShippingMethodSelection({
           newTotal: { label: config.site || 'Store', amount: String(previewResult.total) },
           newLineItems: [
             { label: 'Subtotal', amount: String(previewResult.subtotal) },
             { label: 'Tax', amount: String(previewResult.taxAmount) },
-            { label: 'Shipping', amount: String(previewResult.shippingMethod?.rate ?? 0) },
+            { label: 'Shipping', amount: String(shippingRate) },
           ],
         });
       } catch {

--- a/tests/unit/commerce-api.test.js
+++ b/tests/unit/commerce-api.test.js
@@ -7,7 +7,7 @@
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  getOrder, estimateShipping, estimatePrice, estimateExpressCheckout,
+  getOrder, estimateShipping, estimatePrice, estimateExpressCheckout, parsePreview,
 } from '../../scripts/commerce-api.js';
 import { __setLocale, __resetScripts } from './mocks/scripts.mjs';
 
@@ -236,4 +236,23 @@ test('estimatePrice: includes couponSource when provided with couponCode', async
   assert.equal(lastUrl, `${API_ORIGIN}/estimate/price`);
   assert.equal(body.couponCode, 'IDME10');
   assert.equal(body.couponSource, 'auto');
+});
+
+test('parsePreview: returns zero shipping when a cart rule grants free shipping', () => {
+  const preview = {
+    subtotal: '379.95',
+    taxAmount: '37.09',
+    shippingMethod: { rate: '12.63' },
+    discounts: [{ id: 'us-free-shipping', freeShipping: true, source: 'pricing_rule' }],
+    total: '417.04',
+  };
+  assert.equal(parsePreview(preview, 379.95).shippingRate, 0);
+});
+
+test('parsePreview: preserves the quoted shipping rate without free shipping', () => {
+  const preview = {
+    shippingMethod: { rate: '12.63' },
+    discounts: [{ id: 'save-10', amount: 10 }],
+  };
+  assert.equal(parsePreview(preview, 379.95).shippingRate, '12.63');
 });


### PR DESCRIPTION
Use the normalized preview rate so free-shipping cart rules display zero shipping in the Apple Pay payment sheet.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-apple-pay-free-shipping-display--vitamix--aemsites.aem.network/