### PR TITLE
fix(checkout): remove duplicate currency on total row

### DIFF
--- a/blocks/cart-summary/cart-summary.js
+++ b/blocks/cart-summary/cart-summary.js
@@ -1,5 +1,5 @@
 import { loadCSS } from '../../scripts/aem.js';
-import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
+import { getConfig, formatPrice, formatPriceAmount } from '../../scripts/commerce-config.js';
 import cart from '../../scripts/cart.js';
 import {
   previewOrder, createOrder, initiatePayment, estimatePrice,
@@ -215,9 +215,9 @@ export default async function decorate(block) {
 
   // 3. Bind cart:change to keep totals in sync
   const updateTotals = () => {
-    const formatted = formatPrice(cart.subtotal, getCurrencyCode());
-    subtotalEl.textContent = formatted;
-    grandTotalEl.textContent = formatted;
+    const currency = getCurrencyCode();
+    subtotalEl.textContent = formatPrice(cart.subtotal, currency);
+    grandTotalEl.textContent = formatPriceAmount(cart.subtotal, currency);
   };
   updateTotals();
   document.addEventListener('cart:change', updateTotals);
@@ -237,7 +237,7 @@ export default async function decorate(block) {
     const discountTotal = parseFloat(estimate.orderDiscountTotal) || 0;
     const total = Math.max(0, subtotal - discountTotal);
     subtotalEl.textContent = formatPrice(subtotal, currency);
-    grandTotalEl.textContent = formatPrice(total, currency);
+    grandTotalEl.textContent = formatPriceAmount(total, currency);
     showDiscountRow(couponCode, `-${formatPrice(discountTotal, currency)}`);
   };
 

--- a/blocks/order-summary/order-summary.js
+++ b/blocks/order-summary/order-summary.js
@@ -1,6 +1,6 @@
 import { loadCSS } from '../../scripts/aem.js';
 import cart from '../../scripts/cart.js';
-import { getConfig, formatPrice } from '../../scripts/commerce-config.js';
+import { getConfig, formatPrice, formatPriceAmount } from '../../scripts/commerce-config.js';
 import buildCartItem, { buildGiftItem } from '../../scripts/commerce/cart-item.js';
 import buildWarrantySelector from '../cart/warranty-selector.js';
 import { parsePreview, estimatePrice } from '../../scripts/commerce-api.js';
@@ -317,7 +317,7 @@ export default async function decorate(block) {
       shippingEl.textContent = shippingRate === 0 ? s.free : formatPrice(shippingRate, currency);
     }
     taxesEl.textContent = '--';
-    grandTotalEl.textContent = formatPrice(total, currency);
+    grandTotalEl.textContent = formatPriceAmount(total, currency);
     headerTotalEl.textContent = formatPrice(total, currency);
   };
 
@@ -545,7 +545,7 @@ export default async function decorate(block) {
       ? s.free
       : formatPrice(parseFloat(shippingRate), currency);
     taxesEl.textContent = formatPrice(taxAmount, currency);
-    grandTotalEl.textContent = formatPrice(total, currency);
+    grandTotalEl.textContent = formatPriceAmount(total, currency);
     headerTotalEl.textContent = formatPrice(total, currency);
   });
 

--- a/scripts/commerce-config.js
+++ b/scripts/commerce-config.js
@@ -152,6 +152,25 @@ export function formatPrice(amount, currencyCode) {
   }).format(amount);
 }
 
+/**
+ * Formats a numeric amount with currency-appropriate grouping and decimals
+ * but without the currency symbol. Used alongside a separate currency code
+ * label (e.g. the Total row: "USD $549.95" → "USD 549.95" with the symbol
+ * already provided by the label).
+ *
+ * @param {number} amount
+ * @returns {string}
+ */
+export function formatPriceAmount(amount) {
+  const lang = defaults.getLanguage();
+  const locale = lang.replace('_', '-').replace(/-([a-z]{2})$/, (_, r) => `-${r.toUpperCase()}`);
+  return new Intl.NumberFormat(locale, {
+    style: 'decimal',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
 export function getConfig() {
   const merged = { ...defaults, ...(window.CommerceConfig || {}) };
   merged.apiOrigin = resolveApiOrigin(merged.org, merged.site);

--- a/tests/unit/mocks/commerce-config.mjs
+++ b/tests/unit/mocks/commerce-config.mjs
@@ -25,6 +25,14 @@ export function formatPrice(value, currency = 'USD') {
   }).format(value);
 }
 
+export function formatPriceAmount(value) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 export function getConfig() {
   return {
     getLocale: () => 'us',


### PR DESCRIPTION
Fixes #688

The Total row in order-summary and cart-summary shows an explicit USD/CAD label via a separate span, but after the deterministic-locale fix (merged in #707) formatPrice also included the currency symbol in the formatted number — producing 'CAD CA$1,589.85'. Add a formatPriceAmount decimal-only formatter and use it for the grand total so the label and number don't double up.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://issue-688-checkout-currency-symbol-is-showin--vitamix--aemsites.aem.network/