### PR TITLE
fix: remove redundant root wrapper div from self-named widget fragments

### DIFF
--- a/widgets/article-center/article-center.html
+++ b/widgets/article-center/article-center.html
@@ -1,5 +1,3 @@
-<script type="module" src="/widgets/article-center/article-center.js"></script>
-<div class="article-center">
   <form class="controls" aria-label="Article search">
     <div class="search">
       <input id="fulltext" type="search" aria-label="Search articles" placeholder="">
@@ -25,4 +23,3 @@
   </div>
   <ul class="results"></ul>
   <nav class="pagination"></nav>
-</div>

--- a/widgets/press-center/press-center.html
+++ b/widgets/press-center/press-center.html
@@ -1,5 +1,3 @@
-<script type="module" src="/widgets/press-center/press-center.js"></script>
-<div class="press-center">
   <form class="controls" aria-label="Press release search">
     <div class="search">
       <input id="fulltext" type="search" aria-label="Search press releases" placeholder="">
@@ -25,4 +23,3 @@
   </div>
   <ul class="results"></ul>
   <nav class="pagination"></nav>
-</div>

--- a/widgets/sales-plp/sales-plp.html
+++ b/widgets/sales-plp/sales-plp.html
@@ -1,5 +1,3 @@
-<div class="sales-plp">
   <p class="sales-plp-results-count"><span id="sales-plp-results-count">0</span> <span class="sales-plp-results-label"></span></p>
   <div class="plp-results" role="list"></div>
   <p class="sales-plp-empty" hidden></p>
-</div>

--- a/widgets/search-results/search-results.html
+++ b/widgets/search-results/search-results.html
@@ -1,5 +1,3 @@
-<script type="module" src="/widgets/search-results/search-results.js"></script>
-<div class="search-results">
   <form class="controls" aria-label="Search">
     <div class="search">
       <input id="fulltext" type="search" aria-label="Search" placeholder="">
@@ -16,4 +14,3 @@
   </div>
   <ul class="results"></ul>
   <nav class="pagination"></nav>
-</div>


### PR DESCRIPTION
## Problem

Several widget fragments wrap their content in a `<div>` using the same class name as the widget's own folder (e.g. `<div class="article-center">` inside `widgets/article-center/article-center.html`). `blocks/widget/widget.js`'s `decorate()` already stamps that same class (`cssPrefix`) onto the outer `.widget` block element before/around injecting the fragment's HTML — so these widgets end up with **two nested elements sharing one class name**.

This is exactly what caused the recipe-center regression (`cde6217`, fixed separately): any CSS keyed to that shared class (`grid-template-areas`, negative margins, `>` child selectors, etc.) matches both the outer wrapper and the inner fragment root, and can silently break layout — see the recipe-center incident where the outer element became a grid container whose only real content was an unlabeled, auto-placed inner div, collapsing the whole widget to a sliver at desktop widths.

This PR applies the same fix pattern to the other widgets with the identical structural issue: `article-center`, `press-center`, `search-results`, and `sales-plp`.

## Changes

- Removes the redundant root `<div class="{widget-name}">` wrapper from each fragment's HTML, so the fragment's real content becomes the *direct* children of the outer `.widget` block (matching the pattern already used correctly by `product-list`, `compare-products`, `support-search`, etc., which use a distinct root class like `product-list-widget`).
- Removes the dead `<script type="module" src="...">` tags in `article-center.html`, `press-center.html`, and `search-results.html` — scripts inserted via `innerHTML` never execute in the browser, so these were inert markup left over from copy-paste; the module is already loaded via `widget.js`'s dynamic `import()`.
- `sales-plp.html` had no `<script>` tag, only the wrapper div.

None of these four widgets currently key layout CSS off their own top-level class the way recipe-center did, so this isn't a visible bug fix today — it's removing the same latent structural landmine before a future CSS change (grid, negative margins, child selectors) trips over it again.

## Verification

Checked each widget's JS for anything that depended on the removed wrapper or script tag — all of them resolve their root via `document.querySelector('.{name}')` or receive the widget element directly as a function argument, both of which work correctly (and more correctly) once there's only one matching element. Verified live locally: `/articles` now renders with exactly one `.article-center` element (full width, all real children present) instead of a nested pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)