### PR TITLE
fix(checkout): proactively refresh expired estimate tokens before order creation

### DIFF
--- a/blocks/checkout/checkout-order.js
+++ b/blocks/checkout/checkout-order.js
@@ -15,6 +15,32 @@ import { getStandardCheckoutContext } from '../../scripts/checkout-context.js';
 export { validateLinkIntegrity };
 
 /**
+ * Minimum remaining lifetime (in ms) before an estimate token is considered
+ * "expiring soon" and should be proactively refreshed. 5 minutes gives enough
+ * headroom to complete the order-create + payment-initiate round-trips.
+ */
+const ESTIMATE_TOKEN_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * Decode a JWT's `exp` claim and return whether the token is expired or will
+ * expire within the buffer window. Returns `true` (needs refresh) when the
+ * token cannot be decoded.
+ *
+ * @param {string|null|undefined} token - JWT estimate token
+ * @param {number} [bufferMs] - refresh when fewer than this many ms remain
+ * @returns {boolean}
+ */
+export function isEstimateExpiringSoon(token, bufferMs = ESTIMATE_TOKEN_BUFFER_MS) {
+  if (!token) return true;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return (payload.exp * 1000) - Date.now() < bufferMs;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Returns the explicitly selected checkout payment method, if any.
  * @param {HTMLFormElement} form
  * @returns {string|null}
@@ -203,6 +229,17 @@ export function initOrder(form, cart, state, config, strings) {
         console.error(integrity.error);
         throw new Error(integrity.error);
       }
+
+      // Proactively refresh the estimate token if it is expired or about to
+      // expire (e.g. the customer idled on the checkout page). Re-calling
+      // preview is invisible to the user; if totals changed we surface the
+      // updated amounts via the returned preview state.
+      if (isEstimateExpiringSoon(orderBody.estimateToken)) {
+        const refreshed = await callbacks.previewOrderDirect(orderBody);
+        // eslint-disable-next-line no-param-reassign
+        orderBody.estimateToken = refreshed.estimateToken;
+      }
+
       const result = await createOrder(orderBody);
       subscribeNewsletter(new FormData(form));
       return result;
@@ -315,7 +352,8 @@ export function initOrder(form, cart, state, config, strings) {
         return;
       }
 
-      if (!state.currentEstimateToken) {
+      if (!state.currentEstimateToken
+        || isEstimateExpiringSoon(state.currentEstimateToken)) {
         await callbacks.updatePreview();
         if (!state.currentEstimateToken) {
           showError(form, strings.errorCalculateTotals);

--- a/scripts/payments/affirm.js
+++ b/scripts/payments/affirm.js
@@ -26,8 +26,10 @@ export default {
       callbacks.clearError();
       btn.disabled = true;
 
+      const { isEstimateExpiringSoon } = await import('../../blocks/checkout/checkout-order.js');
       const state = callbacks.getState();
-      if (!state.currentEstimateToken) {
+      if (!state.currentEstimateToken
+        || isEstimateExpiringSoon(state.currentEstimateToken)) {
         await callbacks.updatePreview();
         if (!callbacks.getState().currentEstimateToken) {
           callbacks.showError('Unable to calculate totals. Please try again.');

--- a/scripts/payments/paypal-context.js
+++ b/scripts/payments/paypal-context.js
@@ -1,4 +1,5 @@
 import { getExpressCheckoutContext } from '../checkout-context.js';
+import { isEstimateExpiringSoon } from '../../blocks/checkout/checkout-order.js';
 
 /**
  * Builds PayPal express context for the page where the button is rendered.
@@ -28,7 +29,8 @@ export function withPayPalExpressContext(payload, entryPoint) {
  * @returns {Promise<boolean>}
  */
 export default async function ensureCheckoutPreviewToken(callbacks) {
-  if (callbacks.getState().currentEstimateToken) return true;
+  const { currentEstimateToken } = callbacks.getState();
+  if (currentEstimateToken && !isEstimateExpiringSoon(currentEstimateToken)) return true;
   await callbacks.updatePreview();
   return Boolean(callbacks.getState().currentEstimateToken);
 }

--- a/tests/unit/estimate-token-expiry.test.js
+++ b/tests/unit/estimate-token-expiry.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isEstimateExpiringSoon } from '../../blocks/checkout/checkout-order.js';
+
+/**
+ * Build a minimal JWT with the given `exp` (seconds since epoch).
+ * The signature is irrelevant — only the payload is decoded client-side.
+ */
+function fakeJwt(exp) {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.fake-sig`;
+}
+
+test('isEstimateExpiringSoon returns true for null/undefined tokens', () => {
+  assert.equal(isEstimateExpiringSoon(null), true);
+  assert.equal(isEstimateExpiringSoon(undefined), true);
+  assert.equal(isEstimateExpiringSoon(''), true);
+});
+
+test('isEstimateExpiringSoon returns true for malformed tokens', () => {
+  assert.equal(isEstimateExpiringSoon('not-a-jwt'), true);
+  assert.equal(isEstimateExpiringSoon('a.b.c'), true);
+});
+
+test('isEstimateExpiringSoon returns true for an already-expired token', () => {
+  const expired = fakeJwt(Math.floor(Date.now() / 1000) - 60);
+  assert.equal(isEstimateExpiringSoon(expired), true);
+});
+
+test('isEstimateExpiringSoon returns true when token expires within the buffer', () => {
+  // Expires in 2 minutes — inside the default 5-minute buffer
+  const soonToken = fakeJwt(Math.floor(Date.now() / 1000) + 120);
+  assert.equal(isEstimateExpiringSoon(soonToken), true);
+});
+
+test('isEstimateExpiringSoon returns false when token has plenty of time left', () => {
+  // Expires in 1 hour — well outside the 5-minute buffer
+  const freshToken = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+  assert.equal(isEstimateExpiringSoon(freshToken), false);
+});
+
+test('isEstimateExpiringSoon respects a custom buffer', () => {
+  // Expires in 10 minutes
+  const token = fakeJwt(Math.floor(Date.now() / 1000) + 600);
+  // With a 15-minute buffer → expiring soon
+  assert.equal(isEstimateExpiringSoon(token, 15 * 60 * 1000), true);
+  // With a 5-minute buffer → not expiring soon
+  assert.equal(isEstimateExpiringSoon(token, 5 * 60 * 1000), false);
+});

--- a/tests/unit/paypal-checkout-preview.test.js
+++ b/tests/unit/paypal-checkout-preview.test.js
@@ -25,6 +25,16 @@ test('withPayPalExpressContext adds authoritative context to payloads', () => {
   });
 });
 
+/**
+ * Build a minimal JWT with the given `exp` (seconds since epoch).
+ * The signature is irrelevant — only the payload is decoded client-side.
+ */
+function fakeJwt(exp) {
+  const header = btoa(JSON.stringify({ alg: 'HS256' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.fake-sig`;
+}
+
 function callbacksForState(state) {
   let updatePreviewCalls = 0;
   return {
@@ -40,12 +50,14 @@ function callbacksForState(state) {
 }
 
 test('ensureCheckoutPreviewToken reuses an existing PayPal checkout estimate token', async () => {
-  const state = { currentEstimateToken: 'existing-token' };
+  // Token that expires 1 hour from now — well within the buffer.
+  const validToken = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+  const state = { currentEstimateToken: validToken };
   const { callbacks, getUpdatePreviewCalls } = callbacksForState(state);
 
   assert.equal(await ensureCheckoutPreviewToken(callbacks), true);
   assert.equal(getUpdatePreviewCalls(), 0);
-  assert.equal(state.currentEstimateToken, 'existing-token');
+  assert.equal(state.currentEstimateToken, validToken);
 });
 
 test('ensureCheckoutPreviewToken creates a PayPal checkout estimate token when missing', async () => {


### PR DESCRIPTION
Decode the JWT exp claim client-side and re-call /orders/preview when the estimate token is expired or within 5 minutes of expiring. Covers all payment flows (Chase, PayPal, Apple Pay, Affirm) so idle customers no longer hit ESTIMATE_TOKEN_EXPIRED errors at checkout.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-refresh-expired-estimate-token--vitamix--aemsites.aem.network/