### PR TITLE
fix(pdp): disable Bazaarvoice SEO markup on review widgets

### DIFF
--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -30,7 +30,9 @@ function renderTitle(block, custom, reviewsId) {
 
   const reviewsPlaceholder = document.createElement('div');
   reviewsPlaceholder.classList.add('pdp-reviews-summary-placeholder');
-  reviewsPlaceholder.innerHTML = `<div data-bv-show="rating_summary" data-bv-product-id="${reviewsId}">`;
+  // data-bv-seo="false": suppress Bazaarvoice's own structured-data markup; the
+  // product JSON-LD (with aggregateRating) is rendered server-side by the pipeline.
+  reviewsPlaceholder.innerHTML = `<div data-bv-show="rating_summary" data-bv-product-id="${reviewsId}" data-bv-seo="false">`;
 
   const { collection } = custom;
   const collectionContainer = document.createElement('p');
@@ -70,7 +72,7 @@ async function renderReviews(ph, block, reviewsId) {
   // TODO: Add Bazaarvoice reviews
   const bazaarvoiceContainer = document.createElement('div');
   bazaarvoiceContainer.classList.add('pdp-reviews-container');
-  bazaarvoiceContainer.innerHTML = `<div data-bv-show="reviews" data-bv-product-id="${reviewsId}"></div>`;
+  bazaarvoiceContainer.innerHTML = `<div data-bv-show="reviews" data-bv-product-id="${reviewsId}" data-bv-seo="false"></div>`;
 
   setTimeout(async () => {
     await loadScript(`https://apps.bazaarvoice.com/deployments/vitamix/main_site/production/${ph.languageCode || 'en_US'}/bv.js`);


### PR DESCRIPTION
Set `data-bv-seo="false"` on the PDP Bazaarvoice `rating_summary` and `reviews` widgets so Bazaarvoice no longer injects its own (orphan) structured data. The product JSON-LD with `aggregateRating` is now rendered server-side by the Helix product pipeline, so BV's markup is redundant and was flagged by Google (missing `itemReviewed`).

The visible star widget is unaffected — this only removes BV's structured-data output.

Test URLs (view source, inspect the `application/ld+json` — Bazaarvoice's separate review schema should no longer appear):
- Before: https://main--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5
- After: https://disable-bazaarvoice-seo--vitamix--aemsites.aem.network/us/en_us/products/ascent-x5

Note: review rich-result eligibility now comes from the pipeline's `aggregateRating`, which is populated per product by the catalog sync. Best deployed after the catalog has been (re)synced with ratings.
