### PR TITLE
fix(forms): map registration phone to mobile for SFDC Lead

### DIFF
--- a/tests/unit/product-registration-payload.test.js
+++ b/tests/unit/product-registration-payload.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRegistrationPayload } from '../../widgets/forms/product-registration.js';
+
+const ctx = { locale: 'us', language: 'en_us', pageUrl: 'https://uat.vitamix.com/us/en_us/customer-service/product-registration' };
+
+// --- issue #783: phone must reach SFDC via the `mobile` field ----------------
+
+test('mirrors the phone field into mobile (SFDC Lead phone mapping)', () => {
+  const payload = buildRegistrationPayload({ phone: '(555) 123-4567' }, ctx);
+  assert.equal(payload.mobile, '(555) 123-4567');
+  // original phone key is preserved for backward compatibility
+  assert.equal(payload.phone, '(555) 123-4567');
+});
+
+test('does not add an empty mobile when phone is missing', () => {
+  const payload = buildRegistrationPayload({ email: 'a@b.com' }, ctx);
+  assert.equal('mobile' in payload, false);
+});
+
+test('does not add mobile when phone is an empty string', () => {
+  const payload = buildRegistrationPayload({ phone: '' }, ctx);
+  assert.equal('mobile' in payload, false);
+});
+
+// --- context fields ----------------------------------------------------------
+
+test('sets formId and pageUrl from context', () => {
+  const payload = buildRegistrationPayload({ phone: '5551234567' }, ctx);
+  assert.equal(payload.formId, 'us/en_us/product-registration');
+  assert.equal(payload.pageUrl, ctx.pageUrl);
+});
+
+test('scopes formId to the ca/fr_ca locale', () => {
+  const payload = buildRegistrationPayload(
+    { phone: '4165551234' },
+    { locale: 'ca', language: 'fr_ca', pageUrl: 'https://uat.vitamix.com/ca/fr_ca/' },
+  );
+  assert.equal(payload.formId, 'ca/fr_ca/product-registration');
+});
+
+// --- preserves the rest of the form -----------------------------------------
+
+test('preserves all other form entries (opt-in flags, name, address)', () => {
+  const entries = {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    email: 'ada@example.com',
+    phone: '5551234567',
+    serialNumber: '123456789012345678',
+    smsOptIn: 'yes',
+    marketingOptIn: 'yes',
+    acceptTerms: 'yes',
+  };
+  const payload = buildRegistrationPayload(entries, ctx);
+  assert.equal(payload.firstName, 'Ada');
+  assert.equal(payload.lastName, 'Lovelace');
+  assert.equal(payload.email, 'ada@example.com');
+  assert.equal(payload.serialNumber, '123456789012345678');
+  assert.equal(payload.smsOptIn, 'yes');
+  assert.equal(payload.marketingOptIn, 'yes');
+  assert.equal(payload.acceptTerms, 'yes');
+});
+
+test('does not mutate the input entries object', () => {
+  const entries = { phone: '5551234567' };
+  buildRegistrationPayload(entries, ctx);
+  assert.deepEqual(entries, { phone: '5551234567' });
+});

--- a/widgets/forms/product-registration.js
+++ b/widgets/forms/product-registration.js
@@ -2,6 +2,27 @@ import { getFormSubmissionUrl, getLocaleAndLanguage } from '../../scripts/script
 import getStatesProvincesOptions from './states-provinces.js';
 
 /**
+ * Builds the product-registration submission payload from raw form entries.
+ *
+ * The SFDC Lead integration reads the phone number from `mobile` (the key the
+ * newsletter/SMS opt-in lead flow already uses). The registration form field is
+ * named `phone`, so the value is mirrored into `mobile`; without it the Lead is
+ * created with no phone number ("phone number not being provided by web").
+ * See issue #783.
+ *
+ * @param {Record<string, string>} entries - Raw entries (Object.fromEntries(FormData)).
+ * @param {{ locale: string, language: string, pageUrl: string }} ctx - Submission context.
+ * @returns {Record<string, string>} Payload to POST to the forms endpoint.
+ */
+export function buildRegistrationPayload(entries, { locale, language, pageUrl }) {
+  const payload = { ...entries };
+  if (payload.phone) payload.mobile = payload.phone;
+  payload.formId = `${locale}/${language}/product-registration`;
+  payload.pageUrl = pageUrl;
+  return payload;
+}
+
+/**
  * Loads form copy from the widget's local JSON (same name as the script).
  * @param {string} lang - Language key (en, fr, es)
  * @returns {Promise<Object>} Form copy for that language
@@ -163,9 +184,10 @@ export default async function decorate(widget) {
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const data = new FormData(form);
-    const payload = Object.fromEntries(data.entries());
-    payload.formId = `${locale}/${language}/product-registration`;
-    payload.pageUrl = window.location.href;
+    const payload = buildRegistrationPayload(
+      Object.fromEntries(data.entries()),
+      { locale, language, pageUrl: window.location.href },
+    );
 
     const submitButton = form.querySelector('button[type="submit"]');
     const buttonLabel = submitButton?.textContent;


### PR DESCRIPTION
Fixes #783

Product registration posted the phone number under the `phone` key, but the SFDC Lead integration reads it from `mobile` (the key the newsletter/SMS opt-in lead flow already uses), so registration Leads were created without a phone number ("phone number not being provided by web"). This extracts a pure `buildRegistrationPayload` helper that mirrors `phone` into `mobile` (guarded so a blank phone adds no empty `mobile`) and adds unit coverage. Based on `staginguat` since that is the branch serving uat.vitamix.com and submitting to SFDC (`main` still posts registrations to a test sheet-logger).

Test URLs:
- Before: https://staginguat--vitamix--aemsites.aem.network/us/en_us/customer-service/product-registration
- After: https://fix-783-registration-phone-sfdc--vitamix--aemsites.aem.network/us/en_us/customer-service/product-registration