### PR TITLE
fix(cart): synchronize edge cart across tabs

### DIFF
--- a/blocks/pdp/add-to-cart.js
+++ b/blocks/pdp/add-to-cart.js
@@ -79,17 +79,6 @@ function toggleFixedAddToCart(container) {
 }
 
 /**
- * Returns how many units may be added given what is already in the cart.
- * @param {number} requested - Quantity the user selected
- * @param {number} existing - Quantity already in the cart for this SKU
- * @param {number} max - Per-product maximum allowed quantity
- * @returns {number}
- */
-export function computeAllowedQty(requested, existing, max) {
-  return Math.max(0, Math.min(requested, max - existing));
-}
-
-/**
  * Normalize a price into a number for the edge cart line item.
  * Offers expose a flat numeric price (string or number); simple products
  * without offers expose the Product Bus shape `{ currency, regular, final }`.
@@ -310,12 +299,7 @@ export default function renderAddToCart(ph, block, parent) {
 
         const { sku: variantSku } = selectedVariant;
         const targetSku = variantSku ?? sku;
-
-        // Clamp requested quantity so the cart line never exceeds maxQuantity.
-        const requestedQty = parseInt(quantity, 10);
-        const existingQty = cartApi.items.find((i) => i.sku === targetSku)?.quantity ?? 0;
-        const allowedQty = computeAllowedQty(requestedQty, existingQty, maxQuantity);
-        if (allowedQty <= 0) {
+        const notifyCartLimit = () => {
           window.cartQtyLimitAlerts ||= new Set();
           window.cartQtyLimitAlerts.add(targetSku);
           document.dispatchEvent(new CustomEvent('cart:limit', {
@@ -329,8 +313,11 @@ export default function renderAddToCart(ph, block, parent) {
           }));
           addToCartButton.textContent = ph.addToCart || 'Add to Cart';
           addToCartButton.removeAttribute('aria-disabled');
-          return;
-        }
+        };
+
+        // Cart.addItem enforces this after it has rebased on shared storage,
+        // so a second tab cannot use its stale snapshot to exceed the limit.
+        const requestedQty = parseInt(quantity, 10);
 
         // Prefer the selected variant's price so variant-specific pricing
         // wins; fall back to offers[0] for simple products, where
@@ -373,7 +360,7 @@ export default function renderAddToCart(ph, block, parent) {
         const item = {
           sku: targetSku,
           parentSku: variantSku ? sku : undefined,
-          quantity: allowedQty,
+          quantity: requestedQty,
           price,
           name: parent.name,
           url: selectedVariant.url,
@@ -396,7 +383,11 @@ export default function renderAddToCart(ph, block, parent) {
           } : {}),
           ...(shippingDimensions ? { shippingDimensions } : {}),
         };
-        await cartApi.addItem(item);
+        const addedItem = await cartApi.addItem(item, { maxQuantity });
+        if (!addedItem) {
+          notifyCartLimit();
+          return;
+        }
 
         // If the PDP warranty selector has a paid tier selected, commit it
         // as a paired line item. The cart-page selector reads this state.
@@ -406,7 +397,7 @@ export default function renderAddToCart(ph, block, parent) {
           await cartApi.addItem({
             sku: selectedTier.sku,
             path: selectedTier.path,
-            quantity: allowedQty,
+            quantity: addedItem.quantity,
             price: selectedTier.price,
             name: selectedTier.name,
             custom: {
@@ -419,13 +410,13 @@ export default function renderAddToCart(ph, block, parent) {
           });
         }
 
-        logOperation('added-to-cart', { sku: targetSku, quantity: allowedQty });
-        document.dispatchEvent(new CustomEvent('pdp:add-to-cart', { detail: { item } }));
+        logOperation('added-to-cart', { sku: targetSku, quantity: addedItem.quantity });
+        document.dispatchEvent(new CustomEvent('pdp:add-to-cart', { detail: { item: addedItem } }));
 
         // On mobile the header cart badge is too subtle — redirect to the
         // cart page so the user gets clear feedback that the item was added.
-        // Flush first: addItem uses a debounced persist (300 ms) so
-        // localStorage may not have the new item yet.
+        // Flush first so the cart page always receives the latest shared
+        // localStorage snapshot before navigation.
         if (window.innerWidth < 900) {
           cartApi.flush();
           window.location.href = getOrderPath('cart');

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -1,13 +1,5 @@
 import { getConfig } from './commerce-config.js';
 
-const debounce = (func, wait) => {
-  let timeout;
-  return (...args) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func(...args), wait);
-  };
-};
-
 function deepEqual(a, b) {
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
@@ -37,26 +29,35 @@ export class Cart {
   constructor() {
     this.#restore();
     this.#persistNow();
+    window.addEventListener?.('storage', (event) => {
+      if (event.key === Cart.STORAGE_KEY) {
+        this.#restore('sync', true);
+      }
+    });
   }
 
-  #restore() {
-    const cart = localStorage.getItem(Cart.STORAGE_KEY);
-    if (cart) {
-      const parsed = JSON.parse(cart);
-      if (parsed.version !== Cart.STORAGE_VERSION) {
-        localStorage.removeItem(Cart.STORAGE_KEY);
-        return;
-      }
-      this.#items = parsed.items;
-      document.dispatchEvent(
-        new CustomEvent('cart:change', {
-          detail: {
-            cart: this,
-            action: 'restore',
-          },
-        }),
-      );
+  static #getStoredItems() {
+    const stored = localStorage.getItem(Cart.STORAGE_KEY);
+    if (!stored) return null;
+
+    const parsed = JSON.parse(stored);
+    if (parsed.version !== Cart.STORAGE_VERSION) {
+      localStorage.removeItem(Cart.STORAGE_KEY);
+      return null;
     }
+    return parsed.items;
+  }
+
+  #restore(action = 'restore', clearWhenAbsent = false) {
+    const items = Cart.#getStoredItems();
+    if (items === null && !clearWhenAbsent) return;
+
+    this.#items = items ?? [];
+    this.#dispatchChange(action);
+  }
+
+  #refresh() {
+    this.#items = Cart.#getStoredItems() ?? [];
   }
 
   #persistNow() {
@@ -65,28 +66,29 @@ export class Cart {
     localStorage.setItem(Cart.STORAGE_KEY, JSON.stringify(this));
   }
 
-  #persist = debounce(() => {
-    this.#persistNow();
-  }, 300);
+  #dispatchChange(action, item = undefined) {
+    document.dispatchEvent(
+      new CustomEvent('cart:change', {
+        detail: {
+          cart: this,
+          ...(item === undefined ? {} : { item }),
+          action,
+        },
+      }),
+    );
+  }
 
   #maybeSendEmptyEvent() {
     if (this.itemCount === 0) {
-      document.dispatchEvent(
-        new CustomEvent('cart:change', {
-          detail: {
-            cart: this,
-            action: 'empty',
-          },
-        }),
-      );
+      this.#dispatchChange('empty');
     }
   }
 
   /**
-   * Flush any debounced writes to localStorage immediately. Call before a
-   * page navigation to avoid the race where the next page reads stale state.
+   * Re-persist the latest shared cart before a page navigation.
    */
   flush() {
+    this.#refresh();
     this.#persistNow();
   }
 
