### PR TITLE
fix(pdp): support coming-soon variants

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -80,11 +80,11 @@ function toggleFixedAddToCart(container) {
  * @returns {boolean} True if the variant is available for sale, false otherwise
  */
 export function isVariantAvailableForSale(variant) {
-  const { managedStock, addToCart } = variant?.custom || {};
+  const { managedStock, addToCart, comingSoon } = variant?.custom || {};
 
   // Authored `addToCart` override wins over the product bus custom.addToCart.
   const effectiveAddToCart = getPdpOverride('addToCart') || addToCart;
-  if (!variant || effectiveAddToCart === 'No') {
+  if (!variant || effectiveAddToCart === 'No' || comingSoon === 'Yes') {
     return false;
   }
 
@@ -119,6 +119,14 @@ export default function renderAddToCart(ph, block, parent) {
   const findDealer = getPdpOverride('findDealer') || parent.custom.findDealer;
   block.classList.remove('pdp-find-locally');
   block.classList.remove('pdp-find-dealer');
+
+  // Coming-soon products cannot be added to cart or redirected to a local seller.
+  // Keep an empty container so variant changes can restore the appropriate CTA.
+  if (parent.custom.comingSoon === 'Yes' || selectedVariant?.custom?.comingSoon === 'Yes') {
+    const emptyContainer = document.createElement('div');
+    emptyContainer.classList.add('add-to-cart');
+    return emptyContainer;
+  }
 
   // Figure out if the selected variant is available for sale
   const isAvailableForSale = isVariantAvailableForSale(selectedVariant);

--- a/blocks/pdp/alert.js
+++ b/blocks/pdp/alert.js
@@ -1,0 +1,68 @@
+import { getOfferPricing } from '../../scripts/scripts.js';
+
+/**
+ * Renders the PDP status or promotional alert.
+ * @param {Object} ph - Placeholders object
+ * @param {HTMLElement} block - PDP block element
+ * @param {Object} custom - Parent product custom data
+ * @param {Object} variantCustom - Selected variant custom data
+ * @returns {HTMLElement|null} Alert element, or null when no alert applies
+ */
+export function renderAlert(ph, block, custom, variantCustom) {
+  const alertContainer = document.createElement('div');
+  alertContainer.classList.add('pdp-alert');
+  block.classList.remove('pdp-coming-soon');
+
+  if (custom && custom.retired === 'Yes') {
+    alertContainer.innerText = ph.retiredProduct || 'Retired Product';
+    block.classList.add('pdp-retired');
+    block.dataset.alert = true;
+    return alertContainer;
+  }
+
+  if (custom?.comingSoon === 'Yes' || variantCustom?.comingSoon === 'Yes') {
+    alertContainer.innerText = ph.comingSoon || 'Coming Soon';
+    block.classList.add('pdp-coming-soon');
+    block.dataset.alert = true;
+    return alertContainer;
+  }
+
+  const { promoButton } = custom;
+  if (promoButton) {
+    alertContainer.classList.add('pdp-promo-alert');
+    alertContainer.innerText = promoButton;
+    block.dataset.alert = true;
+    return alertContainer;
+  }
+
+  const pricing = getOfferPricing(window.jsonLdData?.offers?.[0]);
+  if (pricing && pricing.regular && pricing.regular > pricing.final) {
+    alertContainer.classList.add('pdp-promo-alert');
+    alertContainer.innerText = ph.saveNow || 'Save Now!';
+    block.dataset.alert = true;
+    return alertContainer;
+  }
+
+  block.dataset.alert = false;
+  return null;
+}
+
+/**
+ * Refreshes the PDP alert after a variant selection changes.
+ * @param {Object} ph - Placeholders object
+ * @param {HTMLElement} block - PDP block element
+ * @param {Object} custom - Parent product custom data
+ * @param {Object} variantCustom - Selected variant custom data
+ */
+export function updateAlert(ph, block, custom, variantCustom) {
+  const currentAlert = block.querySelector('.pdp-alert');
+  const alertContainer = renderAlert(ph, block, custom, variantCustom);
+
+  if (currentAlert && alertContainer) {
+    currentAlert.replaceWith(alertContainer);
+  } else if (currentAlert) {
+    currentAlert.remove();
+  } else if (alertContainer) {
+    block.prepend(alertContainer);
+  }
+}

--- a/blocks/pdp/options.js
+++ b/blocks/pdp/options.js
@@ -3,6 +3,7 @@ import { rebuildIndices, checkVariantOutOfStock, formatPrice } from '../../scrip
 import { toClassName } from '../../scripts/aem.js';
 import renderPricing from './pricing.js';
 import renderAddToCart from './add-to-cart.js';
+import { updateAlert } from './alert.js';
 
 /**
  * Updates the OOS message text based on whether parent or variant is out of stock.
@@ -133,6 +134,8 @@ export function onOptionChange(ph, block, variants, color, isParentOutOfStock = 
   buildThumbnails(gallery);
 
   window.selectedVariant = variant;
+
+  updateAlert(ph, block, window.jsonLdData.custom, variant.custom);
 
   // update add to cart
   const addToCartContainer = renderAddToCart(ph, block, window.jsonLdData);

--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -5,10 +5,10 @@ import renderAddToCart from './add-to-cart.js';
 import renderGallery from './gallery.js';
 import renderSpecs from './specification-tabs.js';
 import renderPricing from './pricing.js';
+import { renderAlert } from './alert.js';
 // eslint-disable-next-line import/no-cycle
 import { renderOptions, onOptionChange, updateFreeGiftVisibility } from './options.js';
 import {
-  getOfferPricing,
   checkVariantOutOfStock,
   isProductOutOfStock,
   parseEasternDateTime,
@@ -167,36 +167,6 @@ function renderFreeShipping(ph, offers) {
   return freeShippingContainer;
 }
 
-function renderAlert(ph, block, custom) {
-  const alertContainer = document.createElement('div');
-  alertContainer.classList.add('pdp-alert');
-
-  /* retired and coming soon */
-  if (custom && custom.retired === 'Yes') {
-    alertContainer.innerText = ph.retiredProduct || 'Retired Product';
-    block.classList.add('pdp-retired');
-    return alertContainer;
-  }
-  /* promos */
-  const { promoButton } = custom;
-  if (promoButton) {
-    alertContainer.classList.add('pdp-promo-alert');
-    alertContainer.innerText = promoButton;
-    return alertContainer;
-  }
-
-  /* save now */
-  const pricing = getOfferPricing(window.jsonLdData?.offers?.[0]);
-  if (pricing && pricing.regular && pricing.regular > pricing.final) {
-    alertContainer.classList.add('pdp-promo-alert');
-    alertContainer.innerText = ph.saveNow || 'Save Now!';
-    return alertContainer;
-  }
-
-  block.dataset.alert = false;
-  return null;
-}
-
 function renderRelatedProducts(ph, custom) {
   const { relatedSkus } = custom;
   const relatedProducts = relatedSkus || [];
@@ -343,7 +313,7 @@ export default async function decorate(block) {
   const reviewsId = custom.reviewsId || toClassName(getMetadata('sku')).replace(/-/g, '');
   const galleryContainer = renderGallery(block, variants);
   const titleContainer = renderTitle(block, custom, reviewsId);
-  const alertContainer = renderAlert(ph, block, custom);
+  const alertContainer = renderAlert(ph, block, custom, variants[0]?.custom);
   const relatedProductsContainer = renderRelatedProducts(ph, custom);
 
   const buyBox = document.createElement('div');

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -267,6 +267,40 @@ test.describe('PDP Integration Tests', () => {
         console.log('ℹ No variant options found for this product');
       }
     });
+
+    test('coming-soon variant should show alert and suppress purchase CTAs', async ({ page }) => {
+      const productUrl = buildProductUrl(productPath, currentBranch);
+      await page.goto(productUrl);
+      await page.waitForSelector('.pdp-color-options .color-swatch');
+
+      await page.evaluate(() => {
+        window.jsonLdData.custom.comingSoon = 'No';
+        window.variants.forEach((variant) => {
+          variant.custom.comingSoon = 'No';
+        });
+        window.jsonLdData.offers.forEach((offer) => {
+          offer.custom.comingSoon = 'No';
+        });
+
+        window.variants[1].custom.comingSoon = 'Yes';
+        const offer = window.jsonLdData.offers
+          .find(({ sku }) => sku === window.variants[1].sku);
+        offer.custom.comingSoon = 'Yes';
+      });
+
+      const variantOptions = page.locator('.pdp-color-options .color-swatch');
+      await variantOptions.nth(1).click();
+
+      await expect(page.locator('.pdp-alert')).toHaveText(/coming soon/i);
+      await expect(page.locator('.pdp')).toHaveClass(/pdp-coming-soon/);
+      await expect(page.locator('.quantity-container button')).toHaveCount(0);
+      await expect(page.locator('.pdp-find-locally-button')).toHaveCount(0);
+
+      await variantOptions.nth(0).click();
+
+      await expect(page.locator('.pdp')).not.toHaveClass(/pdp-coming-soon/);
+      await expect(page.locator('.quantity-container button')).toBeVisible();
+    });
   });
 
   test.describe('Bundle Product Page', () => {


### PR DESCRIPTION
Refresh the PDP alert when variants change and suppress purchase and local-dealer actions for products that are not yet available.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
- After: https://coming-soon--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2