### PR TITLE
fix(form): restore newsletter /forms payload contract

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -496,12 +496,12 @@ function enableFooterSignUp(form) {
 
     const payload = {
       formId: `${locale}/${language}/newsletter`,
+      pageUrl: window.location.href,
       email,
       mobile,
-      sms_optin: optIn ? '1' : '0',
-      lead_source: leadSource,
-      pageUrl: window.location.href,
-      actionUrl: `/${locale}/${language}/rest/V1/vitamix-api/newslettersubscribe`,
+      smsOptIn: optIn,
+      emailOptIn: true,
+      leadSource,
     };
     try {
       const url = getFormSubmissionUrl();

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -251,8 +251,8 @@ test.describe('PDP Integration Tests', () => {
           'super_attribute[93]': '534',
           vitamixProductId: '3627',
           'options[3000]': '3939',
-          warranty_sku: 'sku-10-year-standard-warranty',
-          'warranty_skus[3939]': 'sku-10-year-standard-warranty',
+          warranty_sku: 'sku-10-year-limited-warranty',
+          'warranty_skus[3939]': 'sku-10-year-limited-warranty',
         });
 
         // Log the arguments that were passed to addToCart


### PR DESCRIPTION
The main->sync-main merge crossed the payload conflict and reverted the newsletter fields to the legacy snake_case shape, dropping emailOptIn so submissions posted the wrong contract; this restores the intended #435 camelCase payload and updates the stale ascent-x2 warranty SKU expectation to match current catalog data.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-pdp-integration-tests--vitamix--aemsites.aem.network/