### PR TITLE
fix(css): replace flexbox gap with margin-right on inputs for iOS Safari

### DIFF
--- a/blocks/cart/warranty-selector.css
+++ b/blocks/cart/warranty-selector.css
@@ -23,4 +23,5 @@
 
 .cart-item-warranty-option input[type="radio"] {
   margin: 0;
+  padding: 0;
 }

--- a/blocks/checkout/checkout.css
+++ b/blocks/checkout/checkout.css
@@ -186,6 +186,7 @@ main > .section:has(.checkout-wrapper) {
   width: 16px;
   height: 16px;
   margin: 0;
+  padding: 0;
   flex-shrink: 0;
   cursor: pointer;
 }
@@ -409,7 +410,7 @@ main > .section:has(.checkout-wrapper) {
 .billing-option-card {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: 10px;
   padding: 14px 16px;
   border: 1px solid var(--commerce-color-border);
   border-radius: var(--commerce-radius-card);
@@ -424,7 +425,8 @@ main > .section:has(.checkout-wrapper) {
 .billing-option-card input[type="radio"] {
   width: 18px;
   height: 18px;
-  margin: 2px 0 0;
+  margin: 0;
+  padding: 0;
   flex-shrink: 0;
   cursor: pointer;
   accent-color: var(--commerce-color-text);

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -639,6 +639,7 @@ a.button.pdp-find-locally-button {
   height: 24px;
   width: 24px;
   margin: 0;
+  padding: 0;
 }
 
 .pdp p + h1 {


### PR DESCRIPTION
Safari iOS renders extra spacing on radio/checkbox inputs when combined with the CSS gap property. Replace gap with margin-right on the input elements across PDP warranty options, cart warranty selector, checkout checkboxes, and billing option cards.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://css-changes--vitamix--aemsites.aem.network/