### PR TITLE
fix(pdp): keep source image paths on commercial PDPs

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1451,10 +1451,11 @@ async function loadEager(doc) {
   if (main) {
     decorateMain(main);
     /* adjust shop images to locale root path, util all of shop is mapped */
-    if (window.location.pathname.includes('/shop/')
+    if ((window.location.pathname.includes('/shop/')
       || window.location.pathname.includes('/foundation/')
       || window.location.pathname.includes('/commercial/')
-      || window.location.pathname.includes('/catalog/product_compare/')) {
+      || window.location.pathname.includes('/catalog/product_compare/'))
+      && !window.location.pathname.includes('/products/commercial/')) {
       const images = doc.querySelectorAll('img[src*="/media_"]');
       images.forEach((img) => {
         img.setAttribute('src', `/us/en_us/media_${img.getAttribute('src').split('/media_').pop()}`);


### PR DESCRIPTION
The eager image-path rewrite in `scripts.js` forced all `/media_` assets to `/us/en_us/media_` on any `/commercial/` page, which incorrectly rewrote commercial product detail page images (dropping the source path, e.g. the `/products/` segment). This excludes `/products/commercial/` so PDP images keep their source locale path, while shop, foundation, commercial-resource, and product-compare pages continue to rewrite as before.

Verified locally: on `/ca/en_us/products/commercial/quick-and-quiet` images now retain `/us/en_us/products/media_….jpg` instead of being mangled to `/us/en_us/media_….jpg`.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/ca/en_us/products/commercial/quick-and-quiet
- After: https://fix-commercial-pdp-image-path--vitamix--aemsites.aem.network/ca/en_us/products/commercial/quick-and-quiet