@@ -124,16 +126,10 @@ export class Cart {
   }
 
   clear() {
+    this.#refresh();
     this.#items = [];
     this.#persistNow();
-    document.dispatchEvent(
-      new CustomEvent('cart:change', {
-        detail: {
-          cart: this,
-          action: 'clear',
-        },
-      }),
-    );
+    this.#dispatchChange('clear');
     this.#maybeSendEmptyEvent();
   }
 
@@ -148,33 +144,43 @@ export class Cart {
    * warranty SKU linked to two different parent products).
    *
    * @param {CartItem} item
-   * @param {{ allowSeparateEntry?: boolean }} [opts]
+   * @param {{ allowSeparateEntry?: boolean, maxQuantity?: number }} [opts]
+   * @returns {CartItem|null} The added item, capped to `maxQuantity` when supplied;
+   *   `null` when the SKU is already at its limit.
    */
-  addItem(item, { allowSeparateEntry = false } = {}) {
-    const existing = this.#items.find((i) => i.sku === item.sku);
+  addItem(item, { allowSeparateEntry = false, maxQuantity = undefined } = {}) {
+    // A second tab can have an old in-memory snapshot. Always rebase the
+    // mutation on localStorage and persist it in this same turn so its item is
+    // retained instead of being overwritten by the stale snapshot.
+    this.#refresh();
+
+    let itemToAdd = item;
+    if (maxQuantity !== undefined) {
+      const existingQuantity = this.#items
+        .filter((i) => i.sku === item.sku)
+        .reduce((total, existing) => total + existing.quantity, 0);
+      const quantity = Math.max(0, Math.min(item.quantity, maxQuantity - existingQuantity));
+      if (quantity === 0) return null;
+      if (quantity !== item.quantity) itemToAdd = { ...item, quantity };
+    }
+
+    const existing = this.#items.find((i) => i.sku === itemToAdd.sku);
     if (existing) {
-      if (!deepEqual(existing.custom, item.custom)) {
+      if (!deepEqual(existing.custom, itemToAdd.custom)) {
         if (allowSeparateEntry) {
-          this.#items.push(item);
+          this.#items.push(itemToAdd);
         } else {
-          throw new Error(`Cannot merge cart item ${item.sku}: incompatible custom payloads`);
+          throw new Error(`Cannot merge cart item ${itemToAdd.sku}: incompatible custom payloads`);
         }
       } else {
-        existing.quantity += item.quantity;
+        existing.quantity += itemToAdd.quantity;
       }
     } else {
-      this.#items.push(item);
+      this.#items.push(itemToAdd);
     }
-    document.dispatchEvent(
-      new CustomEvent('cart:change', {
-        detail: {
-          cart: this,
-          item,
-          action: 'add',
-        },
-      }),
-    );
-    this.#persist();
+    this.#persistNow();
+    this.#dispatchChange('add', itemToAdd);
+    return itemToAdd;
   }
 
   /**
@@ -182,22 +188,15 @@ export class Cart {
    * @param {number} quantity
    */
   updateItem(sku, quantity) {
+    this.#refresh();
     const existing = this.#items.find((i) => i.sku === sku);
     if (!existing) {
       throw new Error(`Item with sku ${sku} not found`);
     }
     existing.quantity = quantity;
-    document.dispatchEvent(
-      new CustomEvent('cart:change', {
-        detail: {
-          cart: this,
-          item: existing,
-          action: 'update',
-        },
-      }),
-    );
+    this.#persistNow();
+    this.#dispatchChange('update', existing);
     this.#maybeSendEmptyEvent();
-    this.#persist();
   }
 
   /**
@@ -208,6 +207,7 @@ export class Cart {
    *   evaluated against each candidate item.
    */
   removeItem(sku, matcher = undefined) {
+    this.#refresh();
     const predicate = typeof matcher === 'function'
       ? matcher
       : (item) => matcher === undefined || item.custom?.linkedTo === matcher;
@@ -218,23 +218,9 @@ export class Cart {
     if (index !== -1) {
       this.#items.splice(index, 1);
     }
-    // Persist synchronously when the cart becomes empty so that any immediate
-    // page reload (e.g. from the checkout empty-cart listener) sees the correct
-    // state rather than restoring the stale pre-removal localStorage snapshot.
-    if (this.#items.length === 0) {
-      this.#persistNow();
-    }
-    document.dispatchEvent(
-      new CustomEvent('cart:change', {
-        detail: {
-          cart: this,
-          item,
-          action: 'remove',
-        },
-      }),
-    );
+    this.#persistNow();
+    this.#dispatchChange('remove', item);
     this.#maybeSendEmptyEvent();
-    this.#persist();
   }
 
   /**

--- a/tests/cart/edge-checkout.spec.js
+++ b/tests/cart/edge-checkout.spec.js
@@ -295,12 +295,10 @@ test.describe('Edge Checkout', () => {
     async function clickAndWait(btn, page) {
       await btn.click();
       await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 10000 });
-      // Close the minicart dialog so it doesn't intercept the next click
-      await page.evaluate(() => {
-        const d = document.querySelector('#minicart');
-        if (d && d.open) d.close();
-      });
-      await page.waitForTimeout(300);
+      const minicart = page.locator('#minicart');
+      await expect(minicart).toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
+      await minicart.locator('.slide-panel-close').click();
+      await expect(minicart).not.toHaveAttribute('aria-expanded', 'true', { timeout: 10000 });
     }
 
     test('can add up to the max quantity of 3', async ({ page }) => {
@@ -326,7 +324,7 @@ test.describe('Edge Checkout', () => {
       await clickAndWait(btn, page);
       await clickAndWait(btn, page);
 
-      // 4th click — allowedQty = 0, should return early (no minicart opens)
+      // 4th click — Cart.addItem rejects the SKU at its limit, so no minicart opens.
       await btn.click();
       await expect(btn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 5000 });
 
@@ -509,6 +507,40 @@ test.describe('Edge Checkout', () => {
       expect(cart.items).toHaveLength(1);
       expect(cart.items[0].quantity).toBe(1);
       console.log('✓ Cart persists after page reload');
+    });
+
+    test('separate product tabs share one cart', async ({ page, context }) => {
+      const secondPage = await context.newPage();
+      try {
+        await secondPage.addInitScript(() => {
+          window.IS_TEST_MODE = true;
+          localStorage.setItem('vitamix.priceRules.stub', JSON.stringify({ promotions: [] }));
+        });
+        await secondPage.route('**/us/en_us/products/operations-log', (route) => route.fulfill({ status: 204, body: '' }));
+
+        await Promise.all([
+          page.goto(buildProductUrl('/us/en_us/products/ascent-x2', currentBranch, { cart: 'edge' })),
+          secondPage.goto(buildProductUrl('/us/en_us/products/20-ounce-travel-cup', currentBranch, { cart: 'edge' })),
+        ]);
+        await Promise.all([waitForAddToCartButton(page), waitForAddToCartButton(secondPage)]);
+
+        await page.locator('.quantity-container button').click();
+        await expect.poll(
+          () => getCart(page).then((cart) => cart?.items?.length ?? 0),
+          { timeout: 10000, message: 'First tab did not persist its cart item' },
+        ).toBe(1);
+        await expect(secondPage.locator(CART_LINK_SELECTOR)).toHaveAttribute('data-cart-items', '1', { timeout: 10000 });
+
+        await secondPage.locator('.quantity-container button').click();
+        await expect.poll(
+          () => getCart(page).then((cart) => cart?.items?.length ?? 0),
+          { timeout: 10000, message: 'Second tab overwrote the first tab\'s cart item' },
+        ).toBe(2);
+        await expect(page.locator(CART_LINK_SELECTOR)).toHaveAttribute('data-cart-items', '2', { timeout: 10000 });
+        console.log('✓ Separate product tabs retain both cart items');
+      } finally {
+        await secondPage.close();
+      }
     });
 
     test('cart badge restored from localStorage on page load', async ({ page }) => {

--- a/tests/unit/add-to-cart.test.js
+++ b/tests/unit/add-to-cart.test.js
@@ -9,7 +9,6 @@ import assert from 'node:assert/strict';
 import {
   normalizeCartPrice,
   isVariantAvailableForSale,
-  computeAllowedQty,
   shippingDimensionsFromOffer,
   resolveLineItemCustom,
 } from '../../blocks/pdp/add-to-cart.js';
@@ -109,28 +108,6 @@ test('isVariantAvailableForSale: page metadata gate wins over variant flags', ()
     isVariantAvailableForSale(inStockVariant({ managedStock: '0' })),
     false,
   );
-});
-
-// --- computeAllowedQty -------------------------------------------------------
-
-test('computeAllowedQty: full quantity allowed when cart is empty', () => {
-  assert.equal(computeAllowedQty(3, 0, 3), 3);
-});
-
-test('computeAllowedQty: zero allowed when already at max', () => {
-  assert.equal(computeAllowedQty(3, 3, 3), 0);
-});
-
-test('computeAllowedQty: partial quantity allowed when cart is partially full', () => {
-  assert.equal(computeAllowedQty(3, 1, 3), 2);
-});
-
-test('computeAllowedQty: normal single-unit add', () => {
-  assert.equal(computeAllowedQty(1, 0, 3), 1);
-});
-
-test('computeAllowedQty: clamps to zero, not negative, when existing exceeds max', () => {
-  assert.equal(computeAllowedQty(1, 4, 3), 0);
 });
 
 // --- shippingDimensionsFromOffer -------------------------------------------

