### PR TITLE
fix(checkout): prefill address after login

### DIFF
--- a/blocks/checkout/checkout-customer-address.js
+++ b/blocks/checkout/checkout-customer-address.js
@@ -1,4 +1,5 @@
 import {
+  AUTH_EVENT,
   authFetch,
   getUser,
   isLoggedIn,
@@ -119,4 +120,19 @@ export async function prefillDefaultShippingAddress({
   if (!await validate()) return false;
   refresh();
   return true;
+}
+
+/**
+ * Runs address prefill on checkout load and again whenever the shopper signs in.
+ * @param {Document|EventTarget} eventTarget
+ * @param {() => void} prefill
+ * @returns {() => void} removes the authentication listener
+ */
+export function watchCustomerAddressPrefill(eventTarget, prefill) {
+  const handleAuthChange = (event) => {
+    if (event.detail?.loggedIn) prefill();
+  };
+  eventTarget.addEventListener(AUTH_EVENT, handleAuthChange);
+  prefill();
+  return () => eventTarget.removeEventListener(AUTH_EVENT, handleAuthChange);
 }

--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -20,7 +20,10 @@ import { validateField } from './checkout-validation.js';
 import { formStateKey, saveFormState, restoreFormState } from './checkout-session-state.js';
 import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
 import { getLocaleAndLanguage } from '../../scripts/scripts.js';
-import { prefillDefaultShippingAddress } from './checkout-customer-address.js';
+import {
+  prefillDefaultShippingAddress,
+  watchCustomerAddressPrefill,
+} from './checkout-customer-address.js';
 
 const ALL_PROVIDERS = [chase, applePay, paypal, affirm];
 
@@ -424,13 +427,14 @@ export default async function decorate(block) {
   // Start a signed-in customer's blank checkout with their default mailing address.
   // Treat saved addresses like manually entered ones: Address Doctor must accept or
   // correct the address before shipping rates are requested.
-  prefillDefaultShippingAddress({
+  const prefillCustomerAddress = () => prefillDefaultShippingAddress({
     form,
     locale,
     save: saveFormState,
     validate: runShippingValidation,
     refresh: refreshShipping,
   }).catch(() => { /* signed-in address prefill is best-effort */ });
+  watchCustomerAddressPrefill(document, prefillCustomerAddress);
 
   // If the address was restored from sessionStorage on this page load, the
   // state select has a value but no `change` event ever fired — so the

--- a/tests/unit/checkout-customer-address.test.js
+++ b/tests/unit/checkout-customer-address.test.js
@@ -6,6 +6,7 @@ import {
   normalizeAddresses,
   populateDefaultShippingAddress,
   prefillDefaultShippingAddress,
+  watchCustomerAddressPrefill,
 } from '../../blocks/checkout/checkout-customer-address.js';
 
 function field(value = '') {
@@ -199,6 +200,27 @@ describe('default checkout customer address', () => {
 
     assert.equal(activated, true);
     assert.deepEqual(calls, ['save', 'validate', 'refresh']);
+  });
+
+  test('reruns prefill after login but not after logout', () => {
+    const listeners = new Map();
+    const eventTarget = {
+      addEventListener: (type, listener) => listeners.set(type, listener),
+      removeEventListener: (type, listener) => {
+        if (listeners.get(type) === listener) listeners.delete(type);
+      },
+    };
+    let prefillCalls = 0;
+    const stopWatching = watchCustomerAddressPrefill(eventTarget, () => { prefillCalls += 1; });
+
+    assert.equal(prefillCalls, 1);
+    listeners.get('commerce:auth-state-changed')({ detail: { loggedIn: true } });
+    assert.equal(prefillCalls, 2);
+    listeners.get('commerce:auth-state-changed')({ detail: { loggedIn: false } });
+    assert.equal(prefillCalls, 2);
+
+    stopWatching();
+    assert.equal(listeners.has('commerce:auth-state-changed'), false);
   });
 
   test('does not refresh shipping when prefill is skipped or validation fails', async () => {


### PR DESCRIPTION
Fixes #686

Rerun the existing default-address prefill when authentication succeeds on checkout while preserving the guard against overwriting shopper-entered data.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://fix-checkout-login-address-prefill--vitamix--aemsites.aem.network/
