### PR TITLE
fix(leadsource): align account/registration lead sources and route forms by edge-checkout locale

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -1,5 +1,6 @@
 import { toCamelCase, toClassName } from '../../scripts/aem.js';
 import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getLeadSource, getLegacyLeadSource } from '../../scripts/lead-source.js';
 
 /**
  * Creates an HTML element with an optional class name
@@ -486,24 +487,23 @@ function enableFooterSignUp(form) {
     const { email, mobile, optIn } = entries;
     const country = window.location.pathname.split('/')[1];
     const { locale, language } = getLocaleAndLanguage();
-    let leadSource = `sub-em-footer-${country}`;
-    if (form.closest('dialog')) {
-      leadSource = `sub-em-modal-${country}`;
-    }
-    if (window.leadSourceOverride) {
-      leadSource = `sub-em-${window.leadSourceOverride}-${country}`;
-    }
+    const smsOptIn = Boolean(optIn);
+    let page = 'footer';
+    if (form.closest('dialog')) page = 'modal';
+    if (window.leadSourceOverride) page = window.leadSourceOverride;
 
     try {
       if (window.useEdgeCheckout) {
+        // Edge locales submit to the new AEM Forms endpoint, not the legacy Magento REST
+        // API, so it's safe to encode the SMS channel in leadSource here.
         const payload = {
           formId: `${locale}/${language}/newsletter`,
           pageUrl: window.location.href,
           email,
           mobile,
-          smsOptIn: optIn,
+          smsOptIn,
           emailOptIn: true,
-          leadSource,
+          leadSource: getLeadSource(page, country, { emailOptIn: true, smsOptIn }),
         };
         const resp = await fetch(getFormSubmissionUrl(), {
           method: 'POST',
@@ -519,11 +519,13 @@ function enableFooterSignUp(form) {
       } else {
         // Non-edge locales still run on Magento: proxy through the AEM bin servlet,
         // which forwards to the Magento REST newsletter-subscribe API server-side.
+        // Never encode channel in leadSource here — it previously caused duplicate SMS
+        // subscriptions on Magento's side (see getLegacyLeadSource doc comment).
         const params = new URLSearchParams({
           email,
           mobile,
-          sms_optin: optIn ? '1' : '0',
-          lead_source: leadSource,
+          sms_optin: smsOptIn ? '1' : '0',
+          lead_source: getLegacyLeadSource(page, country),
           pageUrl: window.location.href,
           actionUrl: `/${locale}/${language}/rest/V1/vitamix-api/newslettersubscribe`,
         });

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -494,31 +494,48 @@ function enableFooterSignUp(form) {
       leadSource = `sub-em-${window.leadSourceOverride}-${country}`;
     }
 
-    const payload = {
-      formId: `${locale}/${language}/newsletter`,
-      pageUrl: window.location.href,
-      email,
-      mobile,
-      smsOptIn: optIn,
-      emailOptIn: true,
-      leadSource,
-    };
     try {
-      const url = getFormSubmissionUrl();
-      const resp = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      });
-      if (!resp.ok) {
+      if (window.useEdgeCheckout) {
+        const payload = {
+          formId: `${locale}/${language}/newsletter`,
+          pageUrl: window.location.href,
+          email,
+          mobile,
+          smsOptIn: optIn,
+          emailOptIn: true,
+          leadSource,
+        };
+        const resp = await fetch(getFormSubmissionUrl(), {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!resp.ok) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to submit newsletter subscription', resp);
+        }
+      } else {
+        // Non-edge locales still run on Magento: proxy through the AEM bin servlet,
+        // which forwards to the Magento REST newsletter-subscribe API server-side.
+        const params = new URLSearchParams({
+          email,
+          mobile,
+          sms_optin: optIn ? '1' : '0',
+          lead_source: leadSource,
+          pageUrl: window.location.href,
+          actionUrl: `/${locale}/${language}/rest/V1/vitamix-api/newslettersubscribe`,
+        });
+        const resp = await fetch(`https://www.vitamix.com/bin/vitamix/newslettersubscription?${params.toString()}`);
+        if (!resp.ok) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to submit newsletter subscription', resp);
+        }
+        const { data: { message } } = await resp.json();
         // eslint-disable-next-line no-console
-        console.error('Failed to submit newsletter subscription', resp);
+        console.log(message);
       }
-      const { data: { message } } = await resp.json();
-      // eslint-disable-next-line no-console
-      console.log(message);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to submit newsletter subscription', error);

--- a/scripts/lead-source.js
+++ b/scripts/lead-source.js
@@ -1,0 +1,33 @@
+/**
+ * Builds the leadSource identifier sent with marketing subscription forms submitted
+ * through the new (edge) AEM Forms endpoint. CA sites don't offer SMS enrollment, so
+ * CA always resolves to the email-only variant. US resolves to email-only, email+SMS,
+ * or SMS-only depending on the channels opted into.
+ *
+ * Only use this for submissions going to the new AEM Forms endpoint. Locales still on
+ * legacy Magento must use `getLegacyLeadSource` instead — see its doc comment for why.
+ * @param {string} page - form identifier, e.g. 'acc', 'reg', 'footer', 'modal'
+ * @param {string} country - 'us' | 'ca'
+ * @param {{ emailOptIn?: boolean, smsOptIn?: boolean }} [channels] - opted-in channels
+ * @returns {string} lead source, e.g. 'sub-emsms-acc-us'
+ */
+export function getLeadSource(page, country, { emailOptIn = true, smsOptIn = false } = {}) {
+  if (country !== 'us') return `sub-em-${page}-${country}`;
+  if (smsOptIn && emailOptIn) return `sub-emsms-${page}-us`;
+  if (smsOptIn && !emailOptIn) return `sub-sms-${page}-us`;
+  return `sub-em-${page}-us`;
+}
+
+/**
+ * Builds the leadSource identifier for submissions still going through legacy Magento.
+ * Never varies by channel — encoding SMS opt-in into leadSource there previously caused
+ * duplicate SMS subscriptions (fixed in commit f6c0267, "changing the leadsource to omit
+ * sms"). SMS consent must still be sent as its own field in the payload; it just can't be
+ * folded into this string for Magento-backed submissions.
+ * @param {string} page - form identifier, e.g. 'footer', 'modal'
+ * @param {string} country - 'us' | 'ca'
+ * @returns {string} lead source, e.g. 'sub-em-footer-us'
+ */
+export function getLegacyLeadSource(page, country) {
+  return `sub-em-${page}-${country}`;
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -238,22 +238,6 @@ export function getFormSubmissionUrl() {
 }
 
 /**
- * Builds the leadSource identifier sent with marketing subscription forms.
- * CA sites don't offer SMS enrollment, so CA always resolves to the email-only variant.
- * US resolves to email-only, email+SMS, or SMS-only depending on the channels opted into.
- * @param {string} page - form identifier, e.g. 'acc', 'reg', 'footer', 'modal'
- * @param {string} country - 'us' | 'ca'
- * @param {{ emailOptIn?: boolean, smsOptIn?: boolean }} [channels] - opted-in channels
- * @returns {string} lead source, e.g. 'sub-emsms-acc-us'
- */
-export function getLeadSource(page, country, { emailOptIn = true, smsOptIn = false } = {}) {
-  if (country !== 'us') return `sub-em-${page}-${country}`;
-  if (smsOptIn && emailOptIn) return `sub-emsms-${page}-us`;
-  if (smsOptIn && !emailOptIn) return `sub-sms-${page}-us`;
-  return `sub-em-${page}-us`;
-}
-
-/**
  * Parses `document.cookie` into key-value map.
  * @returns {Object} Object representing all cookies as key-value pairs
  */

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -238,6 +238,22 @@ export function getFormSubmissionUrl() {
 }
 
 /**
+ * Builds the leadSource identifier sent with marketing subscription forms.
+ * CA sites don't offer SMS enrollment, so CA always resolves to the email-only variant.
+ * US resolves to email-only, email+SMS, or SMS-only depending on the channels opted into.
+ * @param {string} page - form identifier, e.g. 'acc', 'reg', 'footer', 'modal'
+ * @param {string} country - 'us' | 'ca'
+ * @param {{ emailOptIn?: boolean, smsOptIn?: boolean }} [channels] - opted-in channels
+ * @returns {string} lead source, e.g. 'sub-emsms-acc-us'
+ */
+export function getLeadSource(page, country, { emailOptIn = true, smsOptIn = false } = {}) {
+  if (country !== 'us') return `sub-em-${page}-${country}`;
+  if (smsOptIn && emailOptIn) return `sub-emsms-${page}-us`;
+  if (smsOptIn && !emailOptIn) return `sub-sms-${page}-us`;
+  return `sub-em-${page}-us`;
+}
+
+/**
  * Parses `document.cookie` into key-value map.
  * @returns {Object} Object representing all cookies as key-value pairs
  */

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -698,7 +698,7 @@ test.describe('PDP Integration Tests', () => {
       {
         modal: false,
         smsOptin: true,
-        leadSource: 'sub-em-footer-us',
+        leadSource: 'sub-emsms-footer-us',
         pageUrl: '/us/en_us/products/20-ounce-travel-cup',
       },
       {
@@ -710,7 +710,7 @@ test.describe('PDP Integration Tests', () => {
       {
         modal: true,
         smsOptin: true,
-        leadSource: 'sub-em-modal-us',
+        leadSource: 'sub-emsms-modal-us',
         pageUrl: '/us/en_us/products/20-ounce-travel-cup',
       },
     ];

--- a/widgets/account/account.js
+++ b/widgets/account/account.js
@@ -7,7 +7,8 @@ import {
   renderAccountOrderList,
   unwrapPayload,
 } from './account-api.js';
-import { getFormSubmissionUrl, getLocaleAndLanguage, getLeadSource } from '../../scripts/scripts.js';
+import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getLeadSource } from '../../scripts/lead-source.js';
 import { getUser, logout } from '../../scripts/auth-api.js';
 
 /** Select option value for sign out (not a content section). */

--- a/widgets/account/account.js
+++ b/widgets/account/account.js
@@ -7,7 +7,7 @@ import {
   renderAccountOrderList,
   unwrapPayload,
 } from './account-api.js';
-import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getFormSubmissionUrl, getLocaleAndLanguage, getLeadSource } from '../../scripts/scripts.js';
 import { getUser, logout } from '../../scripts/auth-api.js';
 
 /** Select option value for sign out (not a content section). */
@@ -208,7 +208,7 @@ export default async function decorate(widget) {
       const nextEmail = next.emailOptIn !== undefined ? next.emailOptIn : emailOptInStatus;
       const nextSms = next.smsOptIn !== undefined ? next.smsOptIn : smsOptInStatus;
       const country = window.location.pathname.split('/')[1] || 'us';
-      const leadSource = `sub-em-account-${country}`;
+      const leadSource = getLeadSource('acc', country, { emailOptIn: nextEmail, smsOptIn: nextSms });
       const payload = {
         formId: `${locale}/${language}/newsletter`,
         pageUrl: window.location.href,

--- a/widgets/forms/product-registration.js
+++ b/widgets/forms/product-registration.js
@@ -1,4 +1,4 @@
-import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getFormSubmissionUrl, getLocaleAndLanguage, getLeadSource } from '../../scripts/scripts.js';
 import getStatesProvincesOptions from './states-provinces.js';
 
 /**
@@ -166,6 +166,9 @@ export default async function decorate(widget) {
     const payload = Object.fromEntries(data.entries());
     payload.formId = `${locale}/${language}/product-registration`;
     payload.pageUrl = window.location.href;
+    // Registration doesn't offer an SMS-only path, so email is always treated as opted in.
+    const smsOptIn = payload.smsOptIn === 'yes';
+    payload.leadSource = getLeadSource('reg', (locale || 'us').toLowerCase(), { emailOptIn: true, smsOptIn });
 
     const submitButton = form.querySelector('button[type="submit"]');
     const buttonLabel = submitButton?.textContent;

--- a/widgets/forms/product-registration.js
+++ b/widgets/forms/product-registration.js
@@ -166,9 +166,9 @@ export default async function decorate(widget) {
     const payload = Object.fromEntries(data.entries());
     payload.formId = `${locale}/${language}/product-registration`;
     payload.pageUrl = window.location.href;
-    // Registration doesn't offer an SMS-only path, so email is always treated as opted in.
-    const smsOptIn = payload.smsOptIn === 'yes';
-    payload.leadSource = getLeadSource('reg', (locale || 'us').toLowerCase(), { emailOptIn: true, smsOptIn });
+    // Registration's leadSource never varies by channel — SMS consent is carried solely
+    // by the separate smsOptIn field, matching production Magento's behavior.
+    payload.leadSource = getLeadSource('reg', (locale || 'us').toLowerCase());
 
     const submitButton = form.querySelector('button[type="submit"]');
     const buttonLabel = submitButton?.textContent;

--- a/widgets/forms/product-registration.js
+++ b/widgets/forms/product-registration.js
@@ -1,4 +1,5 @@
-import { getFormSubmissionUrl, getLocaleAndLanguage, getLeadSource } from '../../scripts/scripts.js';
+import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/scripts.js';
+import { getLeadSource } from '../../scripts/lead-source.js';
 import getStatesProvincesOptions from './states-provinces.js';
 
 /**
@@ -166,9 +167,15 @@ export default async function decorate(widget) {
     const payload = Object.fromEntries(data.entries());
     payload.formId = `${locale}/${language}/product-registration`;
     payload.pageUrl = window.location.href;
-    // Registration's leadSource never varies by channel — SMS consent is carried solely
-    // by the separate smsOptIn field, matching production Magento's behavior.
-    payload.leadSource = getLeadSource('reg', (locale || 'us').toLowerCase());
+    // Registration submits only to the new AEM Forms endpoint (no legacy Magento path),
+    // so the channel-suppression concern that applies to Magento-backed forms doesn't
+    // apply here — SMS opt-in is safe to encode in the leadSource. Registration has no
+    // SMS-only path (email is always part of registering a product), so email is
+    // always treated as opted in; only the SMS checkbox varies the channel.
+    payload.leadSource = getLeadSource('reg', (locale || 'us').toLowerCase(), {
+      emailOptIn: true,
+      smsOptIn: payload.smsOptIn === 'yes',
+    });
 
     const submitButton = form.querySelector('button[type="submit"]');
     const buttonLabel = submitButton?.textContent;


### PR DESCRIPTION
## Summary

- **Account** (`widgets/account/account.js`): replaced the hardcoded `sub-em-account-{country}` leadSource with a shared `getLeadSource()` helper, producing `sub-em-acc-{ca|us}`, `sub-emsms-acc-us`, or `sub-sms-acc-us` based on the user's live email/SMS opt-in state.
- **Product registration** (`widgets/forms/product-registration.js`): previously sent **no `leadSource` at all**. Now sends `sub-em-reg-{ca|us}` or `sub-emsms-reg-us` based on the SMS consent checkbox (email is always treated as opted in, so there's no SMS-only variant, matching a confirmed real Magento request where `pagetype` stayed `sub-em-reg-us` even with SMS checked). No legacy Magento fallback — the real Magento registration endpoint needs a session-bound `form_key` CSRF token and a completely different field schema, which we deliberately didn't replicate.
- **Footer / newsletter modal / minimized-modal teaser** (`blocks/form/form.js`): `enableFooterSignUp` now branches on `window.useEdgeCheckout` (the same flag/locale list checkout already uses via `EDGE_CHECKOUT_LOCALES`). Edge locales POST JSON to the new AEM Forms endpoint with a channel-aware leadSource (`sub-em-`/`sub-emsms-`/`sub-sms-`). Non-edge locales fall back to the legacy AEM `/bin/vitamix/newslettersubscription` servlet → Magento REST proxy, which never varies leadSource by channel (this protects against a historical duplicate-SMS-subscription bug that channel-encoding caused on the Magento side).
- New `scripts/lead-source.js` module — `getLeadSource()` (channel-aware, edge-only) and `getLegacyLeadSource()` (always email-only, Magento-safe) — kept out of `scripts/scripts.js` so it isn't loaded on every page, only by the forms that need it.
- `tests/pdp/integration.spec.js` updated: SMS-opted-in footer/modal cases now expect `sub-emsms-footer-us`/`sub-emsms-modal-us` instead of `sub-em-*`.

## Not in scope for this PR

- **Blender Recommender's own newsletter modal** (`widgets/blender-recommender/blender-recommender.js`) is untouched — still hardcoded literal `sub-em-modal-us`/`sub-em-modal-ca`, always posts directly to the legacy Magento REST endpoint, no locale routing, inconsistent snake_case `lead_source` payload key.
- **Cloud page** lead source has no implementation anywhere in this repo; out of scope.
- Footer/modal/minimized-modal still can't produce `sub-sms-*` (SMS-only) in practice — `emailOptIn: true` is hardcoded there, so that variant is unreachable even though the helper supports it. Flagged for a follow-up.

## Test URLs (aem.page, this branch)

Most of these forms are global components (header account icon, page footer, newsletter modal/minimized-modal teaser) and can be exercised from any page, including the homepage:

- **US**: https://leadsource-fix--vitamix--aemsites.aem.page/us/en_us/
- **CA (EN)**: https://leadsource-fix--vitamix--aemsites.aem.page/ca/en_us/
- **CA (FR)**: https://leadsource-fix--vitamix--aemsites.aem.page/ca/fr_ca/

On any of the above:
- **Account**: click the header account icon (opens the OTP/account drawer — edge locales only).
- **Footer signup**: scroll to the page footer.
- **Newsletter modal**: click the newsletter link that opens `/modals/sign-up`.
- **Minimized-modal teaser**: the collapsed teaser that appears after the modal is dismissed (governed by a `newsletterMinimized` placeholder + `localStorage`).

**Product registration** (confirmed path via a captured Magento request):
- **US**: https://leadsource-fix--vitamix--aemsites.aem.page/us/en_us/customer-service/product-registration
- **CA (EN)**: https://leadsource-fix--vitamix--aemsites.aem.page/ca/en_us/customer-service/product-registration
- **CA (FR)**: https://leadsource-fix--vitamix--aemsites.aem.page/ca/fr_ca/customer-service/product-registration

**Testing the legacy Magento branch**: all three currently-live locale/language pairs (`us/en_us`, `ca/en_us`, `ca/fr_ca`) are already in `EDGE_CHECKOUT_LOCALES`, so there's no live locale that exercises the legacy footer/modal path today. Force it for QA with `?cart=magento` appended to any of the URLs above (mirrors how checkout's edge/legacy toggle is already tested).

**Blender Recommender** page URL not included — out of scope for this PR (see above).

## Testing

- `npm run lint:js` — clean
- `npm run test:unit` — 357/357 passing
- Playwright e2e newsletter tests weren't runnable in the sandboxed dev environment (no network access to the live preview deployment), but `us/en_us` is in `EDGE_CHECKOUT_LOCALES` so `window.useEdgeCheckout` defaults `true` there, keeping the test assertions on the same code path (updated to reflect the new channel-aware leadSource values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)