### PR TITLE
fix(pdp): retain find dealer alongside add to cart

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -19,22 +19,40 @@ function renderFindLocally(ph, block) {
 }
 
 /**
- * Renders a "Find Dealer" button container.
+ * Appends the commercial dealer and expert consultation links to a PDP CTA container.
+ * @param {Object} ph - Placeholders object
+ * @param {HTMLElement} container - Container receiving the dealer CTA content
+ * @param {boolean} isSecondary - Whether the dealer button follows Add to Cart
+ */
+function appendFindDealerCta(ph, container, isSecondary = false) {
+  const { locale, language } = getLocaleAndLanguage();
+  const findDealerButton = document.createElement('a');
+  findDealerButton.classList.add('button', 'pdp-find-dealer-button');
+  if (!isSecondary) findDealerButton.classList.add('emphasis');
+  findDealerButton.href = `https://www.vitamix.com/${locale}/${language}/where-to-buy?`
+    + 'productFamily=2205202&productType=COMM';
+  findDealerButton.textContent = ph.findDealer || 'Find Dealer';
+
+  const expertQuestion = document.createElement('p');
+  const expertLink = document.createElement('a');
+  expertLink.href = `https://www.vitamix.com/${locale}/${language}/commercial/resources/`
+    + 'consult-an-expert';
+  expertLink.textContent = ph.consultAnExpert || 'Have a question? Consult an expert.';
+  expertQuestion.append(expertLink);
+
+  container.append(findDealerButton, expertQuestion);
+}
+
+/**
+ * Renders a "Find Dealer" button container for an unavailable product.
  * @param {Object} ph - Placeholders object
  * @param {HTMLElement} block - PDP block element
  * @returns {HTMLElement} Container div with "Find Dealer" button and expert consultation link
  */
 function renderFindDealer(ph, block) {
-  const { locale, language } = getLocaleAndLanguage();
   const findDealerContainer = document.createElement('div');
   findDealerContainer.classList.add('add-to-cart');
-  findDealerContainer.innerHTML = `<a
-    class="button emphasis pdp-find-locally-button"
-    href="https://www.vitamix.com/${locale}/${language}/where-to-buy?productFamily=2205202&productType=COMM">${ph.findDealer || 'Find Dealer'}</a>
-  <p>
-    <a
-      href="https://www.vitamix.com/${locale}/${language}/commercial/resources/consult-an-expert">${ph.consultAnExpert || 'Have a question? Consult an expert.'}</a>
-  </p>`;
+  appendFindDealerCta(ph, findDealerContainer);
   block.classList.add('pdp-find-dealer');
   return findDealerContainer;
 }
@@ -265,6 +283,11 @@ export default function renderAddToCart(ph, block, parent) {
 
   // add quantity container to main add to cart container
   addToCartContainer.appendChild(quantityContainer);
+
+  // Saleable commercial products keep the dealer CTA as a secondary action.
+  if (findDealer === 'Yes') {
+    appendFindDealerCta(ph, addToCartContainer, true);
+  }
 
   return addToCartContainer;
 }

