### PR TITLE
Added event tracking for customer registration post order place

### DIFF
--- a/scripts/consented/instrumentation/adobe-runtime.js
+++ b/scripts/consented/instrumentation/adobe-runtime.js
@@ -327,6 +327,14 @@ export function assignDigitalDataUser(userData) {
 }
 
 /**
+ * @param {object} componentData
+ */
+export function assignDigitalDataComponent(componentData) {
+  window.digitalData = window.digitalData || {};
+  window.digitalData.component = componentData;
+}
+
+/**
  * Launch keeps its tracker in AppMeasurement's s_c_il registry, not always window.s.
  */
 export function configureAnalyticsTrackingServers() {

--- a/scripts/consented/instrumentation/order-success.js
+++ b/scripts/consented/instrumentation/order-success.js
@@ -12,12 +12,14 @@ import {
   normalizePurchaseLineItem,
 } from './shared.js';
 import {
+  assignDigitalDataComponent,
   assignDigitalDataTransaction,
   configureAnalyticsTrackingServers,
   getAdobeTarget,
   getPrimaryAnalyticsTracker,
   getSatellite,
   resetTrackerForScAdd,
+  triggerLaunchEvent,
   waitForBeaconComplete,
   whenSatelliteReady,
   whenTargetReady,
@@ -335,6 +337,7 @@ function trackOrderConfirmPage(params) {
 
 let orderConfirmTargetFired = false;
 let purchaseFired = false;
+let registrationCompleteFired = false;
 let orderPurchaseTrackingRegistered = false;
 
 /**
@@ -385,6 +388,35 @@ function trackPurchaseFromContext(context, attempt = 0) {
 }
 
 /**
+ * Fire registration-complete analytics when order-complete reports a new
+ * customer account was created for this order (Adobe Commerce parity).
+ * @param {{ order?: object|null }} context Analytics context from order-complete
+ * @returns {Promise<void>}
+ */
+export async function fireRegistrationComplete(context) {
+  if (registrationCompleteFired) return;
+
+  if (!hasMarketingConsent()) {
+    return;
+  }
+
+  if (!context?.order?.customerCreated) {
+    return;
+  }
+
+  assignDigitalDataComponent({ form: { formName: 'register' } });
+
+  if (!(await triggerLaunchEvent('formStart', window.digitalData.component))
+    || !(await triggerLaunchEvent('registrationComplete', window.digitalData.component))) {
+    debugWarn('Adobe Analytics registrationComplete skipped: Adobe Launch (_satellite) not available');
+    return;
+  }
+
+  registrationCompleteFired = true;
+  debugLog('Adobe Analytics registrationComplete fired', window.digitalData.component);
+}
+
+/**
  * Listen for order-complete confirmation before firing purchase.
  * Purchase must run after the page has authoritative order/line-item data,
  * not on the initial Launch page-view beacon.
@@ -397,11 +429,13 @@ export function registerOrderPurchaseTracking() {
 
   document.addEventListener('order:confirmed', (event) => {
     trackPurchaseFromContext(event.detail);
+    whenSatelliteReady(() => fireRegistrationComplete(event.detail), 'registrationComplete');
   }, { once: true });
 
   const pendingContext = window.vitamixEdsAnalytics?.orderConfirmedContext;
   if (pendingContext) {
     trackPurchaseFromContext(pendingContext);
+    whenSatelliteReady(() => fireRegistrationComplete(pendingContext), 'registrationComplete');
   }
 }
 


### PR DESCRIPTION
Code for tracking the customer registration success after order is placed and the customer details are synced

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://customer-registration-instrumentation--vitamix--aemsites.aem.network/
