### PR TITLE
fix(pdp): scope secondary dealer CTA to commercial products

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -135,6 +135,9 @@ export default function renderAddToCart(ph, block, parent) {
   // Authored overrides win over the product bus custom values.
   const findLocally = getPdpOverride('findLocally') || parent.custom.findLocally;
   const findDealer = getPdpOverride('findDealer') || parent.custom.findDealer;
+  // The commercial flag comes from the product bus (same signal used by the
+  // resources tab) and scopes the secondary dealer CTA to commercial products.
+  const { isCommercial } = parent.custom;
   block.classList.remove('pdp-find-locally');
   block.classList.remove('pdp-find-dealer');
 
@@ -285,7 +288,10 @@ export default function renderAddToCart(ph, block, parent) {
   addToCartContainer.appendChild(quantityContainer);
 
   // Saleable commercial products keep the dealer CTA as a secondary action.
-  if (findDealer === 'Yes') {
+  // Gate on isCommercial so non-commercial products (e.g. bundles) that carry
+  // findDealer=Yes in the product bus don't surface the dealer button alongside
+  // Add to Cart when they are in stock.
+  if (findDealer === 'Yes' && isCommercial) {
     addToCartContainer.classList.add('pdp-add-to-cart-with-dealer');
     appendFindDealerCta(ph, addToCartContainer, true);
   }

--- a/tests/pdp/integration.spec.js
+++ b/tests/pdp/integration.spec.js
@@ -346,6 +346,7 @@ test.describe('PDP Integration Tests', () => {
               findLocally: 'No',
               findDealer: 'Yes',
               comingSoon: 'No',
+              isCommercial: true,
             },
           };
           saleableHost.append(renderAddToCart(ph, saleableHost, saleableProduct));
@@ -362,11 +363,31 @@ test.describe('PDP Integration Tests', () => {
               findLocally: 'No',
               findDealer: 'Yes',
               comingSoon: 'No',
+              isCommercial: true,
             },
           };
           unavailableHost.append(renderAddToCart(ph, unavailableHost, unavailableProduct));
 
-          document.querySelector('main').append(saleableHost, unavailableHost);
+          // A saleable, non-commercial product (e.g. a bundle) that carries
+          // findDealer=Yes in the product bus must NOT show the dealer CTA
+          // because it is not flagged commercial.
+          const nonCommercialHost = document.createElement('div');
+          nonCommercialHost.classList.add('pdp', 'noncommercial-saleable');
+          const nonCommercialProduct = {
+            offers: [{
+              sku: 'noncommercial-saleable',
+              custom: { managedStock: '0', addToCart: 'Yes', comingSoon: 'No' },
+            }],
+            custom: {
+              type: 'bundle',
+              findLocally: 'No',
+              findDealer: 'Yes',
+              comingSoon: 'No',
+            },
+          };
+          nonCommercialHost.append(renderAddToCart(ph, nonCommercialHost, nonCommercialProduct));
+
+          document.querySelector('main').append(saleableHost, unavailableHost, nonCommercialHost);
           window.selectedVariant = selectedVariant;
         });
 
@@ -396,6 +417,13 @@ test.describe('PDP Integration Tests', () => {
         await expect(unavailable.locator('.quantity-container')).toHaveCount(0);
         await expect(unavailableDealerButton).toHaveClass(/emphasis/);
         await expect(unavailableDealerButton).toHaveAttribute('href', dealerUrl);
+
+        // Non-commercial saleable product: Add to Cart shows, but no dealer CTA.
+        const nonCommercial = page.locator('.noncommercial-saleable');
+        await expect(nonCommercial.locator('.quantity-container button')).toBeVisible();
+        await expect(nonCommercial.locator('.pdp-find-dealer-button')).toHaveCount(0);
+        await expect(nonCommercial.locator('.add-to-cart')).not.toHaveClass(/pdp-add-to-cart-with-dealer/);
+        await expect(nonCommercial).not.toHaveClass(/pdp-find-dealer/);
       },
     );
   });


### PR DESCRIPTION
The saleable dealer CTA rendered next to Add to Cart keyed only on findDealer=Yes, so non-commercial products that carry that flag in the product bus (e.g. the Ascent X5 SmartPrep bundle) showed a Find Dealer button while in stock. Gate the secondary CTA on custom.isCommercial — the same commercial signal the resources tab uses — so only commercial products get it. The out-of-stock dealer fallback is unchanged.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/ca/en_us/products/ascent-x5-smartprep-kitchen-system
- After: https://fix-pdp-commercial-dealer-cta--vitamix--aemsites.aem.network/ca/en_us/products/ascent-x5-smartprep-kitchen-system
