### PR TITLE
fix(checkout): use deterministic locale in commerce formatPrice

### DIFF
--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -130,12 +130,23 @@ const defaults = {
 
 /**
  * Formats a numeric amount as a localized currency string.
+ *
+ * 1. Resolve the store language from the URL path (e.g. 'en_us', 'fr_ca')
+ * 2. Convert to a BCP 47 locale tag (e.g. 'en-US', 'fr-CA')
+ * 3. Format with Intl.NumberFormat using that deterministic locale
+ *
+ * Using a store-derived locale instead of the browser default ensures
+ * consistent currency symbol rendering ('$399.95') regardless of the
+ * visitor's OS/browser language settings.
+ *
  * @param {number} amount
  * @param {string} currencyCode - ISO 4217 code, e.g. 'USD', 'CAD'
  * @returns {string}
  */
 export function formatPrice(amount, currencyCode) {
-  return new Intl.NumberFormat(undefined, {
+  const lang = defaults.getLanguage();
+  const locale = lang.replace('_', '-').replace(/-([a-z]{2})$/, (_, r) => `-${r.toUpperCase()}`);
+  return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency: currencyCode || 'USD',
   }).format(amount);

--- a/tests/unit/mocks/commerce-config.mjs
+++ b/tests/unit/mocks/commerce-config.mjs
@@ -19,7 +19,10 @@ export function __resetConfig() {
 }
 
 export function formatPrice(value, currency = 'USD') {
-  return `${currency} ${Number(value).toFixed(2)}`;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(value);
 }
 
 export function getConfig() {


### PR DESCRIPTION
Fixes #688

The formatPrice helper in commerce-config.js passed `undefined` as the Intl.NumberFormat locale, causing the browser's default locale to control currency symbol rendering. Different browsers, locales, or browsing modes (incognito vs normal) could produce inconsistent formatting — '$549.95' vs 'US$549.95' vs '549,95 $US'. This made the currency symbol appear to be missing for some users while present for others. Derive the locale from the store's language setting instead, matching the pattern already used by the formatPrice in scripts.js.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://issue-688-checkout-currency-symbol-is-showin--vitamix--aemsites.aem.network/