--- a/tests/unit/cart.test.js
+++ b/tests/unit/cart.test.js
@@ -69,6 +69,33 @@ test('addItem with different SKUs creates separate entries', () => {
   assert.deepEqual(cart.items.map((i) => i.sku), ['foo', 'bar']);
 });
 
+test('addItem rebases a stale tab before persisting', () => {
+  const firstTab = new Cart();
+  const secondTab = new Cart();
+
+  firstTab.addItem(sampleItem({ sku: 'foo' }));
+  firstTab.flush();
+  secondTab.addItem(sampleItem({ sku: 'bar' }));
+  secondTab.flush();
+
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+  assert.deepEqual(stored.items.map((item) => item.sku), ['foo', 'bar']);
+});
+
+test('addItem caps a stale tab against the shared SKU quantity limit', () => {
+  const firstTab = new Cart();
+  const secondTab = new Cart();
+
+  firstTab.addItem(sampleItem({ sku: 'foo', quantity: 2 }));
+  const partiallyAdded = secondTab.addItem(sampleItem({ sku: 'foo', quantity: 2 }), { maxQuantity: 3 });
+  const rejected = secondTab.addItem(sampleItem({ sku: 'foo' }), { maxQuantity: 3 });
+
+  assert.equal(partiallyAdded.quantity, 1);
+  assert.equal(rejected, null);
+  const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+  assert.equal(stored.items[0].quantity, 3);
+});
+
 test('addItem preserves insertion order across many entries', () => {
   const cart = new Cart();
   ['a', 'b', 'c', 'd'].forEach((sku) => cart.addItem(sampleItem({ sku })));
@@ -137,12 +164,9 @@ test('clear persists the empty state to localStorage immediately', () => {
 
 // --- flush ------------------------------------------------------------------
 
-test('flush persists a debounced addItem to localStorage immediately', () => {
+test('addItem persists to localStorage immediately', () => {
   const cart = new Cart();
   cart.addItem(sampleItem({ sku: 'pending' }));
-  // addItem uses a debounced persist — localStorage may still be stale.
-  // flush() forces the write so a subsequent page load sees the item.
-  cart.flush();
   const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
   assert.equal(stored.items.length, 1);
   assert.equal(stored.items[0].sku, 'pending');


### PR DESCRIPTION
Rebase Edge cart mutations on shared storage, cap quantities at write time, and update connected tabs to prevent stale snapshots from overwriting items.

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2?cart=edge
- After: https://fix-cart-cross-tab-sync--vitamix--aemsites.aem.network/us/en_us/products/ascent-x2?cart=edge