### PR TITLE
fix: article info on pages without hero

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -672,7 +672,7 @@ function buildAutoBlocks(main) {
     }
 
     // setup articles pages
-    if (getMetadata('template') === 'article') {
+    if (document.querySelector('main') === main && getMetadata('template') === 'article') {
       let hero = main.querySelector('.hero');
       if (!hero) {
         const picture = main.querySelector('picture');
@@ -684,9 +684,13 @@ function buildAutoBlocks(main) {
           main.prepend(section);
         }
       }
-      // add article-info block after hero
-      if (hero) {
-        hero.after(buildBlock('article-info', { elems: [] }));
+      const articleInfo = buildBlock('article-info', { elems: [] });
+      if (hero) { // add article-info block after hero
+        hero.after(articleInfo);
+      } else { // or at the top of main if there is no hero
+        const section = document.createElement('div');
+        section.append(articleInfo);
+        main.prepend(section);
       }
     }
 


### PR DESCRIPTION
Fix article template so the author block (`article-info`) still renders when the article has no hero. Scope the article page setup logic to the real page `main` so it doesn't corrupt fragments (`nav`/`footer`) loaded on article-templated pages.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/articles/4-ways-to-care-for-your-vitamix-machine
- After: https://article-info--vitamix--aemsites.aem.network/us/en_us/articles/4-ways-to-care-for-your-vitamix-machine
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/articles/10-easy-fondue-recipes
- After: https://article-info--vitamix--aemsites.aem.network/us/en_us/articles/10-easy-fondue-recipes
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/articles/smoothie-central
- After: https://article-info--vitamix--aemsites.aem.network/us/en_us/articles/smoothie-central