--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -286,6 +286,7 @@ export default function renderAddToCart(ph, block, parent) {
 
   // Saleable commercial products keep the dealer CTA as a secondary action.
   if (findDealer === 'Yes') {
+    addToCartContainer.classList.add('pdp-add-to-cart-with-dealer');
     appendFindDealerCta(ph, addToCartContainer, true);
   }
 

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -204,6 +204,19 @@ a.button.pdp-find-locally-button {
   text-transform: none;
 }
 
+a.button.pdp-find-dealer-button {
+  width: 100%;
+  max-width: 350px;
+  font-weight: var(--weight-light);
+  border-radius: 4px;
+  text-transform: none;
+}
+
+a.button.pdp-find-dealer-button.emphasis {
+  background-color: var(--color-charcoal);
+  border: none;
+}
+
 .details {
   grid-area: details;
   gap: var(--spacing-xl);

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -217,6 +217,23 @@ a.button.pdp-find-dealer-button.emphasis {
   border: none;
 }
 
+.add-to-cart.pdp-add-to-cart-with-dealer .quantity-container {
+  gap: 36px;
+}
+
+.add-to-cart.pdp-add-to-cart-with-dealer select {
+  height: 52px;
+}
+
+.add-to-cart.pdp-add-to-cart-with-dealer button {
+  padding: 11px 16px;
+}
+
+.add-to-cart.pdp-add-to-cart-with-dealer .pdp-find-dealer-button {
+  margin-top: 20px;
+  padding: 10px 24px;
+}
+
 .details {
   grid-area: details;
   gap: var(--spacing-xl);

--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -95,12 +95,16 @@ function renderFAQ(ph) {
 function renderCompare(ph, custom) {
   const { locale, language } = getLocaleAndLanguage();
   const { entityId } = custom;
+  const comparisonLabel = ph.viewComparisonList || 'View Comparison List';
+  const comparisonLinkText = comparisonLabel.endsWith('.')
+    ? comparisonLabel
+    : `${comparisonLabel}.`;
   const compareContainer = document.createElement('div');
   compareContainer.classList.add('pdp-compare-container');
   compareContainer.innerHTML = `
     <div>
       <button class="pdp-compare-button">${ph.compare || 'Compare'}</button>
-      <a href="/${locale}/${language}/catalog/product_compare/index/" title="${ph.viewComparisonList || 'View Comparison List'}" class="comparelistlink">${ph.viewComparisonList || 'View Comparison List'}.</a>
+      <a href="/${locale}/${language}/catalog/product_compare/index/" title="${comparisonLabel}" class="comparelistlink">${comparisonLinkText}</a>
     </div>`;
 
   const compareButton = compareContainer.querySelector('.pdp-compare-button');

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -41,6 +41,15 @@ test.describe('PDP Integration Tests', () => {
       await assertOptionElements(page);
     });
 
+    test('should render one terminal period in the comparison link', async ({ page }) => {
+      const productUrl = buildProductUrl(productPath, currentBranch);
+      await page.goto(productUrl);
+
+      const comparisonLink = page.locator('.pdp-compare-container .comparelistlink');
+      await expect(comparisonLink).toHaveText(/[^.]\.$/);
+      await expect(comparisonLink).not.toHaveText(/\.\.$/);
+    });
+
     test('should deeplink to Ascent X2 variant', async ({ page }) => {
       const productUrl = buildProductUrl(productPath, currentBranch, {
         color: 'polar-white',

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -303,6 +303,93 @@ test.describe('PDP Integration Tests', () => {
     });
   });
 
+  test.describe('Commercial dealer CTA', () => {
+    const productPath = '/us/en_us/products/ascent-x2';
+
+    test(
+      'keeps dealer links beside Add to Cart and preserves the unavailable fallback',
+      async ({ page }) => {
+        const productUrl = buildProductUrl(productPath, currentBranch);
+        await page.goto(productUrl);
+        await page.waitForSelector('.pdp');
+
+        await page.evaluate(async () => {
+          // eslint-disable-next-line import/no-unresolved, import/no-absolute-path
+          const { default: renderAddToCart } = await import('/blocks/pdp/add-to-cart.js');
+          const ph = {
+            addToCart: 'Add to Cart',
+            quantity: 'Quantity',
+            findDealer: 'Find a Dealer',
+            consultAnExpert: 'Have a question? Consult an expert.',
+          };
+          const { selectedVariant } = window;
+          window.selectedVariant = undefined;
+
+          const saleableHost = document.createElement('div');
+          saleableHost.classList.add('pdp', 'commercial-saleable');
+          const saleableProduct = {
+            offers: [{
+              sku: 'commercial-saleable',
+              custom: { managedStock: '0', addToCart: 'Yes', comingSoon: 'No' },
+            }],
+            custom: {
+              type: 'simple',
+              findLocally: 'No',
+              findDealer: 'Yes',
+              comingSoon: 'No',
+            },
+          };
+          saleableHost.append(renderAddToCart(ph, saleableHost, saleableProduct));
+
+          const unavailableHost = document.createElement('div');
+          unavailableHost.classList.add('pdp', 'commercial-unavailable');
+          const unavailableProduct = {
+            offers: [{
+              sku: 'commercial-unavailable',
+              custom: { managedStock: '0', addToCart: 'No', comingSoon: 'No' },
+            }],
+            custom: {
+              type: 'simple',
+              findLocally: 'No',
+              findDealer: 'Yes',
+              comingSoon: 'No',
+            },
+          };
+          unavailableHost.append(renderAddToCart(ph, unavailableHost, unavailableProduct));
+
+          document.querySelector('main').append(saleableHost, unavailableHost);
+          window.selectedVariant = selectedVariant;
+        });
+
+        const saleable = page.locator('.commercial-saleable');
+        const saleableDealerButton = saleable.locator('.pdp-find-dealer-button');
+        const dealerUrl = 'https://www.vitamix.com/us/en_us/where-to-buy?'
+          + 'productFamily=2205202&productType=COMM';
+        const expertUrl = 'https://www.vitamix.com/us/en_us/commercial/resources/'
+          + 'consult-an-expert';
+
+        await expect(saleable.locator('.quantity-container button')).toBeVisible();
+        await expect(saleableDealerButton).toHaveText('Find a Dealer');
+        await expect(saleableDealerButton).toHaveAttribute('href', dealerUrl);
+        await expect(saleable.locator('.add-to-cart > p a')).toHaveText(/consult an expert/i);
+        await expect(saleable.locator('.add-to-cart > p a')).toHaveAttribute('href', expertUrl);
+        await expect(saleable).not.toHaveClass(/pdp-find-dealer/);
+        await expect(saleableDealerButton).not.toHaveClass(/emphasis/);
+        const saleableCtaOrder = await saleable.locator('.add-to-cart').evaluate((container) => (
+          [...container.children].map(({ tagName }) => tagName)
+        ));
+        expect(saleableCtaOrder).toEqual(['LABEL', 'DIV', 'A', 'P']);
+
+        const unavailable = page.locator('.commercial-unavailable');
+        const unavailableDealerButton = unavailable.locator('.pdp-find-dealer-button');
+        await expect(unavailable).toHaveClass(/pdp-find-dealer/);
+        await expect(unavailable.locator('.quantity-container')).toHaveCount(0);
+        await expect(unavailableDealerButton).toHaveClass(/emphasis/);
+        await expect(unavailableDealerButton).toHaveAttribute('href', dealerUrl);
+      },
+    );
+  });
+
   test.describe('Bundle Product Page', () => {
     const productPath = '/us/en_us/products/5200-legacy-bundle';
 

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -374,6 +374,7 @@ test.describe('PDP Integration Tests', () => {
         await expect(saleable.locator('.add-to-cart > p a')).toHaveText(/consult an expert/i);
         await expect(saleable.locator('.add-to-cart > p a')).toHaveAttribute('href', expertUrl);
         await expect(saleable).not.toHaveClass(/pdp-find-dealer/);
+        await expect(saleable.locator('.add-to-cart')).toHaveClass(/pdp-add-to-cart-with-dealer/);
         await expect(saleableDealerButton).not.toHaveClass(/emphasis/);
         const saleableCtaOrder = await saleable.locator('.add-to-cart').evaluate((container) => (
           [...container.children].map(({ tagName }) => tagName)


### PR DESCRIPTION
Fixes #770

Commercial products that can be purchased still need a path to local dealers and expert help. Reuse the existing dealer CTA content in the saleable buy box while preserving the dealer-only fallback for unavailable products.

## Acceptance criteria

- Saleable commercial PDPs retain Add to Cart and show an outlined Find a Dealer action with the expert link.
- Unavailable dealer PDPs retain the existing dealer-only fallback.

## Tests

- `npm run lint`
- `LOCAL_TESTING=1 npm test -- --grep 'Commercial dealer CTA' --reporter=line` (Chromium and Mobile Chrome)
- Recorded local `aem-browser` validation at 1440px and 713px.

## Review notes

The production Drive Socket Kit reference page was unavailable from the main EDS content origin, so browser validation used representative commercial Product Bus data on a local PDP. A complete PDP integration run has eight existing cart/warranty fixture mismatches from current Product Bus data; the focused regression test passes in both browser projects.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/
- After: https://issue-770-commercial-pdps-that-have-add-to-c--vitamix--aemsites.aem.network/