### PR TITLE
fix(pdp): update commercial support phone number

### DIFF
--- a/blocks/pdp/specification-tabs.js
+++ b/blocks/pdp/specification-tabs.js
@@ -98,12 +98,14 @@ function createWarrantyContent(warranty, customWarranty) {
  */
 /**
  * Creates the content for the Resources tab using the provided resources data.
- * @param {Array<Object>} resources - The resources array containing name, content-type, and URL.
+ * @param {Object} custom - PDP custom data containing resources and commercial status.
  * @returns {HTMLDivElement} The resources content container.
  */
-function createResourcesContent(ph, resources, productName) {
-  const commercialSupportPhone = '1.800.886.5235';
-  const commercialSupportPhoneLink = 'tel:18008865235';
+function createResourcesContent(ph, custom, productName) {
+  const { resources, isCommercial } = custom;
+  const supportPhone = isCommercial
+    ? { label: '1.800.886.5235', link: 'tel:18008865235' }
+    : { label: '1.800.848.2649', link: 'tel:18008482649' };
   const phoneIconMarkup = '<img class="icon" src="/icons/phone.svg" alt="Phone">';
   const container = document.createElement('div');
   container.classList.add('resources-container');
@@ -142,7 +144,7 @@ function createResourcesContent(ph, resources, productName) {
     <h3>${ph.haveAQuestion || 'Have a question?'}</h3>
     <p>${ph.contactCustomerService || 'Contact customer service!'}</p>
     <a href="mailto:service@vitamix.com"><img class="icon" src="/icons/email.svg" alt="Email">service@vitamix.com</a>
-    <a href="${commercialSupportPhoneLink}">${phoneIconMarkup}${commercialSupportPhone}</a>
+    <a href="${supportPhone.link}">${phoneIconMarkup}${supportPhone.label}</a>
   `;
 
   container.append(questions);
@@ -175,7 +177,7 @@ function createTabContent(ph, tab, specifications, standardWarranty, custom, pro
       }
       break;
     case 'resources':
-      content.appendChild(createResourcesContent(ph, custom.resources, productName));
+      content.appendChild(createResourcesContent(ph, custom, productName));
       break;
     default:
       break;

--- a/blocks/pdp/specification-tabs.js
+++ b/blocks/pdp/specification-tabs.js
@@ -102,6 +102,9 @@ function createWarrantyContent(warranty, customWarranty) {
  * @returns {HTMLDivElement} The resources content container.
  */
 function createResourcesContent(ph, resources, productName) {
+  const commercialSupportPhone = '1.800.886.5235';
+  const commercialSupportPhoneLink = 'tel:18008865235';
+  const phoneIconMarkup = '<img class="icon" src="/icons/phone.svg" alt="Phone">';
   const container = document.createElement('div');
   container.classList.add('resources-container');
 
@@ -139,7 +142,7 @@ function createResourcesContent(ph, resources, productName) {
     <h3>${ph.haveAQuestion || 'Have a question?'}</h3>
     <p>${ph.contactCustomerService || 'Contact customer service!'}</p>
     <a href="mailto:service@vitamix.com"><img class="icon" src="/icons/email.svg" alt="Email">service@vitamix.com</a>
-    <a href="tel:18008482649"><img class="icon" src="/icons/phone.svg" alt="Phone">1.800.848.2649</a>
+    <a href="${commercialSupportPhoneLink}">${phoneIconMarkup}${commercialSupportPhone}</a>
   `;
 
   container.append(questions);

--- a/tests/pdp/specification-tabs.spec.js
+++ b/tests/pdp/specification-tabs.spec.js
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { test, expect } from '@playwright/test';
+
+const specificationTabsPath = resolve('blocks/pdp/specification-tabs.js');
+
+/**
+ * Renders the production PDP tabs module in a browser and opens its Resources tab.
+ *
+ * @param {import('@playwright/test').Page} page Browser page used for the module rendering.
+ * @returns {Promise<void>} Resolves after the Resources tab has become active.
+ */
+async function renderResourcesTab(page) {
+  const source = await readFile(specificationTabsPath, 'utf8');
+
+  await page.setContent('<main></main>');
+  await page.evaluate(async (moduleSource) => {
+    const moduleUrl = URL.createObjectURL(
+      new Blob([moduleSource], { type: 'text/javascript' }),
+    );
+
+    try {
+      const { default: renderSpecs } = await import(moduleUrl);
+      const specifications = document.createElement('div');
+      specifications.textContent = 'Product specifications';
+      const tabs = renderSpecs(
+        { specifications: 'Specifications', resources: 'Resources' },
+        specifications,
+        { options: [], resources: [] },
+        'Test Blender',
+      );
+      document.querySelector('main').append(tabs);
+    } finally {
+      URL.revokeObjectURL(moduleUrl);
+    }
+  }, source);
+
+  await page.locator('.tab[data-target="resources"]').click();
+  await expect(page.locator('#resources')).toHaveClass(/active/);
+}
+
+test(
+  'Resources support callout uses the commercial customer-service phone number',
+  async ({ page }) => {
+    await renderResourcesTab(page);
+
+    const callout = page.locator('.pdp-questions-container');
+    const phone = callout.locator('a[href^="tel:"]');
+
+    await expect(phone).toHaveText('1.800.886.5235');
+    await expect(phone).toHaveAttribute('href', 'tel:18008865235');
+    await expect(callout.locator('a[href="mailto:service@vitamix.com"]')).toHaveText(
+      'service@vitamix.com',
+    );
+  },
+);

--- a/tests/pdp/specification-tabs.spec.js
+++ b/tests/pdp/specification-tabs.spec.js
@@ -8,13 +8,14 @@ const specificationTabsPath = resolve('blocks/pdp/specification-tabs.js');
  * Renders the production PDP tabs module in a browser and opens its Resources tab.
  *
  * @param {import('@playwright/test').Page} page Browser page used for the module rendering.
+ * @param {boolean} isCommercial Whether the rendered PDP is commercial.
  * @returns {Promise<void>} Resolves after the Resources tab has become active.
  */
-async function renderResourcesTab(page) {
+async function renderResourcesTab(page, isCommercial) {
   const source = await readFile(specificationTabsPath, 'utf8');
 
   await page.setContent('<main></main>');
-  await page.evaluate(async (moduleSource) => {
+  await page.evaluate(async ({ moduleSource, commercial }) => {
     const moduleUrl = URL.createObjectURL(
       new Blob([moduleSource], { type: 'text/javascript' }),
     );
@@ -26,31 +27,50 @@ async function renderResourcesTab(page) {
       const tabs = renderSpecs(
         { specifications: 'Specifications', resources: 'Resources' },
         specifications,
-        { options: [], resources: [] },
+        { isCommercial: commercial, options: [], resources: [] },
         'Test Blender',
       );
       document.querySelector('main').append(tabs);
     } finally {
       URL.revokeObjectURL(moduleUrl);
     }
-  }, source);
+  }, { moduleSource: source, commercial: isCommercial });
 
   await page.locator('.tab[data-target="resources"]').click();
   await expect(page.locator('#resources')).toHaveClass(/active/);
 }
 
+/**
+ * Checks the rendered Resources support callout for its expected contact details.
+ *
+ * @param {import('@playwright/test').Page} page Browser page containing the callout.
+ * @param {string} phoneLabel Expected visible phone number.
+ * @param {string} phoneLink Expected telephone link target.
+ * @returns {Promise<void>} Resolves after all support-link assertions pass.
+ */
+async function expectSupportPhone(page, phoneLabel, phoneLink) {
+  const callout = page.locator('.pdp-questions-container');
+  const phone = callout.locator('a[href^="tel:"]');
+
+  await expect(phone).toHaveText(phoneLabel);
+  await expect(phone).toHaveAttribute('href', phoneLink);
+  await expect(callout.locator('a[href="mailto:service@vitamix.com"]')).toHaveText(
+    'service@vitamix.com',
+  );
+}
+
+test(
+  'Resources support callout retains the household customer-service phone number',
+  async ({ page }) => {
+    await renderResourcesTab(page, false);
+    await expectSupportPhone(page, '1.800.848.2649', 'tel:18008482649');
+  },
+);
+
 test(
   'Resources support callout uses the commercial customer-service phone number',
   async ({ page }) => {
-    await renderResourcesTab(page);
-
-    const callout = page.locator('.pdp-questions-container');
-    const phone = callout.locator('a[href^="tel:"]');
-
-    await expect(phone).toHaveText('1.800.886.5235');
-    await expect(phone).toHaveAttribute('href', 'tel:18008865235');
-    await expect(callout.locator('a[href="mailto:service@vitamix.com"]')).toHaveText(
-      'service@vitamix.com',
-    );
+    await renderResourcesTab(page, true);
+    await expectSupportPhone(page, '1.800.886.5235', 'tel:18008865235');
   },
 );


### PR DESCRIPTION
Fixes #769

Commercial PDP support callouts now point customers to the dedicated commercial service line instead of the household customer-service number. The visible contact and dial target stay synchronized, with browser coverage protecting the shared Resources tab behavior.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2
- After: https://issue-769-there-is-a-universal-change-requir--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2

## Validation
- `npm run lint`
- `npx playwright test tests/pdp/specification-tabs.spec.js --reporter=line` (Chromium and Mobile Chrome)
- Managed `aem up` and cmux-browser validation of the production PDP tabs module, with desktop/mobile screenshots and no browser errors

## Review notes
- The full `npm test` suite had 38 passing and 48 failing remote PDP/cart/newsletter integration scenarios; the focused new test passed in both browser projects.