### PR TITLE
feat(pdp): open image modal when clicking gallery images

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -320,6 +320,39 @@ body.modal-open {
 
 /* stylelint-disable no-descending-specificity */
 
+/* gallery image modal */
+.modal#gallery-image dialog {
+  max-width: 1200px;
+  width: 90vw;
+  background-color: transparent;
+  border: none;
+}
+
+.modal#gallery-image dialog .modal-content {
+  background-color: transparent;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal#gallery-image dialog .modal-content picture {
+  display: block;
+  width: 100%;
+  line-height: 0;
+}
+
+.modal#gallery-image dialog .modal-content picture img {
+  width: 100%;
+  height: auto;
+  max-height: 85vh;
+  object-fit: contain;
+}
+
+.modal#gallery-image .close-button {
+  z-index: 1;
+}
+
 /* foundation modals */
 .modal[data-modal-path*="/modals/foundation/"] dialog .modal-content {
   border-radius: var(--rounding-m);

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -322,35 +322,51 @@ body.modal-open {
 
 /* gallery image modal */
 .modal#gallery-image dialog {
-  max-width: 1200px;
-  width: 90vw;
+  max-width: fit-content;
+  width: auto;
+  max-height: none;
   background-color: transparent;
   border: none;
+  overflow: visible;
 }
 
 .modal#gallery-image dialog .modal-content {
   background-color: transparent;
+  overflow: visible;
+  max-height: none;
+  margin-top: 0;
   padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  line-height: 0;
 }
 
 .modal#gallery-image dialog .modal-content picture {
   display: block;
-  width: 100%;
-  line-height: 0;
 }
 
 .modal#gallery-image dialog .modal-content picture img {
-  width: 100%;
+  display: block;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100dvh - 48px);
+  width: auto;
   height: auto;
-  max-height: 85vh;
   object-fit: contain;
+}
+
+@media (width >= 900px) {
+  .modal#gallery-image dialog .modal-content {
+    padding: 0;
+  }
+
+  .modal#gallery-image dialog .modal-content picture img {
+    max-width: calc(100vw - 96px);
+    max-height: calc(100dvh - 96px);
+  }
 }
 
 .modal#gallery-image .close-button {
   z-index: 1;
+  top: -44px;
+  right: -44px;
 }
 
 /* foundation modals */

--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -17,8 +17,10 @@
   justify-content: center;
 }
 
-.gallery.carousel > ul > li.zoomable {
-  cursor: pointer;
+@media (width >= 900px) {
+  .gallery.carousel > ul > li.zoomable {
+    cursor: pointer;
+  }
 }
 
 .gallery.carousel > ul > li picture {

--- a/blocks/pdp/gallery.css
+++ b/blocks/pdp/gallery.css
@@ -17,6 +17,10 @@
   justify-content: center;
 }
 
+.gallery.carousel > ul > li.zoomable {
+  cursor: pointer;
+}
+
 .gallery.carousel > ul > li picture {
   width: 100%;
 }

--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -1,6 +1,7 @@
 import { buildCarousel } from '../../scripts/scripts.js';
 import { getMetadata } from '../../scripts/aem.js';
 import { embedYoutube } from '../video/video.js';
+import { createModal } from '../modal/modal.js';
 
 /**
  * Checks if a link is a YouTube video.
@@ -146,6 +147,27 @@ export default function renderGallery(block, variants) {
 
   const carousel = buildCarousel(gallery);
   buildThumbnails(carousel);
+
+  // Add click-to-zoom on non-video slides
+  carousel.querySelectorAll(':scope > ul > li').forEach((li) => {
+    const pic = li.querySelector('picture');
+    if (!pic || li.querySelector('a.video-wrapper')) return;
+    li.classList.add('zoomable');
+    li.addEventListener('click', async () => {
+      const img = pic.querySelector('img');
+      if (!img) return;
+      const modalPicture = pic.cloneNode(true);
+      const modalImg = modalPicture.querySelector('img');
+      modalImg.removeAttribute('width');
+      modalImg.removeAttribute('height');
+      modalImg.removeAttribute('loading');
+      const { showModal } = await createModal(
+        [modalPicture],
+        '/modals/gallery-image',
+      );
+      showModal();
+    });
+  });
 
   return carousel;
 }

--- a/blocks/pdp/gallery.js
+++ b/blocks/pdp/gallery.js
@@ -148,12 +148,14 @@ export default function renderGallery(block, variants) {
   const carousel = buildCarousel(gallery);
   buildThumbnails(carousel);
 
-  // Add click-to-zoom on non-video slides
+  // Add click-to-zoom on non-video slides (desktop only)
+  const desktopQuery = window.matchMedia('(min-width: 900px)');
   carousel.querySelectorAll(':scope > ul > li').forEach((li) => {
     const pic = li.querySelector('picture');
     if (!pic || li.querySelector('a.video-wrapper')) return;
     li.classList.add('zoomable');
     li.addEventListener('click', async () => {
+      if (!desktopQuery.matches) return;
       const img = pic.querySelector('img');
       if (!img) return;
       const modalPicture = pic.cloneNode(true);


### PR DESCRIPTION
Fixes #155

Clicking a product image in the PDP gallery now opens a full-size modal view. Video slides are excluded since they have their own click behavior. The modal reuses the existing createModal infrastructure for consistent close-button and backdrop-click dismissal. The modal and pointer cursor are limited to desktop viewports (≥900px) since gallery images are already near full-width on mobile.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
- After: https://issue-155-pdp-clicking-on-an-image-should-di--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2