### PR TITLE
fix(order-status): show user's order number and clearer unavailable label

### DIFF
--- a/widgets/forms/order-status-lookup.js
+++ b/widgets/forms/order-status-lookup.js
@@ -66,12 +66,14 @@ export async function performOrderStatusLookup(orderNumber) {
  * @param {Record<string, any>|null} result - Parsed API response
  * @param {Record<string, any>} copy - Localized order-status copy
  * @param {HTMLElement} container - Element to render into
+ * @param {string} [inputOrderNumber] - The order number the user typed,
+ *   used as a fallback when the API response does not include one
  */
-export function renderOrderStatusResult(result, copy, container) {
+export function renderOrderStatusResult(result, copy, container, inputOrderNumber) {
   const resultLabels = copy.result?.labels ?? {};
   const resultStatuses = copy.result?.statuses ?? {};
 
-  const orderNumber = result?.order?.key ?? '—';
+  const orderNumber = result?.order?.key ?? inputOrderNumber ?? '—';
   const statusKey = deriveOrderStatusKey(result);
   const orderStatus = resultStatuses[statusKey] ?? statusKey;
 

--- a/widgets/forms/order-status.js
+++ b/widgets/forms/order-status.js
@@ -46,7 +46,7 @@ export default async function decorate(widget) {
 
     try {
       const result = await performOrderStatusLookup(orderNumber);
-      renderOrderStatusResult(result, copy, resultEl);
+      renderOrderStatusResult(result, copy, resultEl, orderNumber);
       resultEl.hidden = false;
       resultEl.classList.add('order-status-result-visible');
     } catch (err) {

--- a/widgets/forms/order-status.json
+++ b/widgets/forms/order-status.json
@@ -19,7 +19,7 @@
         "partiallyShipped": "Partially Shipped",
         "shipped": "Order Shipped",
         "cancelled": "Order Cancelled",
-        "unavailable": "Status Unavailable"
+        "unavailable": "Order Status Unavailable"
       },
       "definitionsTitle": "What these statuses mean",
       "descriptions": {
@@ -52,7 +52,7 @@
         "partiallyShipped": "Partiellement expédiée",
         "shipped": "Commande expédiée",
         "cancelled": "Commande annulée",
-        "unavailable": "État indisponible"
+        "unavailable": "Statut de commande indisponible"
       },
       "definitionsTitle": "Signification de ces états",
       "descriptions": {
@@ -85,7 +85,7 @@
         "partiallyShipped": "Parcialmente enviado",
         "shipped": "Pedido enviado",
         "cancelled": "Pedido cancelado",
-        "unavailable": "Estado no disponible"
+        "unavailable": "Estado del pedido no disponible"
       },
       "definitionsTitle": "Qué significan estos estados",
       "descriptions": {


### PR DESCRIPTION
Fixes #612

When the API returns an error, the result now displays the order number the user entered instead of a dash. The unavailable status label is changed from "Status Unavailable" to "Order Status Unavailable" across all three languages.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/order-status
- After: https://issue-612-order-status-form-is-not-showing-t--vitamix--aemsites.aem.network/us/en_us/order-status