### PR TITLE
feat(sidekick): support commercial product syncs

### DIFF
--- a/tools/sidekick/sync/sync-utils.js
+++ b/tools/sidekick/sync/sync-utils.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Resolves the catalog context represented by a product page path.
+ * @param {string} pathname - Product page pathname
+ * @returns {{storeCode: string, storeViewCode: string, urlKey: string, category?: string}}
+ *   Catalog context
+ */
+export function resolveSyncContext(pathname) {
+  const pathParts = pathname.split('/').filter(Boolean);
+  const storeCode = pathParts[0] || '';
+  let storeViewCode = pathParts[1] || '';
+  const category = pathParts[2] === 'products' && pathParts[3] === 'commercial'
+    ? 'commercial'
+    : undefined;
+  const urlKey = pathParts[category ? 4 : 3] || '';
+
+  if (storeCode === 'ca' && storeViewCode === 'en_us') {
+    storeViewCode = 'en_ca';
+  }
+
+  if (storeCode === 'mx' && storeViewCode === 'en_us') {
+    storeViewCode = 'en_mx';
+  }
+
+  return {
+    storeCode,
+    storeViewCode,
+    urlKey,
+    ...(category && { category }),
+  };
+}
+
+/**
+ * Adds an optional catalog category to a sync request.
+ * @param {object} data - Base sync request payload
+ * @param {string} [category] - Product catalog category
+ * @returns {object} sync request payload
+ */
+export function withCategory(data, category) {
+  return category ? { ...data, category } : data;
+}

--- a/tools/sidekick/sync/sync.js
+++ b/tools/sidekick/sync/sync.js
@@ -1,15 +1,17 @@
 import {
   buildBlock, decorateBlock, loadBlock, loadCSS,
 } from '../../../scripts/aem.js';
+import { resolveSyncContext, withCategory } from './sync-utils.js';
 
 const SYNC_WORKER_URL = 'https://vitamix-catalog-sync.adobeaem.workers.dev/';
 
 /**
  * Creates a product sync modal dialog
  *
+ * @param {string} [pathname] Product page pathname to use for catalog context
  * @returns {Promise<{dialog: HTMLDialogElement, showModal: () => Promise<void>}>}
  */
-export async function createSyncModal() {
+export async function createSyncModal(pathname = window.location.pathname) {
   await loadCSS(`${window.hlx.codeBasePath}/blocks/modal/modal.css`);
   await loadCSS('https://main--vitamix--aemsites.aem.page/tools/sidekick/sync/sync.css');
 
@@ -17,28 +19,19 @@ export async function createSyncModal() {
   const dialogContent = document.createElement('div');
   dialogContent.classList.add('modal-content');
 
-  const urlPath = window.location.pathname;
-  const pathParts = urlPath.split('/').filter((part) => part); // Remove empty strings
-
-  // Expected format: /ca/en_us/products/ascent-x5
-  const defaultStoreCode = pathParts[0] || '';
-  let defaultStoreViewCode = pathParts[1] || '';
-  const defaultUrlKey = pathParts[3] || '';
-
-  if (defaultStoreCode === 'ca' && defaultStoreViewCode === 'en_us') {
-    defaultStoreViewCode = 'en_ca';
-  }
-
-  if (defaultStoreCode === 'mx' && defaultStoreViewCode === 'en_us') {
-    defaultStoreViewCode = 'en_mx';
-  }
+  const {
+    storeCode: defaultStoreCode,
+    storeViewCode: defaultStoreViewCode,
+    urlKey: defaultUrlKey,
+    category,
+  } = resolveSyncContext(pathname);
 
   // pull the sku from the sku meta tag
   const skuMeta = document.querySelector('meta[name="sku"]');
   const defaultSku = skuMeta ? skuMeta.content : '';
 
   const h3 = document.createElement('h3');
-  h3.textContent = 'Product Sync';
+  h3.textContent = category ? 'Commercial Product Sync' : 'Product Sync';
   dialogContent.append(h3);
 
   // Create mode selector (tabs)
@@ -81,13 +74,13 @@ export async function createSyncModal() {
     <div class="form-group">
       <label>
         <input type="radio" name="syncAllMode" value="all-stores" checked>
-        Sync All Stores
+        ${category ? 'Sync All Commercial Stores' : 'Sync All Stores'}
       </label>
     </div>
     <div class="form-group">
       <label>
         <input type="radio" name="syncAllMode" value="single-store">
-        Sync Single Store
+        ${category ? 'Sync Single Commercial Store' : 'Sync Single Store'}
       </label>
     </div>
     <div class="single-store-inputs" style="display: none;">
@@ -232,12 +225,12 @@ export async function createSyncModal() {
   syncSkuForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     const formData = new FormData(syncSkuForm);
-    const data = {
+    const data = withCategory({
       storeCode: formData.get('storeCode'),
       storeViewCode: formData.get('storeViewCode'),
       sku: formData.get('sku') || undefined,
       urlKey: formData.get('urlKey') || undefined,
-    };
+    }, category);
 
     // Validate that at least sku or urlKey is provided
     if (!data.sku && !data.urlKey) {
@@ -267,7 +260,7 @@ export async function createSyncModal() {
 
     let data;
     if (syncAllMode === 'all-stores') {
-      data = { syncAll: true };
+      data = withCategory({ syncAll: true }, category);
     } else {
       const storeCode = formData.get('storeCode');
       const storeViewCode = formData.get('storeViewCode');
@@ -283,11 +276,11 @@ export async function createSyncModal() {
         return;
       }
 
-      data = {
+      data = withCategory({
         syncAll: true,
         storeCode,
         storeViewCode,
-      };
+      }, category);
     }
 
     const success = await performSync(data, 'sync-all');


### PR DESCRIPTION
Commercial PDPs add a path segment, so the Sidekick now preserves the correct URL key and identifies catalog sync requests as commercial.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/commercial/touch-go-advance
- After: https://feat-commercial-sidekick-sync--vitamix--aemsites.aem.network/us/en_us/products/commercial/touch-go-advance