### PR TITLE
fix(cart): preserve commercial order type

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -120,6 +120,23 @@ export function shippingDimensionsFromOffer(offer) {
   return { weight: { value: w.value, unit: w.unitText } };
 }
 
+/**
+ * Build the `custom` fragment forwarded onto a cart line item from Product Bus.
+ *
+ * Only commercial products need to carry data today: the order body relays
+ * `custom` verbatim to the Commerce API, and the EBS sync job reads
+ * `item.custom.isCommercial === true` to set the "Commercial" order type.
+ * Commercial is a product-level trait, so it is read from the parent product
+ * rather than a selected variant. Returns an empty object for household
+ * products so the spread adds nothing and their payloads stay unchanged.
+ *
+ * @param {Object} parent - The parent product object from Product Bus
+ * @returns {{custom: {isCommercial: true}} | {}}
+ */
+export function resolveLineItemCustom(parent) {
+  return parent?.custom?.isCommercial ? { custom: { isCommercial: true } } : {};
+}
+
 function getCartCompatibility(parent) {
   const { type, compatibleWith, compatibilityGroup } = parent.custom || {};
   if (!compatibleWith && !compatibilityGroup) return null;
@@ -365,6 +382,9 @@ export default function renderAddToCart(ph, block, parent) {
           image: selectedVariant.image?.[0] ?? parent.image?.[0],
           variant: window.selectedVariant?.options?.color || '',
           selectedOptions: semanticOptions,
+          // Forward the commercial flag from Product Bus so the order carries it
+          // and the EBS sync job can set the "Commercial" order type.
+          ...resolveLineItemCustom(parent),
           ...(parent.bundleItems ? { bundleItems: parent.bundleItems } : {}),
           ...((availableWarranties || compatibility) ? {
             local: {

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -11,6 +11,7 @@ import {
   isVariantAvailableForSale,
   computeAllowedQty,
   shippingDimensionsFromOffer,
+  resolveLineItemCustom,
 } from '../../blocks/pdp/add-to-cart.js';
 import { __setMetadata, __resetMetadata } from './mocks/aem.mjs';
 import { __setOutOfStockSkus, __resetScripts } from './mocks/scripts.mjs';
@@ -182,4 +183,30 @@ test('shippingDimensionsFromOffer: returns undefined when value is not numeric',
 test('shippingDimensionsFromOffer: returns undefined for null/undefined input', () => {
   assert.equal(shippingDimensionsFromOffer(null), undefined);
   assert.equal(shippingDimensionsFromOffer(undefined), undefined);
+});
+
+// --- resolveLineItemCustom ---------------------------------------------------
+
+test('resolveLineItemCustom: forwards isCommercial when the parent is commercial', () => {
+  assert.deepEqual(
+    resolveLineItemCustom({ custom: { isCommercial: true } }),
+    { custom: { isCommercial: true } },
+  );
+});
+
+test('resolveLineItemCustom: empty object for household products', () => {
+  assert.deepEqual(resolveLineItemCustom({ custom: { type: 'simple' } }), {});
+});
+
+test('resolveLineItemCustom: empty object when custom is absent', () => {
+  assert.deepEqual(resolveLineItemCustom({}), {});
+});
+
+test('resolveLineItemCustom: empty object for null/undefined parent', () => {
+  assert.deepEqual(resolveLineItemCustom(null), {});
+  assert.deepEqual(resolveLineItemCustom(undefined), {});
+});
+
+test('resolveLineItemCustom: ignores a falsy isCommercial flag', () => {
+  assert.deepEqual(resolveLineItemCustom({ custom: { isCommercial: false } }), {});
 });


### PR DESCRIPTION
Fixes #740

Forward the Product Bus commercial flag onto cart line items so it reaches the order payload and allows EBS sync to create commercial orders. Household product payloads remain unchanged.

Tests:
- npm run test:unit (336 passing)
- npm run lint (passed)

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://issue-740-commercial-order-type--vitamix--aemsites.aem.network/