### PR TITLE
feat(checkout): display error on ID.me redirect with idme_error param

### DIFF
--- a/blocks/checkout/checkout.js
+++ b/blocks/checkout/checkout.js
@@ -16,6 +16,7 @@ import { initOrder } from './checkout-order.js';
 import { initPayment } from './checkout-payment.js';
 import { parsePreview } from '../../scripts/commerce-api.js';
 import { ensurePriceRulesLoaded, evaluateGWP } from '../../scripts/gift-with-purchase.js';
+import { handleIDMeError } from '../../scripts/commerce/idme.js';
 import { validateField } from './checkout-validation.js';
 import { formStateKey, saveFormState, restoreFormState } from './checkout-session-state.js';
 import { logOperation, getCheckoutId } from '../../scripts/operations-log.js';
@@ -78,6 +79,7 @@ const LOCAL_STRINGS = {
     errorCalculateTotals: 'Unable to calculate totals. Please try again.',
     errorRecaptcha: 'Security verification failed. Please refresh the page and try again.',
     errorGeneric: 'An error occurred. Please try again.',
+    errorIdMe: 'ID.me verification failed. Please try again.',
     processing: 'Processing…',
     addressEyebrow: 'Address verification',
     addressHeading: 'We found a more accurate version',
@@ -151,6 +153,7 @@ const LOCAL_STRINGS = {
     errorCalculateTotals: 'Impossible de calculer les totaux. Veuillez réessayer.',
     errorRecaptcha: 'Échec de la vérification de sécurité. Veuillez actualiser la page et réessayer.',
     errorGeneric: 'Une erreur est survenue. Veuillez réessayer.',
+    errorIdMe: 'La vérification ID.me a échoué. Veuillez réessayer.',
     processing: 'Traitement en cours…',
     addressEyebrow: "Vérification d'adresse",
     addressHeading: 'Nous avons trouvé une version plus précise',
@@ -194,6 +197,10 @@ export default async function decorate(block) {
   // and a visitor who newly qualifies needs the gift added so totals reflect
   // it. Fire-and-forget; the cart:change re-render path picks up the result.
   ensurePriceRulesLoaded({ reason: 'checkout-block-init' }).then(() => evaluateGWP());
+
+  // Read and clean any ID.me error param before the empty-cart guard so the
+  // query string is always tidied, even when the cart is empty.
+  const idmeError = handleIDMeError();
 
   // Empty cart guard
   if (cart.itemCount === 0) {
@@ -239,6 +246,15 @@ export default async function decorate(block) {
 
   // Build form
   const form = buildForm(block, config, strings);
+
+  // Surface ID.me errors carried back via ?idme_error= after redirect
+  if (idmeError) {
+    const errorEl = form.querySelector('.checkout-error');
+    if (errorEl) {
+      errorEl.textContent = strings.errorIdMe;
+      errorEl.hidden = false;
+    }
+  }
 
   // Seed and update order total amount + mobile breakdown
   const orderTotalAmountEl = form.querySelector('.order-total-amount');

--- a/scripts/commerce/idme.js
+++ b/scripts/commerce/idme.js
@@ -108,6 +108,22 @@ function watchIDMePopup(popupWindow) {
 }
 
 /**
+ * Reads ?idme_error= from the current URL. If present, removes it from
+ * the address bar and returns the error value so the caller can display
+ * a user-facing message. Returns null when the param is absent.
+ * @returns {string|null}
+ */
+export function handleIDMeError() {
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get('idme_error');
+  if (!error) return null;
+  params.delete('idme_error');
+  const qs = params.size ? `?${params}` : '';
+  window.history.replaceState(null, '', window.location.pathname + qs);
+  return error;
+}
+
+/**
  * Reads ?idme_coupon= from the current URL, stores it as an auto-applied
  * coupon, fires checkout:coupon-apply, and cleans the param from the address
  * bar. Returns the coupon code if found, otherwise null.

--- a/tests/unit/idme.test.js
+++ b/tests/unit/idme.test.js
@@ -224,4 +224,38 @@ describe('ID.me checkout integration', () => {
 
     assert.match(globalThis.window.location.href, /^https:\/\/groups\.id\.me\//);
   });
+
+  it('returns the idme_error value and cleans the URL', async () => {
+    setLocation(
+      'https://www.vitamix.com/us/en_us/order/checkout?idme_error=token_exchange_failed',
+    );
+    const { handleIDMeError } = await importIDMe();
+
+    assert.equal(handleIDMeError(), 'token_exchange_failed');
+    assert.equal(
+      globalThis.window.history.replaced,
+      '/us/en_us/order/checkout',
+    );
+  });
+
+  it('returns null when no idme_error param is present', async () => {
+    setLocation('https://www.vitamix.com/us/en_us/order/checkout');
+    const { handleIDMeError } = await importIDMe();
+
+    assert.equal(handleIDMeError(), null);
+    assert.equal(globalThis.window.history.replaced, null);
+  });
+
+  it('preserves other query params when cleaning idme_error', async () => {
+    setLocation(
+      'https://www.vitamix.com/us/en_us/order/checkout?foo=bar&idme_error=fail',
+    );
+    const { handleIDMeError } = await importIDMe();
+
+    assert.equal(handleIDMeError(), 'fail');
+    assert.equal(
+      globalThis.window.history.replaced,
+      '/us/en_us/order/checkout?foo=bar',
+    );
+  });
 });


### PR DESCRIPTION
Fixes #509

After ID.me authorization, the redirect back to checkout may carry an idme_error query param (e.g. token_exchange_failed) indicating verification failed. Read the param on page load, clean it from the URL, and show the localized error in the existing checkout error banner so users get clear feedback instead of a silent failure.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://issue-509-checkout-conditionally-display-err--vitamix--aemsites.aem.network/