### PR TITLE
fix(checkout): prevent places autocomplete dropdown from getting stuck open

### DIFF
--- a/blocks/checkout/checkout-address.js
+++ b/blocks/checkout/checkout-address.js
@@ -1110,7 +1110,19 @@ function initPlacesAutocomplete(section, config) {
     }, 300);
   });
 
+  // Dismiss the dropdown when clicking anywhere outside the wrapper so
+  // the user does not have to blur the input to close the suggestion list.
+  document.addEventListener('mousedown', (e) => {
+    if (dropdown && !wrapper.contains(e.target)) {
+      clearTimeout(debounceTimer);
+      removeDropdown();
+    }
+  });
+
   addressInput.addEventListener('blur', () => {
+    // Cancel any pending autocomplete fetch so a late response cannot
+    // re-open the dropdown after the input has already lost focus.
+    clearTimeout(debounceTimer);
     setTimeout(removeDropdown, 200);
   });
 


### PR DESCRIPTION
Fixes #584

The autocomplete fetch is debounced at 300ms while the blur dismiss fires at 200ms. When a user clicks away before the fetch completes, blur runs first (no-op — dropdown doesn't exist yet) and the late fetch response then opens the dropdown with no further blur to close it. Clearing the debounce timer on blur prevents this race. A document-level mousedown listener provides an additional dismiss path when clicking outside the wrapper.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-places-autocomplete-dismiss--vitamix--aemsites.aem.network/