### PR TITLE
fix: allow split hero to inherit color, center hero to set height

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -81,14 +81,19 @@
   position: absolute;
   inset: 0;
   z-index: -1;
-  height: 85%;
+  height: 100%;
   width: 100%;
   object-fit: cover;
 }
 
+.hero.center picture[data-bg] img,
+.hero.center video {
+  height: 85%;
+}
+
 @media (width >= 800px) {
-  .hero picture[data-bg] img,
-  .hero video {
+  .hero.center picture[data-bg] img,
+  .hero.center video {
     height: 100%;
   }
 }
@@ -140,9 +145,6 @@
   width: 100%;
   padding: var(--horizontal-spacing);
   padding-top: 55px;
-}
-
-.hero:not(.split) > div > div {
   color: var(--color-white);
 }
 


### PR DESCRIPTION
- mobile split layout text color now defaults to white for all variants (not just non-split)
- mobile 85% shrink is now scoped to `.hero.center` only, closing the whitespace gap 

Test URLs:
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/shop
- After: https://hero-inheritance--vitamix--aemsites.aem.page/us/en_us/shop
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/
- After: https://hero-inheritance--vitamix--aemsites.aem.page/us/en_us/
- Before: https://main--vitamix--aemsites.aem.page/us/en_us/why-vitamix
- After: https://hero-inheritance--vitamix--aemsites.aem.page/us/en_us/why-vitamix

