### PR TITLE
fix(cart-summary): hide remove action without coupon

### DIFF
--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -377,6 +377,10 @@ dialog.paypal-not-configured-dialog::backdrop {
   font-size: var(--commerce-font-size-sm);
 }
 
+.cart-summary-discount-row[hidden] {
+  display: none;
+}
+
 .cart-summary-shipping {
   color: var(--commerce-color-text-muted);
   font-style: italic;

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -27,6 +27,29 @@ async function getCart(page, key = CART_KEY_US) {
   return raw ? JSON.parse(raw) : null;
 }
 
+/**
+ * Seeds a visible item and optional coupon before the cart page initializes.
+ * @param {import('@playwright/test').Page} page Playwright page
+ * @param {string} couponCode Coupon code to restore, or an empty string
+ */
+async function seedCartSummary(page, couponCode = '') {
+  await page.addInitScript(({ cartKey, code }) => {
+    localStorage.setItem(cartKey, JSON.stringify({
+      version: 1,
+      items: [{
+        sku: 'summary-test-sku',
+        quantity: 1,
+        price: '549.99',
+        name: 'Summary Test Product',
+        path: '/us/en_us/products/ascent-x2',
+      }],
+    }));
+    sessionStorage.removeItem('checkout_coupon_code');
+    sessionStorage.removeItem('checkout_coupon_source');
+    if (code) sessionStorage.setItem('checkout_coupon_code', code);
+  }, { cartKey: CART_KEY_US, code: couponCode });
+}
+
 // Header cart link locator: the cart icon's parent <a>. Stable across
 // edge/Magento modes (href changes but the icon-cart child does not).
 const CART_LINK_SELECTOR = 'header a:has(.icon-cart)';
@@ -671,6 +694,46 @@ test.describe('Edge Checkout', () => {
       const cart = await getCart(page);
       expect(cart.items[0].local?.availableWarranties).toBeUndefined();
       console.log('✓ No availableWarranties stored for product without warranty options');
+    });
+  });
+
+  // ─── Cart summary coupon row ──────────────────────────────────────────────────
+
+  test.describe('Cart Summary Coupon Row @desktop', () => {
+    const cartPath = '/us/en_us/order/cart';
+
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('hides the coupon row when no coupon is applied', async ({ page }) => {
+      await seedCartSummary(page);
+      await page.goto(buildProductUrl(cartPath, currentBranch, { cart: 'edge' }));
+
+      const discountRow = page.locator('.cart-summary-discount-row');
+      await expect(page.locator('.cart-summary-content')).toBeVisible({ timeout: 30000 });
+      await expect(discountRow).toBeHidden();
+      await expect(discountRow.locator('.discount-remove')).toBeHidden();
+      console.log('✓ Coupon row is hidden without an applied coupon');
+    });
+
+    test('shows the remove action when a coupon is applied', async ({ page }) => {
+      await seedCartSummary(page, 'SAVE10');
+      await page.route('**/estimate/price', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          subtotal: 549.99,
+          discounts: [{ source: 'coupon', name: 'SAVE10', amount: 10 }],
+          orderDiscountTotal: 10,
+        }),
+      }));
+      await page.goto(buildProductUrl(cartPath, currentBranch, { cart: 'edge' }));
+
+      const discountRow = page.locator('.cart-summary-discount-row');
+      await expect(discountRow).toBeVisible({ timeout: 30000 });
+      await expect(discountRow.locator('.cart-summary-discount-label')).toContainText('SAVE10');
+      await discountRow.hover();
+      await expect(discountRow.locator('.discount-remove')).toBeVisible();
+      console.log('✓ Coupon row includes its remove action for an applied coupon');
     });
   });
 

--- a/tests/unit/mocks/scripts.mjs
+++ b/tests/unit/mocks/scripts.mjs
@@ -1,9 +1,11 @@
+import { getMetadata } from './aem.mjs';
+
 /**
  * Minimal mock of scripts/scripts.js for unit tests.
  *
  * The real module bootstraps the page at import time, which crashes outside
  * a browser. Tests currently import modules that need `checkVariantOutOfStock`,
- * `getLocaleAndLanguage`, and `loggedFetch` from this module.
+ * `getLocaleAndLanguage`, `getPdpOverride`, and `loggedFetch` from this module.
  */
 
 let outOfStockSkus = new Set();
@@ -24,6 +26,11 @@ export function __resetScripts() {
 
 export function checkVariantOutOfStock(sku) {
   return outOfStockSkus.has(sku);
+}
+
+/** Returns the authored PDP override from mocked page metadata. */
+export function getPdpOverride(name) {
+  return getMetadata(name);
 }
 
 /**


### PR DESCRIPTION
Fixes #667

Keep the coupon row out of the rendered summary until coupon state exists so an inactive remove action cannot appear beneath the subtotal. The coupon input remains visible, and the discount row and remove action appear after a valid coupon is applied.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/ca/en_us/order/cart?cart=edge&martech=off
- After: https://issue-667-cross-should-not-show-in-order-summary-und--vitamix--aemsites.aem.network/ca/en_us/order/cart?cart=edge&martech=off

Validation:
- `npm run lint`
- `npm test` (283 unit tests and 215 Playwright tests)
- Local AEM browser validation on the CA cart page with and without coupon state