### PR TITLE
Order total for Purchase event and new uat pixel id

### DIFF
--- a/scripts/consented.js
+++ b/scripts/consented.js
@@ -70,7 +70,7 @@ const launchConfigByEnv = {
     scriptUrl: 'https://assets.adobedtm.com/8639b8ee2552/0f7a35c4f04b/launch-EN10955306e5aa4722aaabcdd1910448ad-development.min.js',
   },
   uat: {
-    pixelId: 1026941270048701,
+    pixelId: 1371926081780272,
     scriptUrl: 'https://assets.adobedtm.com/8639b8ee2552/0f7a35c4f04b/launch-EN10955306e5aa4722aaabcdd1910448ad-development.min.js',
   },
   localhost: {

--- a/scripts/consented/instrumentation/order-success.js
+++ b/scripts/consented/instrumentation/order-success.js
@@ -426,9 +426,7 @@ function buildMetaPurchasePayload(context = readOrderSuccessContext()) {
 
   const contentIds = items.map((item) => item.sku);
   const numItems = items.reduce((sum, item) => sum + item.quantity, 0);
-  const value = Number(items
-    .reduce((sum, item) => sum + (item.price * item.quantity), 0)
-    .toFixed(2));
+  const value = summary.orderTotal;
 
   const currency = String(
     context?.order?.currencyCode


### PR DESCRIPTION
New UAT pixel id has been updated. And order total including tax has been now added.

Test URLs:
- Before: https://main--vitamix--aemsites.aem.network/us/en_us
- After: https://meta-integration--vitamix--aemsites.aem.network/us/en_us
