### PR TITLE
fix(checkout): spinner on coupon apply and always-visible remove action

### DIFF
--- a/blocks/cart-summary/cart-summary.css
+++ b/blocks/cart-summary/cart-summary.css
@@ -344,6 +344,26 @@ dialog.paypal-not-configured-dialog::backdrop {
   background: var(--commerce-color-text);
 }
 
+.cart-summary .discount-apply.loading {
+  color: transparent;
+  position: relative;
+  pointer-events: none;
+}
+
+.cart-summary .discount-apply.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border: 2px solid rgba(255 255 255 / 40%);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: cart-summary-spin 0.7s linear infinite;
+}
+
 /* ID.me verification */
 .cart-summary .idme-verify {
   margin-bottom: var(--commerce-card-padding);
@@ -434,22 +454,11 @@ dialog.paypal-not-configured-dialog::backdrop {
   font-size: 16px;
   color: var(--commerce-color-text-muted);
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s ease, color 0.15s ease;
-}
-
-.cart-summary-discount-row:hover .discount-remove {
-  opacity: 1;
+  transition: color 0.15s ease;
 }
 
 .cart-summary-discount-row .discount-remove:hover {
   color: var(--commerce-color-error);
-}
-
-@media (width <= 999px) {
-  .cart-summary-discount-row .discount-remove {
-    opacity: 1;
-  }
 }
 
 /* Coupon error — lives inside .cart-summary-discount, wraps to its own row */

--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -314,6 +314,7 @@ export default async function decorate(block) {
     }
 
     discountApply.disabled = true;
+    discountApply.classList.add('loading');
     try {
       const country = config.getLocale();
       const estimate = await estimatePrice(country, cart.getItemsForAPI(), code);
@@ -332,6 +333,7 @@ export default async function decorate(block) {
       couponErrorEl.hidden = false;
     } finally {
       discountApply.disabled = false;
+      discountApply.classList.remove('loading');
     }
   });
 

--- a/blocks/order-summary/order-summary.css
+++ b/blocks/order-summary/order-summary.css
@@ -231,6 +231,26 @@
   background: var(--commerce-color-text);
 }
 
+.discount-apply.loading {
+  color: transparent;
+  position: relative;
+  pointer-events: none;
+}
+
+.discount-apply.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  border: 2px solid rgba(255 255 255 / 40%);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: order-summary-spin 0.7s linear infinite;
+}
+
 /* ID.me verification */
 .idme-verify {
   margin-bottom: var(--commerce-card-padding);
@@ -299,22 +319,11 @@
   font-size: 16px;
   color: var(--commerce-color-text-muted);
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s ease, color 0.15s ease;
-}
-
-.order-summary-discount-item:hover .discount-remove {
-  opacity: 1;
+  transition: color 0.15s ease;
 }
 
 .order-summary-discount-item .discount-remove:hover {
   color: var(--commerce-color-error);
-}
-
-@media (width <= 999px) {
-  .order-summary-discount-item .discount-remove {
-    opacity: 1;
-  }
 }
 
 /* Coupon error — lives inside .order-summary-discount, wraps to its own row */

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -388,6 +388,7 @@ export default async function decorate(block) {
     }
 
     discountApply.disabled = true;
+    discountApply.classList.add('loading');
     try {
       const country = getLocaleAndLanguage().locale;
       const estimate = await estimatePrice(country, cart.getItemsForAPI(), code);
@@ -400,6 +401,7 @@ export default async function decorate(block) {
       couponErrorEl.hidden = false;
     } finally {
       discountApply.disabled = false;
+      discountApply.classList.remove('loading');
     }
   });
 


### PR DESCRIPTION
Show an inline spinner on the Apply button while the coupon estimate request is in flight, and make the coupon remove × always visible instead of hover-only. Both changes apply to cart-summary and order-summary blocks.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/
- After: https://coupon-ux-polish--vitamix--aemsites.aem.network/