### PR TITLE
fix(checkout): route PayPal review fraud declines to the cancelled page

### DIFF
--- a/blocks/order-review/order-review.js
+++ b/blocks/order-review/order-review.js
@@ -69,13 +69,17 @@ export function isOrderNotConfirmable(err) {
  * @param {(message: string) => void} deps.onError
  * @param {() => void} [deps.onNotConfirmable] - called when the order can no
  *   longer be confirmed (cancelled/expired) so retrying is futile
+ * @param {() => void} [deps.onFraudDeclined] - called when the confirm was
+ *   declined by post-authorization fraud review (reason=fraud_declined) so the
+ *   buyer is routed to the order-cancelled page with the Customer Care copy
+ *   rather than bounced to the cart
  * @param {(busy: boolean) => void} [deps.setBusy]
  * @param {string} deps.errorMessage
  * @param {() => string} [deps.newKey]
  * @returns {() => Promise<void>}
  */
 export function createConfirmHandler({
-  orderId, confirm, routeTo, onError, onNotConfirmable, setBusy, errorMessage,
+  orderId, confirm, routeTo, onError, onNotConfirmable, onFraudDeclined, setBusy, errorMessage,
   newKey = newIdempotencyKey,
 }) {
   return async () => {
@@ -85,7 +89,18 @@ export function createConfirmHandler({
       const result = await confirm(orderId, idempotencyKey);
       const { action } = resolveConfirmResult(result);
       if (action === 'failed') {
-        // A `cancelled` failure is terminal — the order was moved to
+        // A post-authorization fraud decline (Forter) is terminal: the order was
+        // moved to payment_cancelled server-side. Route to the order-cancelled
+        // page with reason=fraud_declined so the buyer sees the neutral Customer
+        // Care copy — matching the redirect-based card/wallet flows — instead of
+        // being bounced to the cart with a generic "expired" message. Checked
+        // before the generic `cancelled` branch because fraud declines also carry
+        // `cancelled: true`.
+        if (result?.reason === 'fraud_declined' && onFraudDeclined) {
+          onFraudDeclined();
+          return;
+        }
+        // Any other `cancelled` failure is terminal — the order was moved to
         // payment_cancelled server-side, so retrying is futile. Route back to
         // the cart (same as the 422 order_not_confirmable path) instead of a
         // stay-and-retry error. A failure without `cancelled` is a soft decline
@@ -605,6 +620,16 @@ export default async function decorate(block) {
       window.location.href = config.getOrderPath('cart');
     }, 3000);
   };
+  // A post-authorization fraud decline is terminal. Route to the order-cancelled
+  // page with reason=fraud_declined so the buyer gets the neutral Customer Care
+  // copy (matching Chase / Apple Pay), instead of a generic cart bounce.
+  const onFraudDeclined = () => {
+    finalized = true;
+    logOperation('checkout-failed', {
+      checkoutId: getCheckoutId(), orderId, reason: 'fraud_declined',
+    });
+    window.location.href = `${config.getOrderPath('cancel')}?orderId=${encodeURIComponent(orderId)}&reason=fraud_declined`;
+  };
 
   completeBtn.addEventListener('click', createConfirmHandler({
     orderId,
@@ -612,6 +637,7 @@ export default async function decorate(block) {
     routeTo: routeToComplete,
     onError: showError,
     onNotConfirmable,
+    onFraudDeclined,
     setBusy,
     errorMessage: s.reviewCompleteError,
   }));

--- a/tests/order/order-review-page.spec.js
+++ b/tests/order/order-review-page.spec.js
@@ -112,6 +112,9 @@ async function setupReviewMocks(page, overrides = {}) {
   await page.route('**/us/en_us/order/cart*', (route) => route.fulfill({
     status: 200, contentType: 'text/html', body: '<!doctype html><html><body><h1>Cart (stub)</h1></body></html>',
   }));
+  await page.route('**/us/en_us/order/cancel*', (route) => route.fulfill({
+    status: 200, contentType: 'text/html', body: '<!doctype html><html><body><h1>Order cancelled (stub)</h1></body></html>',
+  }));
 }
 
 async function gotoReview(page, baseUrl, orderId = MOCK_ORDER_ID) {
@@ -286,6 +289,31 @@ test.describe('Order review page (display-only)', () => {
       await expect(page.locator('.order-review-error')).toContainText(/expired or been cancelled/i, { timeout: 10000 });
       await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/order\/cart/);
       console.log('✓ Failed + cancelled:true → clear message → cart');
+    });
+
+    test('a fraud_declined confirm routes to the order-cancelled page (Customer Care copy)', async ({ page }) => {
+      await setupReviewMocks(page, {
+        confirm: async (route) => {
+          // Forter decline: the confirm endpoint returns 200 with
+          // reason=fraud_declined and cancelled:true (order moved to
+          // payment_cancelled server-side).
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ status: 'failed', reason: 'fraud_declined', cancelled: true }),
+          });
+        },
+      });
+      await gotoReview(page, baseUrl);
+
+      await expect(page.locator('.order-review-complete')).toBeVisible({ timeout: 15000 });
+      await page.locator('.order-review-complete').click();
+
+      // Routed to the order-cancelled page with reason=fraud_declined (matching
+      // the redirect-based card/wallet flows) rather than bounced to the cart.
+      await expect.poll(() => page.url(), { timeout: 15000 })
+        .toMatch(/\/order\/cancel\?.*reason=fraud_declined/);
+      console.log('✓ Fraud decline → /order/cancel?reason=fraud_declined');
     });
 
     test('a cancelled/expired order shows a clear message and returns to the cart', async ({ page }) => {

--- a/tests/unit/order-review.test.js
+++ b/tests/unit/order-review.test.js
@@ -216,6 +216,41 @@ describe('createConfirmHandler', () => {
     assert.equal(errored, 'Your card was declined.');
     assert.deepEqual(busy, [true, false]);
   });
+
+  test('routes a fraud_declined result to the fraud handler, not the cart or a generic error', async () => {
+    let errored = null;
+    let notConfirmable = false;
+    let fraudDeclined = false;
+    const handler = createConfirmHandler({
+      orderId: 'o',
+      // The confirm endpoint returns a 200 with reason=fraud_declined and
+      // cancelled:true when Forter declines the capture.
+      confirm: async () => ({ status: 'failed', reason: 'fraud_declined', cancelled: true }),
+      routeTo: () => {},
+      onError: (msg) => { errored = msg; },
+      onNotConfirmable: () => { notConfirmable = true; },
+      onFraudDeclined: () => { fraudDeclined = true; },
+      errorMessage: 'fallback message',
+    });
+    await handler();
+    assert.equal(fraudDeclined, true); // routed to the order-cancelled page
+    assert.equal(notConfirmable, false); // NOT the generic cart bounce
+    assert.equal(errored, null); // terminal: no stay-and-retry error
+  });
+
+  test('falls back to the cancelled path for fraud_declined when no fraud handler is wired', async () => {
+    let notConfirmable = false;
+    const handler = createConfirmHandler({
+      orderId: 'o',
+      confirm: async () => ({ status: 'failed', reason: 'fraud_declined', cancelled: true }),
+      routeTo: () => {},
+      onError: () => {},
+      onNotConfirmable: () => { notConfirmable = true; },
+      errorMessage: 'fallback message',
+    });
+    await handler();
+    assert.equal(notConfirmable, true); // still terminal, just without the tailored copy
+  });
 });
 
 describe('isOrderNotConfirmable', () => {


### PR DESCRIPTION
Fixes #800

## Description

On the PayPal order-review flow, a Forter fraud decline on the confirm (capture) step returns a 200 `{ status: 'failed', reason: 'fraud_declined', cancelled: true }`. Because it carries `cancelled: true`, it was being collapsed into the generic expired/cancelled path, which showed a misleading "this order may have expired" message and bounced the buyer to the **cart**.

This detects `reason === 'fraud_declined'` first (before the generic `cancelled` branch) and routes to `order/cancel?reason=fraud_declined`, which renders the neutral Customer Care copy ("…please contact our Customer Care team at 1-800-VITAMIX") — matching the redirect-based Chase card / Apple Pay flows fixed in #782. Other `cancelled: true` reasons (expired/abandoned/amount mismatch) still route to the cart as before.

Storefront-only change: the confirm endpoint already returns `reason: 'fraud_declined'` and cancels the order server-side.

## Tests

- `npm run lint` — clean (js + css)
- `npm run test:unit` — 367 passing, incl. 2 new `createConfirmHandler` cases (fraud routes to the fraud handler, not the cart; graceful fallback when no fraud handler is wired)
- Added a Playwright regression in `tests/order/order-review-page.spec.js` asserting a `fraud_declined` confirm navigates to `/order/cancel?reason=fraud_declined` (runs against the branch preview)

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/us/en_us/order/cancel?reason=fraud_declined
- After: https://fix-800-paypal-review-fraud-cancel--vitamix--aemsites.aem.network/us/en_us/order/cancel?reason=fraud_declined
