### PR TITLE
fix(pdp): fr_ca features section + new swatch colors

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -509,7 +509,7 @@ function parsePDPContentSections(sections) {
   sections.forEach((section) => {
     const h3 = section.querySelector('h3')?.textContent.toLowerCase();
     if (h3) {
-      if (h3.includes('features') || h3.includes('caractéristiques') || h3.includes('características')) {
+      if (h3.includes('features') || h3.includes('caractéristiques') || h3.includes('fonctionnalités') || h3.includes('características')) {
         window.features = section;
       } else if (h3.includes('specifications') || h3.includes('spécifications') || h3.includes('especificaciones')) {
         window.specifications = section;

--- a/styles/color-swatches.css
+++ b/styles/color-swatches.css
@@ -34,6 +34,7 @@
 
   /* reds */
   --color-red: #c03;
+  --color-very-berry: #921944;
   --color-candy-apple: #c00310;
   --color-candy-apple-red: #c00310;
   --color-ruby: #e01160;
@@ -47,9 +48,11 @@
 
   /* greens */
   --color-sour-apple-green: #e3edb5;
+  --color-emerald: #017864;
   --color-turquoise: #30d5c7;
 
   /* blues */
+  --color-willow-blue: #073a6f;
   --color-cobalt: #0047ab;
   --color-blue: #1131d4;
   --color-matte-navy: #00263e;


### PR DESCRIPTION
Two related PDP fixes for the French-Canadian storefront and new product variants:

- **Features section on fr_ca**: `parsePDPContentSections` only matched `Caractéristiques`, so pages whose heading was translated as `Fonctionnalités` dropped the features section. Both translate to "Features" in English, so we now match both.
- **New swatch colors**: new variants use colors (`willow-blue`, `emerald`, `very-berry`) that were not in the swatch map, so their swatches rendered with no fill. Added the `--color-*` hex definitions so `var(--color-<slug>)` resolves.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://fix-fr-features-fonctionnalites--vitamix--aemsites.aem.network/
