### PR TITLE
fix(checkout): distinguish express and standard context

### DIFF
--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -339,6 +339,7 @@ export default async function decorate(block) {
   const state = { currentEstimateToken: null, currentPreview: null };
 
   const callbacks = {
+    expressEntryPoint: 'cart',
     getCart: () => cart,
     getConfig: () => config,
     getState: () => state,

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -10,22 +10,10 @@ import { FORMS_ENDPOINT, getLocaleAndLanguage } from '../../scripts/scripts.js';
 import { validateLinkIntegrity } from './link-integrity.js';
 import { validateForm } from './checkout-validation.js';
 import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
+import { getStandardCheckoutContext } from '../../scripts/checkout-context.js';
 
 export { validateLinkIntegrity };
-
-/**
- * Builds checkout context fields for full-checkout order payloads.
- * @param {string|null} paymentMethod
- * @returns {Object|null}
- */
-export function getCheckoutContext(paymentMethod) {
-  if (!paymentMethod) return null;
-  return {
-    paymentMethod,
-    checkoutFlow: paymentMethod === 'apple-pay' ? 'express' : 'standard',
-    entryPoint: 'checkout',
-  };
-}
+export { getStandardCheckoutContext as getCheckoutContext };
 
 /**
  * Returns the explicitly selected checkout payment method, if any.
@@ -110,7 +98,7 @@ export function buildOrderJSON(formData, form, cart, state, config) {
   order.locale = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
   order.country = locale;
 
-  const checkoutContext = getCheckoutContext(formData.get('paymentMethod'));
+  const checkoutContext = getStandardCheckoutContext(formData.get('paymentMethod'));
   if (checkoutContext) Object.assign(order, checkoutContext);
 
   const customerTimezone = getCustomerTimezone();
@@ -185,6 +173,7 @@ function subscribeNewsletter(formData) {
  */
 export function initOrder(form, cart, state, config, strings) {
   const callbacks = {
+    expressEntryPoint: 'checkout',
     getCart: () => cart,
     getConfig: () => config,
     strings,

--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -13,7 +13,6 @@ import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 import { getStandardCheckoutContext } from '../../scripts/checkout-context.js';
 
 export { validateLinkIntegrity };
-export { getStandardCheckoutContext as getCheckoutContext };
 
 /**
  * Returns the explicitly selected checkout payment method, if any.

--- a/blocks/checkout/checkout-payment.js
+++ b/blocks/checkout/checkout-payment.js
@@ -221,7 +221,7 @@ export async function initPayment(container, providers, callbacks, config, strin
 
   renderPaymentSection(container, available, callbacks, strings, config);
 
-  // Render express buttons on the cart page (order-summary block)
+  // Render express buttons above the checkout form when the authored container exists.
   const expressContainer = document.querySelector('.express-checkout-buttons');
   if (expressContainer) {
     available.filter((p) => p.supportsExpress).forEach((p) => {

--- a/blocks/checkout/checkout-shipping.js
+++ b/blocks/checkout/checkout-shipping.js
@@ -1,5 +1,6 @@
 import { estimateShipping, previewOrder } from '../../scripts/commerce-api.js';
 import { formatPrice } from '../../scripts/commerce-config.js';
+import { getStandardCheckoutContext } from '../../scripts/checkout-context.js';
 import { wireRadioTabNav } from './checkout-form.js';
 
 /**
@@ -140,13 +141,14 @@ export async function updatePreview(form, cart, state, config) {
     email,
   };
 
+  const checkoutContext = getStandardCheckoutContext(data.get('paymentMethod'));
   const orderBody = {
     shipping: Object.fromEntries(Object.entries(shippingAddr).filter(([, v]) => v !== '')),
     items: cart.getItemsForAPI(),
     shippingMethod: { id: state.selectedShippingMethodId },
     locale: `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`,
     country: locale,
-    paymentMethod: data.get('paymentMethod') || null,
+    ...(checkoutContext || {}),
   };
 
   const couponCode = sessionStorage.getItem('checkout_coupon_code') || undefined;

--- a/scripts/checkout-context.js
+++ b/scripts/checkout-context.js
@@ -1,0 +1,41 @@
+const CHECKOUT_ENTRY_POINTS = new Set(['cart', 'checkout', 'pdp']);
+
+/**
+ * Builds checkout facts shared by estimate, preview, and order payloads.
+ * @param {string|null} paymentMethod
+ * @param {'standard'|'express'} checkoutFlow
+ * @param {'cart'|'checkout'|'pdp'} entryPoint
+ * @returns {Object|null}
+ */
+export function createCheckoutContext(paymentMethod, checkoutFlow, entryPoint) {
+  if (!paymentMethod) return null;
+  if (!['standard', 'express'].includes(checkoutFlow)) {
+    throw new Error(`Unsupported checkout flow: ${checkoutFlow}`);
+  }
+  if (!CHECKOUT_ENTRY_POINTS.has(entryPoint)) {
+    throw new Error(`Unsupported checkout entry point: ${entryPoint}`);
+  }
+  return { paymentMethod, checkoutFlow, entryPoint };
+}
+
+/**
+ * Context for a payment selected after the shopper completes checkout fields.
+ * @param {string|null} paymentMethod
+ * @returns {Object|null}
+ */
+export function getStandardCheckoutContext(paymentMethod) {
+  return createCheckoutContext(paymentMethod, 'standard', 'checkout');
+}
+
+/**
+ * Context for a wallet that collects checkout details without the full form.
+ * @param {string} paymentMethod
+ * @param {'cart'|'checkout'|'pdp'} entryPoint
+ * @returns {Object}
+ */
+export function getExpressCheckoutContext(paymentMethod, entryPoint) {
+  if (!paymentMethod) {
+    throw new Error('Payment method is required for express checkout');
+  }
+  return createCheckoutContext(paymentMethod, 'express', entryPoint);
+}

--- a/scripts/payments/apple-pay-context.js
+++ b/scripts/payments/apple-pay-context.js
@@ -1,21 +1,38 @@
-export const APPLE_PAY_CART_CONTEXT = {
-  paymentMethod: 'apple-pay',
-  checkoutFlow: 'express',
-  entryPoint: 'cart',
-};
+import { getExpressCheckoutContext } from '../checkout-context.js';
+
+export const APPLE_PAY_CART_CONTEXT = getExpressCheckoutContext('apple-pay', 'cart');
 
 /**
- * Builds the Apple Pay cart preview payload for a selected shipping method.
+ * Builds Apple Pay express context for the page where the button is rendered.
+ * @param {'cart'|'checkout'|'pdp'} entryPoint
+ * @returns {Object}
+ */
+export function getApplePayExpressContext(entryPoint) {
+  return getExpressCheckoutContext('apple-pay', entryPoint);
+}
+
+/**
+ * Builds the Apple Pay express preview payload for a selected shipping method.
  * @param {Object} cart
  * @param {string} shippingMethodId
  * @param {string} locale
  * @param {Object|null} contact
+ * @param {Object} checkoutContext
  * @returns {Object}
  */
-export function buildApplePayCartPreviewPayload(cart, shippingMethodId, locale, contact) {
+export function buildApplePayExpressPreviewPayload(
+  cart,
+  shippingMethodId,
+  locale,
+  contact,
+  checkoutContext,
+) {
+  if (!checkoutContext) {
+    throw new Error('Apple Pay express preview requires checkout context');
+  }
   const countryCode = contact?.countryCode?.toLowerCase();
   return {
-    ...APPLE_PAY_CART_CONTEXT,
+    ...checkoutContext,
     items: cart.getItemsForAPI(),
     shippingMethod: { id: shippingMethodId },
     locale,
@@ -31,7 +48,7 @@ export function buildApplePayCartPreviewPayload(cart, shippingMethodId, locale, 
 }
 
 /**
- * Builds the Apple Pay cart order payload from the authorized payment contact.
+ * Builds the Apple Pay express order payload from the authorized payment contact.
  * @param {Object} params
  * @param {Object} params.payment
  * @param {Object} params.cart
@@ -41,9 +58,10 @@ export function buildApplePayCartPreviewPayload(cart, shippingMethodId, locale, 
  * @param {string} params.locale
  * @param {string} params.customerEmail
  * @param {string} [params.customerTimezone]
+ * @param {Object} params.checkoutContext
  * @returns {Object}
  */
-export function buildApplePayCartOrderPayload(params) {
+export function buildApplePayExpressOrderPayload(params) {
   const {
     payment,
     cart,
@@ -53,7 +71,11 @@ export function buildApplePayCartOrderPayload(params) {
     locale,
     customerEmail,
     customerTimezone,
+    checkoutContext,
   } = params;
+  if (!checkoutContext) {
+    throw new Error('Apple Pay express order requires checkout context');
+  }
   const contact = payment.shippingContact;
   const shippingAddr = {
     name: `${contact.givenName} ${contact.familyName}`.trim(),
@@ -68,7 +90,7 @@ export function buildApplePayCartOrderPayload(params) {
   };
 
   return {
-    ...APPLE_PAY_CART_CONTEXT,
+    ...checkoutContext,
     customer: {
       firstName: contact.givenName || '',
       lastName: contact.familyName || '',

--- a/scripts/payments/apple-pay.js
+++ b/scripts/payments/apple-pay.js
@@ -7,9 +7,9 @@ import {
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
 import {
-  APPLE_PAY_CART_CONTEXT,
-  buildApplePayCartOrderPayload,
-  buildApplePayCartPreviewPayload,
+  buildApplePayExpressOrderPayload,
+  buildApplePayExpressPreviewPayload,
+  getApplePayExpressContext,
 } from './apple-pay-context.js';
 
 const APPLE_PAY_SDK_URL = 'https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js';
@@ -40,6 +40,7 @@ function startExpressSession(btn, config, callbacks) {
     const locale = config.getLocale();
     const language = config.getLanguage();
     const bcp47 = `${language.split('_')[0]}-${(language.split('_')[1] || locale).toUpperCase()}`;
+    const checkoutContext = getApplePayExpressContext(callbacks.expressEntryPoint);
 
     let lastShippingContact = null;
     let lastShippingMethodId = null;
@@ -84,7 +85,7 @@ function startExpressSession(btn, config, callbacks) {
           contact.administrativeArea,
           contact.postalCode,
           cart.getItemsForAPI(),
-          APPLE_PAY_CART_CONTEXT,
+          checkoutContext,
         );
         const methods = result.shippingMethods || [];
         if (!methods.length) {
@@ -124,11 +125,12 @@ function startExpressSession(btn, config, callbacks) {
     session.onshippingmethodselected = async (e) => {
       try {
         const previewResult = await callbacks.previewOrderDirect(
-          buildApplePayCartPreviewPayload(
+          buildApplePayExpressPreviewPayload(
             cart,
             e.shippingMethod.identifier,
             bcp47,
             lastShippingContact,
+            checkoutContext,
           ),
         );
         lastShippingMethodId = e.shippingMethod.identifier;
@@ -157,7 +159,7 @@ function startExpressSession(btn, config, callbacks) {
         // commerce account email, which causes assertEmail to reject the request.
         const customerEmail = (isLoggedIn() && getUser()?.email) || contact.emailAddress || '';
         const customerTimezone = getCustomerTimezone();
-        const orderBody = buildApplePayCartOrderPayload({
+        const orderBody = buildApplePayExpressOrderPayload({
           payment,
           cart,
           shippingMethodId: lastShippingMethodId || e.payment.shippingMethod?.identifier || '',
@@ -166,6 +168,7 @@ function startExpressSession(btn, config, callbacks) {
           locale: bcp47,
           customerEmail,
           customerTimezone,
+          checkoutContext,
         });
 
         const createdOrder = await callbacks.createOrder(orderBody);
@@ -348,6 +351,9 @@ export default {
   isAvailable: () => Boolean(window.ApplePaySession),
 
   renderExpressButton(container, callbacks) {
+    if (!callbacks.expressEntryPoint) {
+      throw new Error('Apple Pay express checkout requires an entry point');
+    }
     const config = callbacks.getConfig();
     const locale = config.getLocale();
     const language = config.getLanguage();

--- a/scripts/payments/paypal-context.js
+++ b/scripts/payments/paypal-context.js
@@ -1,3 +1,27 @@
+import { getExpressCheckoutContext } from '../checkout-context.js';
+
+/**
+ * Builds PayPal express context for the page where the button is rendered.
+ * @param {'cart'|'checkout'|'pdp'} entryPoint
+ * @returns {Object}
+ */
+export function getPayPalExpressContext(entryPoint) {
+  return getExpressCheckoutContext('paypal', entryPoint);
+}
+
+/**
+ * Adds authoritative PayPal express facts to a preview or order payload.
+ * @param {Object} payload
+ * @param {'cart'|'checkout'|'pdp'} entryPoint
+ * @returns {Object}
+ */
+export function withPayPalExpressContext(payload, entryPoint) {
+  return {
+    ...payload,
+    ...getPayPalExpressContext(entryPoint),
+  };
+}
+
 /**
  * Ensures checkout PayPal has a signed estimate token before order creation.
  * @param {Object} callbacks

--- a/scripts/payments/paypal.js
+++ b/scripts/payments/paypal.js
@@ -7,7 +7,7 @@ import {
 import { getLocaleAndLanguage } from '../scripts.js';
 import { getUser, isLoggedIn } from '../auth-api.js';
 import { logOperation, getCheckoutId } from '../operations-log.js';
-import ensureCheckoutPreviewToken from './paypal-context.js';
+import ensureCheckoutPreviewToken, { withPayPalExpressContext } from './paypal-context.js';
 
 let sdkLoadPromise = null;
 
@@ -145,6 +145,10 @@ export default {
       return;
     }
 
+    if (!callbacks.expressEntryPoint) {
+      throw new Error('PayPal express checkout requires an entry point');
+    }
+
     let lastShippingMethods = [];
     let lastShippingAddress = null;
 
@@ -199,7 +203,7 @@ export default {
           // only fires on an explicit option change, not on initial address selection).
           const countryCode = data.shippingAddress.countryCode?.toLowerCase();
           const [defaultMethod] = lastShippingMethods;
-          const preview = await callbacks.previewOrderDirect({
+          const preview = await callbacks.previewOrderDirect(withPayPalExpressContext({
             items: cart.getItemsForAPI(),
             shippingMethod: { id: String(defaultMethod.id) },
             ...(countryCode ? {
@@ -210,7 +214,7 @@ export default {
                 zip: data.shippingAddress.postalCode || '',
               },
             } : {}),
-          });
+          }, callbacks.expressEntryPoint));
           state.currentEstimateToken = preview.estimateToken;
         } catch {
           return actions.reject(data.errors.ADDRESS_ERROR);
@@ -236,7 +240,7 @@ export default {
           shippingRate: method.rate,
         });
         const countryCode = lastShippingAddress?.countryCode?.toLowerCase();
-        const preview = await callbacks.previewOrderDirect({
+        const preview = await callbacks.previewOrderDirect(withPayPalExpressContext({
           items: cart.getItemsForAPI(),
           shippingMethod: { id: String(method.id) },
           ...(countryCode ? {
@@ -247,7 +251,7 @@ export default {
               zip: lastShippingAddress.postalCode || '',
             },
           } : {}),
-        });
+        }, callbacks.expressEntryPoint));
         state.currentEstimateToken = preview.estimateToken;
         return undefined;
       },
@@ -267,7 +271,7 @@ export default {
           // return a different payer email, which remains on billing/shipping.
           const accountEmail = isLoggedIn() ? getUser()?.email : '';
           const customerEmail = accountEmail || session.payer.email || '';
-          const orderBody = {
+          const orderBody = withPayPalExpressContext({
             customer: {
               firstName: session.payer.firstName,
               lastName: session.payer.lastName,
@@ -290,7 +294,7 @@ export default {
             country: session.shippingAddress.country,
             locale: getLocaleAndLanguage(false, true).language,
             ...(customerTimezone ? { customerTimezone } : {}),
-          };
+          }, callbacks.expressEntryPoint);
           const createdOrder = await callbacks.createOrder(orderBody);
           const fraudToken = (() => {
             try { return sessionStorage.getItem('forter_token') || undefined; } catch { return undefined; }

--- a/tests/checkout/checkout-page.spec.js
+++ b/tests/checkout/checkout-page.spec.js
@@ -566,9 +566,14 @@ test.describe('Edge Checkout Page', () => {
       await expect(page.locator('.checkout-form [name="shippingMethod"][value="797"]')).toBeChecked({ timeout: 10000 });
       expect(previewRequests).toHaveLength(0);
       await selectCreditCardAndWaitForPreview(page);
-      expect(previewRequests.some(
+      const initialPreview = previewRequests.find(
         (body) => body.items?.[0]?.quantity === 2 && body.shippingMethod?.id === '797',
-      )).toBe(true);
+      );
+      expect(initialPreview).toMatchObject({
+        paymentMethod: 'chase',
+        checkoutFlow: 'standard',
+        entryPoint: 'checkout',
+      });
 
       // Changing quantity invalidates the provider-specific shipping id. The
       // checkout should re-fetch rates, preserve the Standard service by type,
@@ -1085,6 +1090,9 @@ test.describe('Edge Checkout Page', () => {
       expect(orderRequest.body.shipping.city).toBe(VALID_ADDRESS.city);
       expect(orderRequest.body.shipping.state).toBe(VALID_ADDRESS.state);
       expect(orderRequest.body.estimateToken).toBe(MOCK_PREVIEW.estimateToken);
+      expect(orderRequest.body.paymentMethod).toBe('chase');
+      expect(orderRequest.body.checkoutFlow).toBe('standard');
+      expect(orderRequest.body.entryPoint).toBe('checkout');
       expect(orderRequest.body.items).toHaveLength(1);
       console.log('✓ Place order happy path: preview → order → payment → /order/complete');
     });

--- a/tests/scripts/paypal-express.spec.js
+++ b/tests/scripts/paypal-express.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { withPayPalExpressContext } from '../../scripts/payments/paypal-context.js';
 
 /**
  * Unit tests for renderExpressButton callbacks in scripts/payments/paypal.js.
@@ -76,7 +77,7 @@ async function handleShippingOptionsChange(data, actions, closureState, callback
     shippingRate: method.rate,
   });
   const countryCode = closureState.lastShippingAddress?.countryCode?.toLowerCase();
-  const preview = await callbacks.previewOrderDirect({
+  const preview = await callbacks.previewOrderDirect(withPayPalExpressContext({
     items: cart.getItemsForAPI(),
     shippingMethod: { id: method.id },
     ...(countryCode ? {
@@ -87,7 +88,7 @@ async function handleShippingOptionsChange(data, actions, closureState, callback
         zip: closureState.lastShippingAddress.postalCode || '',
       },
     } : {}),
-  });
+  }, callbacks.expressEntryPoint));
   state.currentEstimateToken = preview.estimateToken;
   return undefined;
 }
@@ -104,7 +105,7 @@ async function handleApprove(callbacks, deps) {
     const config = callbacks.getConfig();
     const accountEmail = deps.isLoggedInFn?.() ? deps.getUserFn?.()?.email : '';
     const customerEmail = accountEmail || session.payer.email || '';
-    const orderBody = {
+    const orderBody = withPayPalExpressContext({
       customer: {
         firstName: session.payer.firstName,
         lastName: session.payer.lastName,
@@ -126,7 +127,7 @@ async function handleApprove(callbacks, deps) {
       estimateToken: state.currentEstimateToken,
       country: session.shippingAddress.country,
       locale: config.getLanguage(),
-    };
+    }, callbacks.expressEntryPoint);
     const createdOrder = await callbacks.createOrder(orderBody);
     const fraudToken = (() => {
       try {
@@ -191,6 +192,7 @@ function makeState(overrides = {}) {
 
 function makeCallbacks(state = makeState(), overrides = {}) {
   return {
+    expressEntryPoint: 'cart',
     getConfig: () => ({
       getLanguage: () => 'en-US',
       currency: 'USD',
@@ -378,6 +380,11 @@ test.describe('onShippingOptionsChange callback', () => {
     expect(previewArg.shipping.state).toBe('CA');
     expect(previewArg.shipping.zip).toBe('90210');
     expect(previewArg.shippingMethod.id).toBe('std');
+    expect(previewArg).toMatchObject({
+      paymentMethod: 'paypal',
+      checkoutFlow: 'express',
+      entryPoint: 'cart',
+    });
   });
 
   test('calls previewOrderDirect without country/shipping when lastShippingAddress is null', async () => {
@@ -466,6 +473,11 @@ test.describe('onApprove callback', () => {
     expect(orderBody.shippingMethod.id).toBe('std');
     expect(orderBody.estimateToken).toBe('est-tok');
     expect(orderBody.country).toBe('us');
+    expect(orderBody).toMatchObject({
+      paymentMethod: 'paypal',
+      checkoutFlow: 'express',
+      entryPoint: 'cart',
+    });
   });
 
   test('uses authenticated account email for order customer when signed in', async () => {

--- a/tests/unit/apple-pay-context.test.js
+++ b/tests/unit/apple-pay-context.test.js
@@ -2,8 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   APPLE_PAY_CART_CONTEXT,
-  buildApplePayCartOrderPayload,
-  buildApplePayCartPreviewPayload,
+  buildApplePayExpressOrderPayload,
+  buildApplePayExpressPreviewPayload,
+  getApplePayExpressContext,
 } from '../../scripts/payments/apple-pay-context.js';
 
 const ITEMS = [{
@@ -43,12 +44,40 @@ test('APPLE_PAY_CART_CONTEXT identifies cart-origin Apple Pay express checkout',
   });
 });
 
-test('buildApplePayCartPreviewPayload includes cart context and partial shipping', () => {
-  const payload = buildApplePayCartPreviewPayload(
+test('getApplePayExpressContext preserves the express button entry point', () => {
+  assert.deepEqual(getApplePayExpressContext('checkout'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'checkout',
+  });
+});
+
+test('Apple Pay express payload builders require explicit context', () => {
+  assert.throws(
+    () => buildApplePayExpressPreviewPayload(cart, 'standard', 'en-US', shippingContact),
+    /preview requires checkout context/,
+  );
+  assert.throws(
+    () => buildApplePayExpressOrderPayload({
+      payment: { shippingContact: paymentContact },
+      cart,
+      shippingMethodId: 'standard',
+      estimateToken: 'estimate-token',
+      country: 'us',
+      locale: 'en-US',
+      customerEmail: 'account@example.com',
+    }),
+    /order requires checkout context/,
+  );
+});
+
+test('buildApplePayExpressPreviewPayload includes cart context and partial shipping', () => {
+  const payload = buildApplePayExpressPreviewPayload(
     cart,
     'standard',
     'en-US',
     shippingContact,
+    APPLE_PAY_CART_CONTEXT,
   );
 
   assert.equal(payload.paymentMethod, 'apple-pay');
@@ -65,16 +94,22 @@ test('buildApplePayCartPreviewPayload includes cart context and partial shipping
   });
 });
 
-test('buildApplePayCartPreviewPayload omits shipping when contact has no country', () => {
-  const payload = buildApplePayCartPreviewPayload(cart, 'standard', 'en-US', null);
+test('buildApplePayExpressPreviewPayload omits shipping when contact has no country', () => {
+  const payload = buildApplePayExpressPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    null,
+    APPLE_PAY_CART_CONTEXT,
+  );
 
   assert.equal(payload.paymentMethod, 'apple-pay');
   assert.equal(payload.country, undefined);
   assert.equal(payload.shipping, undefined);
 });
 
-test('buildApplePayCartOrderPayload includes cart context and full address data', () => {
-  const payload = buildApplePayCartOrderPayload({
+test('buildApplePayExpressOrderPayload includes cart context and full address data', () => {
+  const payload = buildApplePayExpressOrderPayload({
     payment: { shippingContact: paymentContact },
     cart,
     shippingMethodId: 'standard',
@@ -83,6 +118,7 @@ test('buildApplePayCartOrderPayload includes cart context and full address data'
     locale: 'en-US',
     customerEmail: 'account@example.com',
     customerTimezone: 'America/New_York',
+    checkoutContext: APPLE_PAY_CART_CONTEXT,
   });
 
   assert.equal(payload.paymentMethod, 'apple-pay');
@@ -111,14 +147,16 @@ test('buildApplePayCartOrderPayload includes cart context and full address data'
   assert.deepEqual(payload.billing, payload.shipping);
 });
 
-test('Apple Pay cart preview and order payloads use matching context facts', () => {
-  const preview = buildApplePayCartPreviewPayload(
+test('Apple Pay checkout express preview and order use matching context facts', () => {
+  const checkoutContext = getApplePayExpressContext('checkout');
+  const preview = buildApplePayExpressPreviewPayload(
     cart,
     'standard',
     'en-US',
     shippingContact,
+    checkoutContext,
   );
-  const order = buildApplePayCartOrderPayload({
+  const order = buildApplePayExpressOrderPayload({
     payment: { shippingContact: paymentContact },
     cart,
     shippingMethodId: 'standard',
@@ -126,6 +164,38 @@ test('Apple Pay cart preview and order payloads use matching context facts', () 
     country: 'us',
     locale: 'en-US',
     customerEmail: 'account@example.com',
+    checkoutContext,
+  });
+
+  assert.deepEqual({
+    paymentMethod: preview.paymentMethod,
+    checkoutFlow: preview.checkoutFlow,
+    entryPoint: preview.entryPoint,
+  }, checkoutContext);
+  assert.deepEqual({
+    paymentMethod: order.paymentMethod,
+    checkoutFlow: order.checkoutFlow,
+    entryPoint: order.entryPoint,
+  }, checkoutContext);
+});
+
+test('Apple Pay cart preview and order payloads use matching context facts', () => {
+  const preview = buildApplePayExpressPreviewPayload(
+    cart,
+    'standard',
+    'en-US',
+    shippingContact,
+    APPLE_PAY_CART_CONTEXT,
+  );
+  const order = buildApplePayExpressOrderPayload({
+    payment: { shippingContact: paymentContact },
+    cart,
+    shippingMethodId: 'standard',
+    estimateToken: 'estimate-token',
+    country: 'us',
+    locale: 'en-US',
+    customerEmail: 'account@example.com',
+    checkoutContext: APPLE_PAY_CART_CONTEXT,
   });
 
   assert.deepEqual(

--- a/tests/unit/checkout-context.test.js
+++ b/tests/unit/checkout-context.test.js
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createCheckoutContext,
+  getExpressCheckoutContext,
+  getStandardCheckoutContext,
+} from '../../scripts/checkout-context.js';
+
+test('getStandardCheckoutContext describes form-based checkout', () => {
+  assert.deepEqual(getStandardCheckoutContext('apple-pay'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'standard',
+    entryPoint: 'checkout',
+  });
+  assert.equal(getStandardCheckoutContext(null), null);
+});
+
+test('getExpressCheckoutContext preserves the launch entry point', () => {
+  assert.deepEqual(getExpressCheckoutContext('apple-pay', 'cart'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+  });
+  assert.deepEqual(getExpressCheckoutContext('apple-pay', 'checkout'), {
+    paymentMethod: 'apple-pay',
+    checkoutFlow: 'express',
+    entryPoint: 'checkout',
+  });
+});
+
+test('getExpressCheckoutContext requires a payment method', () => {
+  assert.throws(
+    () => getExpressCheckoutContext(null, 'cart'),
+    /Payment method is required/,
+  );
+});
+
+test('createCheckoutContext rejects unsupported context facts', () => {
+  assert.throws(
+    () => createCheckoutContext('apple-pay', 'accelerated', 'cart'),
+    /Unsupported checkout flow/,
+  );
+  assert.throws(
+    () => createCheckoutContext('apple-pay', 'express', 'unknown'),
+    /Unsupported checkout entry point/,
+  );
+});

--- a/tests/unit/checkout-order-context.test.js
+++ b/tests/unit/checkout-order-context.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildOrderJSON, getCheckoutContext } from '../../blocks/checkout/checkout-order.js';
+import { buildOrderJSON } from '../../blocks/checkout/checkout-order.js';
+import { getStandardCheckoutContext } from '../../scripts/checkout-context.js';
 import { APPLE_PAY_CART_CONTEXT } from '../../scripts/payments/apple-pay-context.js';
 
 function formData(values) {
@@ -56,21 +57,21 @@ function buildOrder(values) {
   );
 }
 
-test('getCheckoutContext returns null when payment method is absent', () => {
-  assert.equal(getCheckoutContext(''), null);
-  assert.equal(getCheckoutContext(null), null);
+test('getStandardCheckoutContext returns null when payment method is absent', () => {
+  assert.equal(getStandardCheckoutContext(''), null);
+  assert.equal(getStandardCheckoutContext(null), null);
 });
 
-test('getCheckoutContext returns standard checkout context for card payments', () => {
-  assert.deepEqual(getCheckoutContext('chase'), {
+test('getStandardCheckoutContext returns standard checkout context for card payments', () => {
+  assert.deepEqual(getStandardCheckoutContext('chase'), {
     paymentMethod: 'chase',
     checkoutFlow: 'standard',
     entryPoint: 'checkout',
   });
 });
 
-test('getCheckoutContext returns standard context for form-based Apple Pay', () => {
-  assert.deepEqual(getCheckoutContext('apple-pay'), {
+test('getStandardCheckoutContext returns standard context for form-based Apple Pay', () => {
+  assert.deepEqual(getStandardCheckoutContext('apple-pay'), {
     paymentMethod: 'apple-pay',
     checkoutFlow: 'standard',
     entryPoint: 'checkout',

--- a/tests/unit/checkout-order-context.test.js
+++ b/tests/unit/checkout-order-context.test.js
@@ -69,10 +69,10 @@ test('getCheckoutContext returns standard checkout context for card payments', (
   });
 });
 
-test('getCheckoutContext returns express checkout context for checkout-page Apple Pay', () => {
+test('getCheckoutContext returns standard context for form-based Apple Pay', () => {
   assert.deepEqual(getCheckoutContext('apple-pay'), {
     paymentMethod: 'apple-pay',
-    checkoutFlow: 'express',
+    checkoutFlow: 'standard',
     entryPoint: 'checkout',
   });
 });
@@ -85,20 +85,28 @@ test('buildOrderJSON includes checkout context for card checkout', () => {
   assert.equal(order.entryPoint, 'checkout');
 });
 
-test('buildOrderJSON includes checkout entry point for checkout-page Apple Pay', () => {
+test('buildOrderJSON includes standard context for form-based Apple Pay', () => {
   const order = buildOrder({ paymentMethod: 'apple-pay' });
 
   assert.equal(order.paymentMethod, 'apple-pay');
-  assert.equal(order.checkoutFlow, 'express');
+  assert.equal(order.checkoutFlow, 'standard');
   assert.equal(order.entryPoint, 'checkout');
 });
 
-test('checkout-page Apple Pay context does not reuse cart entry point', () => {
+test('form-based Apple Pay uses standard checkout rather than express cart context', () => {
   const order = buildOrder({ paymentMethod: 'apple-pay' });
 
   assert.equal(APPLE_PAY_CART_CONTEXT.entryPoint, 'cart');
+  assert.equal(APPLE_PAY_CART_CONTEXT.checkoutFlow, 'express');
   assert.equal(order.entryPoint, 'checkout');
-  assert.notEqual(order.entryPoint, APPLE_PAY_CART_CONTEXT.entryPoint);
+  assert.equal(order.checkoutFlow, 'standard');
+  assert.notDeepEqual({
+    checkoutFlow: order.checkoutFlow,
+    entryPoint: order.entryPoint,
+  }, {
+    checkoutFlow: APPLE_PAY_CART_CONTEXT.checkoutFlow,
+    entryPoint: APPLE_PAY_CART_CONTEXT.entryPoint,
+  });
 });
 
 test('buildOrderJSON omits checkout context when payment method is absent', () => {

--- a/tests/unit/paypal-checkout-preview.test.js
+++ b/tests/unit/paypal-checkout-preview.test.js
@@ -1,6 +1,29 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import ensureCheckoutPreviewToken from '../../scripts/payments/paypal-context.js';
+import ensureCheckoutPreviewToken, {
+  getPayPalExpressContext,
+  withPayPalExpressContext,
+} from '../../scripts/payments/paypal-context.js';
+
+test('getPayPalExpressContext preserves the express button entry point', () => {
+  assert.deepEqual(getPayPalExpressContext('checkout'), {
+    paymentMethod: 'paypal',
+    checkoutFlow: 'express',
+    entryPoint: 'checkout',
+  });
+});
+
+test('withPayPalExpressContext adds authoritative context to payloads', () => {
+  assert.deepEqual(withPayPalExpressContext({
+    paymentMethod: 'incorrect',
+    items: [{ sku: 'sku-1' }],
+  }, 'cart'), {
+    paymentMethod: 'paypal',
+    checkoutFlow: 'express',
+    entryPoint: 'cart',
+    items: [{ sku: 'sku-1' }],
+  });
+});
 
 function callbacksForState(state) {
   let updatePreviewCalls = 0;


### PR DESCRIPTION
Preserves truthful cart and checkout entry points for express wallets while classifying form-based payments as standard, keeping preview and order context consistent for tax routing.

Validation:
- Context-focused unit tests: 31 passed
- PayPal express tests: 30 passed
- Checkout Mobile Chrome tests: 31 passed
- Lint passed

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://checkout-express-context--vitamix--aemsites.aem.network/
