### PR TITLE
feat: add marketing tile styling to product-row

### DIFF
--- a/blocks/product-row/product-row.css
+++ b/blocks/product-row/product-row.css
@@ -81,6 +81,7 @@
 .product-row li.carousel-slide {
   cursor: pointer;
   height: auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -102,6 +103,12 @@
 .product-row .slide-image img {
   display: block;
   border-radius: var(--rounding-m);
+}
+
+.product-row .slide-image img {
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  width: 100%;
 }
 
 .product-row .slide-body {
@@ -221,4 +228,48 @@
 
 .product-row .save {
   white-space: nowrap;
+}
+
+/* marketing slide */
+.product-row .carousel-slide.marketing .slide-image picture,
+.product-row .carousel-slide.marketing .slide-image img {
+  border-radius: 0;
+}
+
+.product-row .carousel-slide.marketing .slide-image img {
+  aspect-ratio: 3 / 4;
+}
+
+.product-row .carousel-slide.marketing .slide-body {
+  justify-content: center;
+  padding: var(--spacing-l);
+  background-color: var(--marketing-color, var(--color-charcoal));
+}
+
+.product-row .carousel-slide.marketing .slide-body > :first-child {
+  margin-top: 0;
+}
+
+.product-row .carousel-slide.marketing .slide-body > :last-child {
+  margin-bottom: 0;
+}
+
+.product-row .carousel-slide.marketing .slide-body.dark {
+  color: var(--color-white);
+}
+
+.product-row .carousel-slide.marketing .slide-body.light {
+  color: var(--color-charcoal);
+}
+
+.product-row .carousel-slide.marketing .slide-body.dark .button {
+  border-color: var(--color-white);
+  background-color: transparent;
+  color: var(--color-white);
+}
+
+.product-row .carousel-slide.marketing .slide-body.light .button {
+  border-color: var(--color-charcoal);
+  background-color: transparent;
+  color: var(--color-charcoal);
 }

--- a/blocks/product-row/product-row.css
+++ b/blocks/product-row/product-row.css
@@ -100,12 +100,14 @@
 }
 
 .product-row .slide-image picture,
-.product-row .slide-image img {
+.product-row .slide-image img,
+.product-row .slide-image video {
   display: block;
   border-radius: var(--rounding-m);
 }
 
-.product-row .slide-image img {
+.product-row .slide-image img,
+.product-row .slide-image video {
   aspect-ratio: 1 / 1;
   object-fit: cover;
   width: 100%;
@@ -232,11 +234,13 @@
 
 /* marketing slide */
 .product-row .carousel-slide.marketing .slide-image picture,
-.product-row .carousel-slide.marketing .slide-image img {
+.product-row .carousel-slide.marketing .slide-image img,
+.product-row .carousel-slide.marketing .slide-image video {
   border-radius: 0;
 }
 
-.product-row .carousel-slide.marketing .slide-image img {
+.product-row .carousel-slide.marketing .slide-image img,
+.product-row .carousel-slide.marketing .slide-image video {
   aspect-ratio: 3 / 4;
 }
 

--- a/blocks/product-row/product-row.js
+++ b/blocks/product-row/product-row.js
@@ -2,7 +2,7 @@
 import {
   fetchPlaceholders, toClassName, buildBlock, decorateBlock, loadBlock,
 } from '../../scripts/aem.js';
-import { getLocaleAndLanguage, formatPrice } from '../../scripts/scripts.js';
+import { getLocaleAndLanguage, formatPrice, buildVideo } from '../../scripts/scripts.js';
 import {
   createCallouts, createStarRating, fetchReviewsData, getReviewsBySlug, slugFromUrl,
 } from '../../scripts/product-badges.js';
@@ -304,6 +304,23 @@ async function resolveRowProduct(row) {
 }
 
 /**
+ * Converts an authored `.mp4` link in the image cell into a video.
+ * @param {HTMLElement} image - Row's image cell
+ * @returns {HTMLVideoElement|null} Created video, or null if no video link was found
+ */
+function buildRowVideo(image) {
+  const picture = image.querySelector('picture');
+  const video = buildVideo(image);
+  if (!video) return null;
+  if (picture) {
+    const img = picture.querySelector('img');
+    if (img) video.poster = img.src;
+    picture.remove();
+  }
+  return video;
+}
+
+/**
  * Transforms one authored row into a styled slide populated with the resolved product's data.
  * @param {HTMLElement} row - Row element containing image and body cells
  * @param {Object} ph - Placeholder object with localized text/badge labels
@@ -311,6 +328,7 @@ async function resolveRowProduct(row) {
  */
 async function styleRowAsSlide(row, ph) {
   const [image, body] = row.children;
+  const video = buildRowVideo(image);
 
   const product = await resolveRowProduct(row);
   if (!product) {
@@ -324,8 +342,10 @@ async function styleRowAsSlide(row, ph) {
   const description = body.firstElementChild;
   if (description) description.classList.add('description');
 
-  const img = image.querySelector('picture') || createProductImage(product);
-  image.replaceChildren(img);
+  if (!video) {
+    const img = image.querySelector('picture') || createProductImage(product);
+    image.replaceChildren(img);
+  }
   const badges = createCallouts(product, ph);
   if (badges.children.length > 0) image.append(badges);
 

--- a/blocks/product-row/product-row.js
+++ b/blocks/product-row/product-row.js
@@ -277,6 +277,33 @@ function createShopNowButton(product, ph) {
 }
 
 /**
+ * Resolves an authored row's link (if any) to a product, or null if the row is not a product
+ * @param {HTMLElement} row - Row element containing image and body cells
+ * @returns {Promise<Object|null>} Resolved product, or null
+ */
+async function resolveRowProduct(row) {
+  const [, body] = row.children;
+  if (!body) return null;
+
+  const link = body.querySelector('a[href]');
+  if (!link) return null;
+
+  let pathname;
+  try {
+    pathname = new URL(link.href, window.location.origin).pathname;
+  } catch {
+    return null;
+  }
+
+  const [product] = await lookupProducts([pathname]);
+  if (!product) {
+    link.classList.add('linkchecker-invalid-link');
+    return null;
+  }
+  return product;
+}
+
+/**
  * Transforms one authored row into a styled slide populated with the resolved product's data.
  * @param {HTMLElement} row - Row element containing image and body cells
  * @param {Object} ph - Placeholder object with localized text/badge labels
@@ -284,23 +311,14 @@ function createShopNowButton(product, ph) {
  */
 async function styleRowAsSlide(row, ph) {
   const [image, body] = row.children;
-  if (!body) return;
+
+  const product = await resolveRowProduct(row);
+  if (!product) {
+    row.classList.add('marketing');
+    return;
+  }
 
   const link = body.querySelector('a[href]');
-  if (!link) return;
-
-  let pathname;
-  try {
-    pathname = new URL(link.href, window.location.origin).pathname;
-  } catch {
-    return;
-  }
-
-  const [product] = await lookupProducts([pathname]);
-  if (!product) {
-    link.classList.add('linkchecker-invalid-link');
-    return;
-  }
   link.parentElement.remove();
 
   const description = body.firstElementChild;
@@ -359,12 +377,48 @@ function classifySlideCells(row) {
 }
 
 /**
+ * Returns the perceived luminance (0-255) of an element's computed background color.
+ * @param {Element} el - Element with a resolved background-color
+ * @returns {number}
+ */
+function getLuminance(el) {
+  const [r, g, b] = getComputedStyle(el).backgroundColor.match(/\d+/g).map(Number);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
+/**
+ * Finds a block variant matching a defined `--color-*` custom property.
+ * @param {HTMLElement} block - product-row block element
+ * @returns {string|undefined} Matching color token, if any
+ */
+function getMarketingColor(block) {
+  return [...block.classList].find(
+    (c) => getComputedStyle(document.documentElement).getPropertyValue(`--color-${c}`).trim(),
+  );
+}
+
+/**
+ * Sets the marketing tile's background to the block's color variant (or charcoal by default),
+ * then adds a `light`/`dark` class to the slide body so text stays readable against it.
+ * @param {HTMLElement} li - Marketing slide element, already inserted into the document
+ * @param {string} colorOverride - Color token matching a --color-* custom property, or undefined
+ */
+function applyMarketingColor(li, colorOverride) {
+  const body = li.querySelector(':scope > .slide-body');
+  if (!body) return;
+  body.style.setProperty('--marketing-color', `var(--color-${colorOverride || 'charcoal'})`);
+  const luminance = getLuminance(body);
+  body.classList.add(luminance > 128 ? 'light' : 'dark');
+}
+
+/**
  * Transforms each row into a styled slide and wraps them in a generic carousel block.
  * @param {HTMLElement} block - product-row block element with product rows
  * @param {Object} ph - Placeholder object with localized text/badge labels
+ * @param {string} colorOverride - Color token for marketing tiles, or undefined
  * @returns {Promise<void>}
  */
-async function buildProductRowCarousel(block, ph) {
+async function buildProductRowCarousel(block, ph, colorOverride) {
   const rows = [...block.children];
   await Promise.all(rows.map((row) => styleRowAsSlide(row, ph)));
 
@@ -379,6 +433,15 @@ async function buildProductRowCarousel(block, ph) {
   block.replaceWith(carousel);
   decorateBlock(carousel);
   await loadBlock(carousel);
+
+  const slides = [...carousel.querySelectorAll(':scope > ul > li.carousel-slide')];
+  rows.forEach((row, i) => {
+    if (row.classList.contains('marketing') && slides[i]) {
+      slides[i].classList.add('marketing');
+      applyMarketingColor(slides[i], colorOverride);
+    }
+  });
+
   wireSlideClicks(carousel);
 }
 
@@ -386,30 +449,38 @@ async function buildProductRowCarousel(block, ph) {
  * Transforms each row into a styled slide and lays them out in a static, non-scrolling grid.
  * @param {HTMLElement} block - product-row block element with product rows
  * @param {Object} ph - Placeholder object with localized text/badge labels
+ * @param {string} colorOverride - Color token for marketing tiles, or undefined
  * @returns {Promise<void>}
  */
-async function buildProductRowGrid(block, ph) {
+async function buildProductRowGrid(block, ph, colorOverride) {
   const rows = [...block.children];
   await Promise.all(rows.map((row) => styleRowAsSlide(row, ph)));
   rows.forEach(classifySlideCells);
 
   const ul = document.createElement('ul');
+  const marketingSlides = [];
 
   rows.forEach((row) => {
     const li = document.createElement('li');
     li.className = 'carousel-slide';
+    if (row.classList.contains('marketing')) {
+      li.classList.add('marketing');
+      marketingSlides.push(li);
+    }
     li.append(...row.children);
     ul.append(li);
   });
 
   block.replaceChildren(ul);
+  marketingSlides.forEach((li) => applyMarketingColor(li, colorOverride));
   wireSlideClicks(block);
 }
 
 export default async function decorate(block) {
   const { locale, language } = getLocaleAndLanguage();
   const ph = await fetchPlaceholders(`/${locale}/${language}/products/config`);
+  const colorOverride = getMarketingColor(block);
   const isCarousel = block.classList.contains('carousel');
-  if (isCarousel) await buildProductRowCarousel(block, ph);
-  else await buildProductRowGrid(block, ph);
+  if (isCarousel) await buildProductRowCarousel(block, ph, colorOverride);
+  else await buildProductRowGrid(block, ph, colorOverride);
 }


### PR DESCRIPTION
Adds support for non-product "marketing" content mixed into product-row grids/carousels. Rows without a resolvable product link now render as a styled tile: same card size, colored panel (defaults to charcoal, or the block's color variant if set), with light/dark text auto-contrasted the same way `banner.js` already does it.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/homepage-updates
- After: https://product-row-marketing--vitamix--aemsites.aem.page/us/en_us/drafts/fkakatie/homepage-updates
