### PR TITLE
fix(pdp): hide zero-priced related products

### DIFF
--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -209,8 +209,9 @@ function renderRelatedProducts(ph, custom) {
           const li = document.createElement('li');
           const title = product.name;
           const image = new URL(product.images[0].url, window.location.href);
-          const price = +product.price.final;
-          li.innerHTML = `<a href="${product.url}"><img src="${image}?width=750&#x26;format=webply&#x26;optimize=medium" alt="${title}" /><div><p>${title}</p><strong>${formatPrice(price, ph)}</strong></div></a>`;
+          const price = Number(product.price?.final);
+          const priceMarkup = price > 0 ? `<strong>${formatPrice(price, ph)}</strong>` : '';
+          li.innerHTML = `<a href="${product.url}"><img src="${image}?width=750&#x26;format=webply&#x26;optimize=medium" alt="${title}" /><div><p>${title}</p>${priceMarkup}</div></a>`;
           ul.appendChild(li);
         });
         relatedProductsContainer.appendChild(ul);


### PR DESCRIPTION
Commercial related products without a sellable price should not display a misleading formatted zero price.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/mx/en_us/products/commercial/quick-and-quiet
- After: https://fix-related-products-zero-price--vitamix--aemsites.aem.network/mx/en_us/products/commercial/quick-and-quiet