### PR TITLE
fix(pdp): select support email by product type

### DIFF
--- a/blocks/pdp/specification-tabs.js
+++ b/blocks/pdp/specification-tabs.js
@@ -103,9 +103,11 @@ function createWarrantyContent(warranty, customWarranty) {
  */
 function createResourcesContent(ph, custom, productName) {
   const { resources, isCommercial } = custom;
+  const supportEmail = isCommercial ? 'commercial@vitamix.com' : 'service@vitamix.com';
   const supportPhone = isCommercial
     ? { label: '1.800.886.5235', link: 'tel:18008865235' }
     : { label: '1.800.848.2649', link: 'tel:18008482649' };
+  const emailIconMarkup = '<img class="icon" src="/icons/email.svg" alt="Email">';
   const phoneIconMarkup = '<img class="icon" src="/icons/phone.svg" alt="Phone">';
   const container = document.createElement('div');
   container.classList.add('resources-container');
@@ -143,7 +145,7 @@ function createResourcesContent(ph, custom, productName) {
   questions.innerHTML = `
     <h3>${ph.haveAQuestion || 'Have a question?'}</h3>
     <p>${ph.contactCustomerService || 'Contact customer service!'}</p>
-    <a href="mailto:service@vitamix.com"><img class="icon" src="/icons/email.svg" alt="Email">service@vitamix.com</a>
+    <a href="mailto:${supportEmail}">${emailIconMarkup}${supportEmail}</a>
     <a href="${supportPhone.link}">${phoneIconMarkup}${supportPhone.label}</a>
   `;
 

--- a/tests/pdp/specification-tabs.spec.js
+++ b/tests/pdp/specification-tabs.spec.js
@@ -44,26 +44,32 @@ async function renderResourcesTab(page, isCommercial) {
  * Checks the rendered Resources support callout for its expected contact details.
  *
  * @param {import('@playwright/test').Page} page Browser page containing the callout.
+ * @param {string} supportEmail Expected visible support email address.
  * @param {string} phoneLabel Expected visible phone number.
  * @param {string} phoneLink Expected telephone link target.
  * @returns {Promise<void>} Resolves after all support-link assertions pass.
  */
-async function expectSupportPhone(page, phoneLabel, phoneLink) {
+async function expectSupportContact(page, supportEmail, phoneLabel, phoneLink) {
   const callout = page.locator('.pdp-questions-container');
+  const email = callout.locator('a[href^="mailto:"]');
   const phone = callout.locator('a[href^="tel:"]');
 
+  await expect(email).toHaveText(supportEmail);
+  await expect(email).toHaveAttribute('href', `mailto:${supportEmail}`);
   await expect(phone).toHaveText(phoneLabel);
   await expect(phone).toHaveAttribute('href', phoneLink);
-  await expect(callout.locator('a[href="mailto:service@vitamix.com"]')).toHaveText(
-    'service@vitamix.com',
-  );
 }
 
 test(
   'Resources support callout retains the household customer-service phone number',
   async ({ page }) => {
     await renderResourcesTab(page, false);
-    await expectSupportPhone(page, '1.800.848.2649', 'tel:18008482649');
+    await expectSupportContact(
+      page,
+      'service@vitamix.com',
+      '1.800.848.2649',
+      'tel:18008482649',
+    );
   },
 );
 
@@ -71,6 +77,11 @@ test(
   'Resources support callout uses the commercial customer-service phone number',
   async ({ page }) => {
     await renderResourcesTab(page, true);
-    await expectSupportPhone(page, '1.800.886.5235', 'tel:18008865235');
+    await expectSupportContact(
+      page,
+      'commercial@vitamix.com',
+      '1.800.886.5235',
+      'tel:18008865235',
+    );
   },
 );


### PR DESCRIPTION
Follow-up to #777.

Commercial PDP support callouts now use the commercial service email while household products retain the existing household contact. Both contact channels are selected from the product commercial-status field to keep the callout consistent.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/commercial/products/the-quiet-one
- After: https://fix-769-commercial-support-email--vitamix--aemsites.aem.network/us/en_us/commercial/products/the-quiet-one

## Validation
- `npm run lint`
- `npx playwright test tests/pdp/specification-tabs.spec.js --reporter=line` (4/4 across Chromium and Mobile Chrome)
- Managed `aem up` and cmux-browser validation for household and commercial contacts, with desktop/mobile screenshots and no browser errors